### PR TITLE
Add MIT license badge and PyPI classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/gimlelabs/gimle-hugin/actions/workflows/ci.yml/badge.svg)](https://github.com/gimlelabs/gimle-hugin/actions/workflows/ci.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/gimlelabs/gimle-hugin/main/hugin.gif" alt="Hugin demo" width="900" />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,16 @@ dynamic = ["version"]
 description = "Hugin - An agentic framework for creative reasoning tasks"
 readme = "README.md"
 license = "MIT"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+]
 requires-python = ">=3.12"
 authors = [{name = "gimlelabs", email = "noreply@github.com"}]
 keywords = ["agents", "agentic-framework", "llm", "ai", "anthropic"]


### PR DESCRIPTION
## Summary
- Add MIT license badge to README.md after the existing Python version badge
- Add PyPI classifiers to `pyproject.toml` for better package discoverability

## Changes
- **README.md**: Added `[![License: MIT](...)](LICENSE)` badge
- **pyproject.toml**: Added `classifiers` list with development status, audience, license, Python version, and topic classifiers

## Testing
Visual inspection of badge rendering and valid PyPI classifier strings.