### PR TITLE
Close task 017 — template-name render fix shipped in PR #42

### DIFF
--- a/tasks/closed/017-template-name-rendering-silent-failure.md
+++ b/tasks/closed/017-template-name-rendering-silent-failure.md
@@ -1,10 +1,12 @@
 ---
 github_issue: null
 title: Bare template-name references in task.prompt and config.system_template silently send the literal name to the LLM
-state: OPEN
+state: CLOSED
 labels: [bug, prompts]
 author: erikarne
 created: 2026-05-09
+closed: 2026-05-11
+resolution: Fixed in PR #42 (commit 7e116df) — see the Resolution section below.
 ---
 
 # Bare template-name references silently send the literal name to the LLM


### PR DESCRIPTION
## Summary
Move `tasks/open/017-template-name-rendering-silent-failure.md` to `tasks/closed/` and mark it `state: CLOSED`. The fix landed in #42.

## Changes
- `git mv tasks/open/017-...md tasks/closed/017-...md`
- Frontmatter: `state: OPEN` → `state: CLOSED`, added `closed:` / `resolution:` fields

## Testing
Docs/task-tracking only — no code changes.