### PR TITLE
Improve docs code blocks and header navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ agents
 /storage
 reports
 data
+.claude
 
 _site/
 node_modules/

--- a/docs/src/_includes/base.njk
+++ b/docs/src/_includes/base.njk
@@ -27,7 +27,13 @@
     {% set conceptsActive = '/concepts/' in page.url %}
     {% set howToActive = '/how-to/' in page.url %}
     <div class="container header-main">
-      <a href="/" class="logo">Hugin</a>
+      <div class="logo-group">
+        <a href="/" class="logo">Hugin</a>
+        <span class="logo-byline">by <a href="https://gimlelabs.com">Gimle Labs</a></span>
+      </div>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
       <nav>
         <a href="/getting-started/"{% if page.url == '/getting-started/' %} class="active"{% endif %}>Getting Started</a>
         <a href="/how-to/"{% if howToActive %} class="active"{% endif %}>How-To</a>
@@ -73,5 +79,13 @@
   </footer>
 
   <script type="module" src="/assets/js/animator/state-machine-animator.js"></script>
+  <script>
+    document.querySelector('.nav-toggle').addEventListener('click', function() {
+      var nav = document.querySelector('header nav');
+      var expanded = this.getAttribute('aria-expanded') === 'true';
+      this.setAttribute('aria-expanded', !expanded);
+      nav.classList.toggle('open');
+    });
+  </script>
 </body>
 </html>

--- a/docs/src/assets/css/style.css
+++ b/docs/src/assets/css/style.css
@@ -57,6 +57,28 @@ header .header-main {
   color: var(--color-primary);
 }
 
+.logo-group {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.logo-byline {
+  font-size: 11px;
+  color: var(--color-text-light);
+}
+
+.logo-byline a {
+  color: var(--color-text-light);
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+.logo-byline a:hover {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
 nav {
   display: flex;
   align-items: center;
@@ -184,6 +206,75 @@ code {
   padding: 2px 6px;
   border-radius: 4px;
   color: var(--color-primary-dark);
+}
+
+/* Prism.js syntax highlighting (matches #1e293b code block bg) */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #636f88;
+  font-style: italic;
+}
+
+.token.punctuation {
+  color: #a0aec0;
+}
+
+.token.namespace {
+  opacity: 0.8;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #f59e0b;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #34d399;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string {
+  color: #67e8f9;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #a78bfa;
+}
+
+.token.function,
+.token.class-name {
+  color: #60a5fa;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #fbbf24;
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+
+.token.italic {
+  font-style: italic;
 }
 
 /* Tables */
@@ -487,6 +578,38 @@ footer a {
   color: var(--color-text-light);
 }
 
+/* Hamburger toggle (hidden on desktop) */
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: var(--color-text);
+  border-radius: 2px;
+  transition: transform 0.2s, opacity 0.2s;
+}
+
+.nav-toggle[aria-expanded="true"] span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.nav-toggle[aria-expanded="true"] span:nth-child(2) {
+  opacity: 0;
+}
+
+.nav-toggle[aria-expanded="true"] span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
 /* Blockquote */
 blockquote {
   border-left: 3px solid var(--color-primary);
@@ -497,8 +620,31 @@ blockquote {
 
 /* Responsive */
 @media (max-width: 768px) {
-  nav {
-    gap: 16px;
+  .nav-toggle {
+    display: flex;
+  }
+
+  header nav {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: var(--color-bg);
+    border-bottom: 1px solid var(--color-border);
+    flex-direction: column;
+    padding: 12px 24px;
+    gap: 4px;
+  }
+
+  header nav.open {
+    display: flex;
+  }
+
+  header nav a {
+    padding: 10px 12px;
+    border-radius: 6px;
+    font-size: 15px;
   }
 
   h1 {


### PR DESCRIPTION
## Summary
- Add syntax highlighting colors to code blocks (Prism.js theme matching the dark slate background)
- Add visible "by Gimle Labs" link below the Hugin logo in the header
- Add responsive hamburger menu for mobile navigation

## Changes
- **style.css**: Prism token colors (green strings, purple keywords, blue functions, amber numbers, cyan operators), logo-group layout, hamburger button styles with animated X toggle, mobile nav dropdown at 768px breakpoint
- **base.njk**: Logo group wrapper with Gimle Labs byline, hamburger button markup, toggle script

## Testing
- Built docs with `npm run build` — no errors
- Verified Prism token classes present in output HTML
- Tested responsive menu at mobile breakpoints via dev server