### PR TITLE
Add follow-up tasks 018-020 from #42

### DIFF
--- a/tasks/open/018-persist-rendered-prompt.md
+++ b/tasks/open/018-persist-rendered-prompt.md
@@ -1,0 +1,53 @@
+---
+github_issue: null
+title: Persist the rendered system + user prompt that was actually sent to the LLM
+state: OPEN
+labels: [enhancement, observability]
+author: erikarne
+created: 2026-05-11
+---
+
+# Persist the rendered prompt sent to the LLM
+
+## Why
+
+`OracleResponse` interactions store only the assistant's response — not the
+rendered system prompt and user message(s) that were actually sent to
+`chat_completion`. When a prompt-rendering bug triggers (e.g. the bare
+template-name silent failure fixed in #42), nothing in the persisted session
+reveals it: you have to monkey-patch `chat_completion` to see what was sent.
+That's what turned #42 into a ~half-day debug in `gimle-heimdall` PR #14.
+
+## What
+
+On `AskOracle.step()` (`src/gimle/hugin/interaction/ask_oracle.py`), capture:
+
+- the rendered `system_prompt` (already computed there via
+  `PromptRenderer.render_system_prompt`)
+- the rendered user message content (the list returned by
+  `render_user_message` / `render_stack_context` for this interaction)
+
+…and persist it — either as fields on `OracleResponse`
+(`src/gimle/hugin/interaction/oracle_response.py`) or new fields on `AskOracle`
+— so it round-trips through storage and shows up in the monitor UI
+(`src/gimle/hugin/cli/monitor_agents.py`, `src/gimle/hugin/ui/page.py`).
+
+## Open questions
+
+- Verbosity: rendered prompts can be large. Gate behind a debug flag /
+  config option, or always store but only render in the monitor on demand?
+- Storage cost: full prompt per `AskOracle` step. Acceptable, or store a
+  hash + the prompt only when it differs from the previous step?
+
+## Success criteria
+
+- [ ] Given a session that hit a prompt-rendering bug, the persisted
+      session shows the literal-vs-rendered system/user prompt without any
+      monkey-patching.
+- [ ] Monitor UI surfaces the rendered prompt for an `AskOracle`/`OracleResponse`.
+- [ ] Old sessions (without the new field) still load.
+
+## Context
+
+Surfaced as a follow-up in `tasks/closed/017-template-name-rendering-silent-failure.md`
+("Related observation").

--- a/tasks/open/019-warn-on-unknown-template-reference.md
+++ b/tasks/open/019-warn-on-unknown-template-reference.md
@@ -1,0 +1,54 @@
+---
+github_issue: null
+title: Warn at load time when a config/task references a template name that isn't registered
+state: OPEN
+labels: [enhancement, dx]
+author: erikarne
+created: 2026-05-11
+---
+
+# Warn on bare template references that match no registered template
+
+## Why
+
+#42 made bare template-name references work: `system_template: my_template` /
+`prompt: my_prompt` (a bare string, no Jinja) now resolves to the registered
+template's body. But a **misspelled** bare name — `system_template:
+basci_system` instead of `basic_system` — still silently sends the literal
+typo string to the LLM, because it matches no registered template and contains
+no Jinja, so the renderer passes it through verbatim. Same silent-failure class
+as #42, just narrower (and now arguably more surprising, since the non-typo
+case works).
+
+## What
+
+After `Environment.load()` has registered all templates, configs, and tasks
+(`src/gimle/hugin/agent/environment.py`), validate that each `config.system_template`,
+`task.system_template`, and `task.prompt` that *looks like a bare template
+reference* — i.e. contains no Jinja syntax, no newlines, and reads like an
+identifier — actually matches a registered template name. If it doesn't, emit
+a warning pointing at the likely typo (closest registered name?) and the
+`{{ X.template }}` form.
+
+Validation must run *after* the full load, not while registering configs — a
+config may be registered before the template it names.
+
+## Watch out for
+
+- Don't false-positive on legitimate short literal prompts (e.g. a task whose
+  prompt genuinely is `"Summarize this."`). Heuristic: single token, snake_case,
+  no spaces → likely a template reference; anything with a space → a literal.
+  Worst case it's a `logger.warning`, not an error, so a false positive is cheap.
+- Consider whether this should be a hard error in strict mode and a warning
+  otherwise.
+
+## Success criteria
+
+- [ ] Loading an environment with `system_template: <typo>` logs a clear
+      warning naming the offending config/task and the unknown template.
+- [ ] No warnings for the bundled apps/examples (they all reference real
+      templates) or for tasks with inline-prose prompts.
+
+## Context
+
+"Suggested fix 2" in `tasks/closed/017-template-name-rendering-silent-failure.md`.

--- a/tasks/open/020-jinja-renderer-escape-and-undefined.md
+++ b/tasks/open/020-jinja-renderer-escape-and-undefined.md
@@ -1,0 +1,54 @@
+---
+github_issue: null
+title: render_jinja_recursive can never emit literal Jinja syntax; reconsider Undefined behavior
+state: OPEN
+labels: [enhancement, tech-debt, prompts]
+author: erikarne
+created: 2026-05-11
+---
+
+# Give the Jinja renderer an escape mechanism (and reconsider Undefined)
+
+## The problem
+
+`render_jinja_recursive` (`src/gimle/hugin/llm/prompt/jinja.py`) renders to a
+fixpoint of "no `{{ }}` / `{% %}` / `{# #}` left in the string". Consequence:
+a template can never produce literal Jinja syntax in its output —
+`{% raw %}{{ x }}{% endraw %}` renders to `{{ x }}` on pass 1, then gets
+re-rendered (and `{{ x }}` with `x` undefined renders to `''`) on pass 2.
+
+This bit us in #42: `apps/agent_builder/templates/builder_system.yaml` had
+`{{ param.value }}` in its body as a **documentation example** showing the
+agent-builder LLM how to write task prompts. The template body was never
+rendered before #42, so it never blew up; once #42 made bare-name system
+templates actually render, `param.value` (attribute access on an undefined
+`param`) raised `UndefinedError`. We reworked it to prose, losing the literal
+example.
+
+## What to consider
+
+1. **Escape mechanism that survives recursion.** Honor `{% raw %}…{% endraw %}`
+   non-recursively (strip the markers only on the *final* pass), or a sentinel
+   token that's substituted back to `{{`/`}}` at the very end, or stop the
+   recursion at a fixpoint (if a render pass changes nothing, stop) plus a
+   max-depth guard.
+2. **`Undefined` behavior.** `render_jinja` uses Jinja's default `Undefined`:
+   `{{ x }}` with `x` undefined → `''` (silent), but `{{ x.attr }}` → raises.
+   That's an inconsistent foot-gun (it's exactly what blew up in #42).
+   Consider `jinja2.ChainableUndefined` so `{{ x.attr }}` also renders empty —
+   or, conversely, `StrictUndefined` everywhere so *both* fail loudly (which
+   pairs well with task 019). Pick one consistent policy.
+3. **The agent-builder case specifically.** Once an escape mechanism exists,
+   restore the literal `{{ param.value }}` example in `builder_system.yaml`.
+
+## Success criteria
+
+- [ ] A template body can include literal `{{ … }}` text that reaches the
+      model verbatim, via a documented mechanism, with a test.
+- [ ] `{{ undefined.attr }}` behaves consistently with `{{ undefined }}`
+      (both silent, or both loud — decided and documented).
+- [ ] Existing prompt-rendering tests still pass.
+
+## Context
+
+Follow-up noted in `tasks/closed/017-template-name-rendering-silent-failure.md`.


### PR DESCRIPTION
## Summary
Spin off the follow-ups noted in the (now-closed) task 017 / PR #42 into their own task files.

## Changes
- `tasks/open/018-persist-rendered-prompt.md` — persist the rendered system + user prompt that was actually sent to `chat_completion`, so prompt-rendering bugs are visible in the persisted session / monitor without monkey-patching. (This is the one that turned #42 into a half-day debug.)
- `tasks/open/019-warn-on-unknown-template-reference.md` — warn at `Environment.load` time when a `config.system_template` / `task.system_template` / `task.prompt` is a bare string that matches no registered template (a typo still silently leaks the literal name to the LLM — same class as #42, narrower).
- `tasks/open/020-jinja-renderer-escape-and-undefined.md` — `render_jinja_recursive` renders to a fixpoint of "no Jinja left", so a template can never emit literal `{{ }}`; even `{% raw %}` only survives one pass (this forced reworking `builder_system.yaml` in #42). Also reconsider the inconsistent default-`Undefined` behavior (`{{ x }}` silent, `{{ x.attr }}` raises).

## Testing
Task-tracking files only — no code changes.