### PR TITLE
Render bare template-name references instead of leaking the name to the LLM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,28 @@ agent_directory/
 - Agent configs specify `system_template`, `llm_model`, and available `tools`
 - Tasks define the initial prompt and parameters for an agent
 
+### Prompt Templates
+
+Reusable prompt bodies live in `templates/*.yaml` (each file has `name:` and
+`template:`). They can be referenced from a config's `system_template`, a
+task's `system_template`, or a task's `prompt` in two equivalent ways:
+
+- **Bare name** — `system_template: my_template` / `prompt: my_prompt`. The
+  renderer expands a bare string that exactly matches a registered template
+  name to that template's body before rendering. (Expansion happens once, at
+  the top level only — it does not chain through a body that is itself a bare
+  name.)
+- **Explicit Jinja** — `system_template: "{{ my_template.template }}"`. Useful
+  when you want to compose a template with other text or inputs in the same
+  string.
+
+Either way, the resolved body is then rendered recursively against the task
+parameters and template inputs, so the body can itself contain `{{ ... }}`.
+Inline prompts (a string containing `{{ ... }}` that isn't just a template
+name) are rendered as-is — no template lookup happens. To send a literal
+string that happens to collide with a template name, force Jinja, e.g.
+`prompt: "{{ 'summary' }}"`.
+
 ### Tool Development
 - Tools must accept `stack` parameter (auto-injected)
 - Access agent context via `stack.agent.environment.env_vars`

--- a/src/gimle/hugin/agent/config.py
+++ b/src/gimle/hugin/agent/config.py
@@ -14,7 +14,9 @@ class Config:
     Attributes:
         name: Unique identifier for this configuration.
         description: Human-readable description of the agent's purpose.
-        system_template: Name of the system prompt template to use.
+        system_template: System prompt. May be a registered template name, an
+                         inline Jinja2 string, or "{{ name.template }}". See
+                         CLAUDE.md -> Prompt Templates.
         llm_model: LLM model identifier (default: "sonnet-latest").
         tools: List of tool names this agent can use.
         interactive: Whether this agent requires human interaction.

--- a/src/gimle/hugin/agent/task.py
+++ b/src/gimle/hugin/agent/task.py
@@ -27,9 +27,13 @@ class Task:
         name: Unique identifier for this task.
         description: Human-readable description of the task.
         parameters: Template parameters for the prompt.
-        prompt: The prompt template (Jinja2).
+        prompt: Task prompt. May be a registered template name, an inline
+                Jinja2 string, or "{{ name.template }}". See CLAUDE.md ->
+                Prompt Templates.
         tools: Optional list of tool names for this task.
-        system_template: Optional system prompt template name.
+        system_template: Optional system prompt override (same forms as
+                         ``prompt``); falls back to the config's
+                         system_template.
         llm_model: Optional LLM model override.
         next_task: Name of task to chain to after completion.
         task_sequence: Ordered list of tasks to execute in sequence.

--- a/src/gimle/hugin/apps/agent_builder/templates/builder_system.yaml
+++ b/src/gimle/hugin/apps/agent_builder/templates/builder_system.yaml
@@ -15,7 +15,8 @@ template: |
 
   **Template** (templates/name.yaml): System prompt with domain-specific expertise.
 
-  **Task** (tasks/name.yaml): Prompt with Jinja2 `{{ param.value }}` syntax.
+  **Task** (tasks/name.yaml): Prompt with Jinja2 parameter interpolation —
+  reference a "foo" parameter as foo.value inside double curly braces.
   Parameters use strict schema: `{type: string, description: "...", required: true}`
 
   **Tools** (tools/name.py + name.yaml):

--- a/src/gimle/hugin/llm/prompt/renderer.py
+++ b/src/gimle/hugin/llm/prompt/renderer.py
@@ -6,7 +6,10 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from pandas import DataFrame, read_parquet
 
-from gimle.hugin.llm.prompt.jinja import render_jinja_recursive
+from gimle.hugin.llm.prompt.jinja import (
+    contains_jinja,
+    render_jinja_recursive,
+)
 
 if TYPE_CHECKING:
     from gimle.hugin.agent.agent import Agent
@@ -105,13 +108,30 @@ class PromptRenderer:
         template_inputs: Dict[str, Any],
         reduced: Optional[bool] = False,
     ) -> str:
-        """Render a prompt with template inputs."""
+        """Render a prompt with template inputs.
+
+        If ``prompt_text`` is a bare reference to a registered template (i.e.
+        it contains no Jinja syntax and matches a template name exactly), it is
+        expanded to that template's body before rendering. This makes the
+        documented YAML form ``system_template: my_template`` / ``prompt:
+        my_prompt`` work as written, instead of sending the literal name to the
+        LLM.
+        """
+        registered_templates = (
+            self.agent.environment.template_registry.registered()
+        )
+        if (
+            isinstance(prompt_text, str)
+            and not contains_jinja(prompt_text)
+            and prompt_text in registered_templates
+        ):
+            logger.debug(
+                f"Expanding bare template reference '{prompt_text}' to its body"
+            )
+            prompt_text = registered_templates[prompt_text].template
         template_inputs = {
             **template_inputs,
-            **{
-                k: v
-                for k, v in self.agent.environment.template_registry.registered().items()
-            },
+            **registered_templates,
             **PromptRenderer.render_template_inputs(template_inputs, reduced),
             **{
                 "agent": self,

--- a/tasks/open/017-template-name-rendering-silent-failure.md
+++ b/tasks/open/017-template-name-rendering-silent-failure.md
@@ -1,0 +1,116 @@
+---
+github_issue: null
+title: Bare template-name references in task.prompt and config.system_template silently send the literal name to the LLM
+state: OPEN
+labels: [bug, prompts]
+author: erikarne
+created: 2026-05-09
+---
+
+# Bare template-name references silently send the literal name to the LLM
+
+## Summary
+
+Writing `prompt: research_prompt` (a bare template name) in a task YAML
+or `system_template: builder_system` in a config YAML produces no error
+and looks correct, but the LLM receives the **literal name string** —
+not the rendered template content. Hugin's own test
+(`tests/test_prompt.py:334`) shows the working pattern is
+`"{{ research_prompt.template }}"`, but every YAML example in
+`apps/agent_builder/configs/agent_builder.yaml` and friends uses the
+broken bare-name form.
+
+This is a silent-correctness bug. The agent still runs, the model
+still emits tool calls, the session still completes — but it improvises
+entirely from tool schemas because no actual instructions reached it.
+
+## Reproduction
+
+```python
+# Run any task that uses a bare-name reference, intercept chat_completion.
+from unittest.mock import patch
+
+CAPTURED = {}
+def fake(system_prompt, messages, tools, llm_model):
+    CAPTURED.setdefault("system_prompt", system_prompt)
+    CAPTURED.setdefault("messages", list(messages))
+    return {"role": "assistant", "content": "stub", "tool_call": None,
+            "tool_call_id": None, "input_tokens": 0, "output_tokens": 0,
+            "extra_content": []}
+
+# Build any session whose task YAML has `prompt: foo_prompt`
+# and whose config has `system_template: bar_system`.
+with patch("gimle.hugin.llm.completion.chat_completion", side_effect=fake):
+    session.run(max_steps=1)
+
+assert CAPTURED["system_prompt"] == "bar_system"          # bare name leaks
+assert CAPTURED["messages"][0]["content"][0]["text"] == "foo_prompt"  # bare name leaks
+```
+
+Verified against `apps/agent_builder` (system prompt = `'builder_system'`,
+14 chars) — the agent works in spite of this because tools like
+`generate_config` / `generate_template` are leading enough that the
+model improvises sensibly.
+
+## Root cause
+
+Two paths share the same root:
+
+1. **System prompt** — `PromptRenderer.render_system_prompt()` calls
+   `stack.get_system_template()`, which returns
+   `agent.config.system_template` as a plain string (`"builder_system"`).
+   That string is then passed to `render_prompt(prompt_text, inputs)`.
+   `render_jinja_recursive("builder_system", inputs)` short-circuits
+   because `contains_jinja("builder_system")` is False — the bare name
+   has no `{{ }}` syntax, so it returns the name verbatim.
+
+2. **User prompt** — When `AskOracle.create_from_task_definition` is used,
+   it sets `prompt = Prompt(type="template", text=task.prompt)` (no
+   `template_name`). `render_user_message` then takes the
+   `template_name is None` branch and calls `render_task_prompt`, which
+   does `task_prompt = task_definition.prompt; render_prompt(task_prompt, ...)`.
+   Same short-circuit — the bare name is returned.
+
+The pattern that does work — and is exercised by
+`tests/test_prompt.py::test_render_prompt_with_template` — is
+`"{{ template_name.template }}"`. Jinja then dereferences the registered
+`Template` dataclass via `.template`, returns the content, and the
+recursive renderer expands inner `{{ }}` against the live inputs.
+
+## Impact
+
+- `apps/agent_builder/configs/agent_builder.yaml` (and presumably every
+  config that ships with Hugin) has a system prompt that never reaches
+  the LLM. agent_builder works because tools carry the intent.
+- Downstream apps (`apps/financial_newspaper/tasks/create_layout.yaml`
+  uses `prompt: create_layout_prompt`) hit the same trap and ship
+  silently broken.
+- We hit this in `gimle-heimdall` PR #14 — spent ~half a day debugging
+  why the model "ignored" the prompt before discovering it never
+  arrived. Linked discussion / writeup is in
+  `gimle-heimdall/docs/superpowers/specs/2026-05-08-insights-agent-topology-rework-design.md`.
+
+## Suggested fixes (not mutually exclusive)
+
+1. **Auto-lookup in `render_prompt`** — if `prompt_text` matches a
+   registered template name exactly (no Jinja syntax), look it up and
+   render `template.template` instead. This makes the naive YAML form
+   work as users expect. Risk: shadowing if a user happens to write a
+   string that collides with a template name.
+
+2. **Validate at load time** — `Environment.load` could refuse to
+   register a config/task whose `system_template`/`prompt` is a bare
+   string that matches a known template name AND has no Jinja syntax,
+   pointing the user at the `{{ X.template }}` form.
+
+3. **Doc + audit** — fix every bundled YAML to use
+   `"{{ X.template }}"`, add a section to the README/CLAUDE.md, and
+   leave the renderer alone. Lowest-risk, highest-toil.
+
+## Related observation (separate, smaller issue)
+
+`OracleResponse` interactions store only the assistant response — not
+the rendered system+user prompt that was actually sent. When the bug
+above triggers, nothing in the persisted session reveals it; you have
+to monkey-patch `chat_completion`. Worth logging the rendered prompt
+on `AskOracle.step()` (gated by debug flag if it's verbose).

--- a/tasks/open/017-template-name-rendering-silent-failure.md
+++ b/tasks/open/017-template-name-rendering-silent-failure.md
@@ -114,3 +114,63 @@ the rendered system+user prompt that was actually sent. When the bug
 above triggers, nothing in the persisted session reveals it; you have
 to monkey-patch `chat_completion`. Worth logging the rendered prompt
 on `AskOracle.step()` (gated by debug flag if it's verbose).
+
+## Resolution
+
+Implemented **suggested fix 1**: `PromptRenderer.render_prompt()` now
+expands a bare `prompt_text` to the registered template's body when the
+string contains no Jinja syntax and matches a template name exactly.
+This covers both call paths (`render_system_prompt` and
+`render_task_prompt`) at their single chokepoint, so all bundled YAML
+that uses the bare-name form (every shipped config) now works
+unchanged. `Prompt(type="template", template_name=...)` already
+resolved correctly and is untouched.
+
+Also documented the two equivalent reference forms (bare name vs.
+`{{ X.template }}`), the shadowing escape hatch, and the one-shot nature
+of bare-name expansion in `CLAUDE.md` -> Prompt Templates, and
+reconciled the now-accurate docstrings on `Config.system_template`,
+`Task.prompt`, and `Task.system_template`.
+
+Fixed one template that had been relying on the broken behavior:
+`apps/agent_builder/templates/builder_system.yaml` contained literal
+example Jinja (`{{ param.value }}`) in its body as documentation. The
+body was never rendered before, so it never blew up; now that it is
+rendered the `param.value` attribute access on an undefined `param`
+raises. Reworded it to prose (the recursive renderer cannot emit literal
+`{{ }}` in its output — even `{% raw %}` gets re-rendered on the next
+pass — so the example had to go). A smoke test renders every bundled
+config's system prompt and every bare-name task prompt; all pass. (Note:
+`apps/data_analyst`, `apps/financial_newspaper`, `apps/rap_machine`,
+`apps/the_hugins` fail to load via `Environment.load(<relative path>)`
+from an arbitrary cwd — a pre-existing tool-import path issue,
+reproducible on `main`, unrelated to this change; their templates were
+audited statically and contain only bare-variable interpolation, which
+renders to empty strings rather than erroring.)
+
+Tests added in `tests/test_prompt.py`:
+`test_render_prompt_with_bare_template_name`,
+`test_render_prompt_literal_text_not_a_template_name`,
+`test_render_task_prompt_with_bare_template_name`,
+`test_render_system_prompt_with_bare_template_name`, and
+`TestSystemPromptReachesModel::test_bare_system_template_reaches_model`
+(end-to-end: builds a session, runs a step with a patched
+`chat_completion`, asserts the rendered body — not the literal name —
+reaches the model).
+
+### Out of scope / follow-ups
+
+- The `OracleResponse` observation above (persist the rendered prompt
+  for debuggability) — should become its own task; it's what turned
+  this into a half-day debug in heimdall.
+- Suggested fix 2 (load-time validation) is *not* implemented and is
+  still worthwhile: a *misspelled* bare name (`system_template:
+  basci_system`) still silently sends the typo to the LLM, because it
+  matches no template and isn't Jinja. Worth a warning at
+  `Environment.load`.
+- `render_jinja_recursive` renders to a fixpoint of "no Jinja syntax
+  left", so a template can never emit literal `{{ }}`/`{% %}` in its
+  output (even `{% raw %}` only survives one pass). Fine today, but if a
+  prompt ever legitimately needs to show Jinja syntax to the model,
+  the recursive renderer needs a real escape mechanism (or a fixpoint /
+  depth guard).

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,7 +1,7 @@
 """Tests for prompt rendering, templates, and Jinja utilities."""
 
 from io import BytesIO
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -337,6 +337,23 @@ class TestPromptRenderer:
         result = renderer.render_prompt(template_str, inputs)
         assert result == "Hello World"
 
+    def test_render_prompt_with_bare_template_name(self, mock_agent):
+        """A bare template name resolves to and renders the template body."""
+        template = Template(
+            name="greeting_template", template="Hello {{ name }}"
+        )
+        mock_agent.environment.template_registry.register(template)
+
+        renderer = PromptRenderer(mock_agent)
+        result = renderer.render_prompt("greeting_template", {"name": "World"})
+        assert result == "Hello World"
+
+    def test_render_prompt_literal_text_not_a_template_name(self, mock_agent):
+        """Plain text that matches no registered template is returned as-is."""
+        renderer = PromptRenderer(mock_agent)
+        result = renderer.render_prompt("not a registered template", {})
+        assert result == "not a registered template"
+
     def test_render_prompt_with_dataframe(self, mock_agent):
         """Test prompt rendering with DataFrame."""
         renderer = PromptRenderer(mock_agent)
@@ -435,6 +452,26 @@ class TestPromptRenderer:
         result = renderer.render_task_prompt(inputs)
         assert result == "Task: test_task"
 
+    def test_render_task_prompt_with_bare_template_name(self, mock_agent):
+        """A task whose prompt is a bare template name renders the body."""
+        template = Template(
+            name="do_the_thing_prompt", template="Please {{ action }}."
+        )
+        mock_agent.environment.template_registry.register(template)
+        task = Task(
+            name="do_the_thing",
+            description="Do the thing",
+            parameters={},
+            prompt="do_the_thing_prompt",
+            tools=[],
+        )
+        task_definition = TaskDefinition(stack=mock_agent.stack, task=task)
+        mock_agent.stack.interactions = [task_definition]
+
+        renderer = PromptRenderer(mock_agent)
+        result = renderer.render_task_prompt({"action": "save the file"})
+        assert result == "Please save the file."
+
     def test_render_system_prompt(self, mock_agent):
         """Test rendering system prompt."""
         renderer = PromptRenderer(mock_agent)
@@ -468,6 +505,21 @@ class TestPromptRenderer:
 
         result = renderer.render_system_prompt()
         assert "System:" in result
+
+    def test_render_system_prompt_with_bare_template_name(self, mock_agent):
+        """A config whose system_template is a bare name renders the body."""
+        template = Template(name="bare_system", template="You are {{ role }}.")
+        mock_agent.environment.template_registry.register(template)
+        config = Config(
+            name="bare-agent",
+            description="Agent with a bare system_template reference",
+            system_template="bare_system",
+        )
+        agent = Agent(session=mock_agent.session, config=config)
+
+        renderer = PromptRenderer(agent)
+        result = renderer.render_system_prompt({"role": "a helpful assistant"})
+        assert result == "You are a helpful assistant."
 
     def test_prompt_renderer_interactions_attribute(
         self, mock_agent, mock_interaction
@@ -539,6 +591,67 @@ class TestPromptRenderer:
         result = PromptRenderer.render_template_inputs(inputs)
         assert result["name"] == "test"
         assert result["count"] == 42
+
+
+class TestSystemPromptReachesModel:
+    """End-to-end: the rendered system prompt actually reaches the model."""
+
+    def test_bare_system_template_reaches_model(self, mock_session):
+        """A config's bare ``system_template`` name reaches the model rendered.
+
+        Regression test for the silent-failure bug: ``system_template: name``
+        used to send the literal string ``"name"`` to the LLM instead of the
+        rendered template body.
+        """
+        mock_session.environment.template_registry.register(
+            Template(
+                name="e2e_system",
+                template="You are the e2e system for {{ agent.config.name }}.",
+            )
+        )
+        config = Config(
+            name="e2e-agent",
+            description="agent under e2e test",
+            system_template="e2e_system",
+            tools=[],
+        )
+        task = Task(
+            name="e2e_task",
+            description="task under e2e test",
+            prompt="Do the e2e thing.",
+            tools=[],
+        )
+        mock_session.create_agent_from_task(config, task)
+        agent = mock_session.agents[0]
+
+        captured: dict = {}
+
+        def fake_chat_completion(system_prompt, messages, tools, llm_model):
+            captured.setdefault("system_prompt", system_prompt)
+            return {
+                "role": "assistant",
+                "content": "ok",
+                "tool_call": None,
+                "tool_call_id": None,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "extra_content": [],
+            }
+
+        with patch(
+            "gimle.hugin.llm.completion.chat_completion",
+            side_effect=fake_chat_completion,
+        ):
+            for _ in range(5):
+                if "system_prompt" in captured:
+                    break
+                if not agent.step():
+                    break
+
+        assert (
+            captured.get("system_prompt")
+            == "You are the e2e system for e2e-agent."
+        )
 
 
 class TestPrompt:


### PR DESCRIPTION
## Summary

Writing `system_template: my_template` (a config) or `prompt: my_prompt` (a task) — i.e. a bare template name — produced no error but sent the **literal name string** to the LLM instead of the rendered template body. `render_jinja_recursive` short-circuits when the text contains no `{{ }}`, so a bare name passed straight through. Every bundled config uses this form, so **every shipped agent's system prompt never reached the model** (apps still "worked" because tool schemas + the Jinja-containing task prompts carried the intent); several `financial_newspaper` task prompts shipped silently broken too. This was a half-day debugging trap in `gimle-heimdall` PR #14. See `tasks/open/017-template-name-rendering-silent-failure.md`.

## Changes

- **`PromptRenderer.render_prompt()`** — if `prompt_text` contains no Jinja syntax **and** exactly matches a registered template name, expand it to that template's body before rendering. Single chokepoint, so both `render_system_prompt()` and `render_task_prompt()` are covered; bundled YAML is unchanged (it just works now). `Prompt(type="template", template_name=...)` already resolved correctly and is untouched.
- **`apps/agent_builder/templates/builder_system.yaml`** — its body documented `` `{{ param.value }}` `` as literal example text. The body was never rendered before, so it never blew up; now that it is, `param.value` on an undefined `param` raises. Reworded to prose. (The recursive renderer renders to a fixpoint of "no Jinja left", so a template can never emit literal `{{ }}` in its output — even `{% raw %}` only survives one pass — noted as a follow-up in the task doc.)
- **`CLAUDE.md`** — new "Prompt Templates" subsection documenting the two equivalent reference forms (bare name vs. `{{ X.template }}`), the shadowing escape hatch, and the one-shot nature of bare-name expansion.
- **Docstrings** — reconciled `Config.system_template`, `Task.prompt`, `Task.system_template` (were contradictory; now accurate).
- **Tests** (`tests/test_prompt.py`) — bare-name resolution for `render_prompt` / `render_task_prompt` / `render_system_prompt`, literal-text passthrough (shadowing guard), and an end-to-end test that builds a session, runs a step with a patched `chat_completion`, and asserts the rendered body — not the literal name — reaches the model.

## Behavior change / risk

This is a real behavior change for **every bundled app and example**: their system prompts (and the `financial_newspaper` task prompts that used bare names) now actually reach the model. That's the point — but worth knowing. Shadowing: a one-word literal prompt that collides with a template name is now expanded instead of sent verbatim — negligible (zero collisions in-repo; degenerate input; benign failure mode), and the escape hatch (`prompt: "{{ 'summary' }}"`) is documented.

## Testing

- `uv run pytest -q` → **605 passed, 12 skipped** (skips are the pre-existing ollama tests).
- `uv run pre-commit run --all-files` → black / isort / flake8 / check-yaml / whitespace pass. The `mypy` hook hits an internal mypy error inside `openai/_client.py` — **pre-existing on `main`**, unrelated; `mypy` on the changed source files directly is clean.
- TDD: confirmed all new bare-name tests fail before the fix (e.g. `assert 'e2e_system' == 'You are the e2e system for e2e-agent.'`) and pass after.
- Smoke test: rendered every bundled config's system prompt and every bare-name task prompt across `examples/*` and `apps/agent_builder` — all OK. (`apps/data_analyst`, `apps/financial_newspaper`, `apps/rap_machine`, `apps/the_hugins` fail to load via `Environment.load(<relative path>)` from an arbitrary cwd — a pre-existing tool-import path issue, reproducible on `main`; their templates were audited statically and contain only bare-variable interpolation, which renders to empty strings, not errors.)
- Real CLI: `uv run hugin run --task hello_world --task-path examples/basic_agent` now logs `System prompt rendered=You are a helpful AI assistant.` (previously the literal `basic_system`).

## Follow-ups (noted in the task doc, not in scope here)

- `OracleResponse` doesn't persist the rendered prompt — what turned this into a half-day debug. Should become its own task.
- Load-time validation (suggested fix 2): a *misspelled* bare name (`system_template: basci_system`) still silently leaks the typo to the LLM since it matches no template and isn't Jinja.
- `render_jinja_recursive` has no real escape mechanism / fixpoint guard for emitting literal Jinja syntax.