### PR TITLE
Stop model adapters collapsing newlines in assistant text

### DIFF
--- a/src/gimle/hugin/llm/models/anthropic.py
+++ b/src/gimle/hugin/llm/models/anthropic.py
@@ -143,7 +143,7 @@ MAX TOKENS:\n{self.max_tokens}"""
         text_content = getattr(first_content, "text", "") or ""
         return ModelResponse(
             role="assistant",
-            content=text_content.replace("\n", " "),
+            content=text_content,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )

--- a/src/gimle/hugin/llm/models/model.py
+++ b/src/gimle/hugin/llm/models/model.py
@@ -11,7 +11,16 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ModelResponse:
-    """A model response."""
+    """A model response.
+
+    ``content`` depends on which path the model took:
+
+    - Plain-text path (no tool call): the model's text **verbatim**, with
+      newlines preserved. Adapters must not collapse or otherwise mutate the
+      text — any single-line formatting belongs to the display/logging layer.
+    - Tool-call path: the tool-arguments dict (``tool_call`` / ``tool_call_id``
+      identify the tool).
+    """
 
     role: Literal["user", "assistant", "system"]
     content: Any

--- a/src/gimle/hugin/llm/models/ollama.py
+++ b/src/gimle/hugin/llm/models/ollama.py
@@ -1050,7 +1050,7 @@ TEMPERATURE:\n{self.temperature}"""
             )
         return ModelResponse(
             role="assistant",
-            content=(response.message.content or "").replace("\n", " "),
+            content=(response.message.content or ""),
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )

--- a/src/gimle/hugin/llm/models/openai.py
+++ b/src/gimle/hugin/llm/models/openai.py
@@ -159,7 +159,7 @@ class OpenAIModel(Model):
         text_content = message.content or ""
         return ModelResponse(
             role="assistant",
-            content=text_content.replace("\n", " "),
+            content=text_content,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             reasoning_content=reasoning_content,

--- a/tasks/closed/022-model-adapters-collapse-newlines.md
+++ b/tasks/closed/022-model-adapters-collapse-newlines.md
@@ -1,6 +1,6 @@
 ---
 title: Model adapters collapse newlines in assistant text content
-state: OPEN
+state: CLOSED
 labels: [bug, llm]
 author: arnovich
 created: 2026-05-25

--- a/tests/test_model_adapters.py
+++ b/tests/test_model_adapters.py
@@ -1,0 +1,75 @@
+r"""Regression tests for LLM adapter plain-text content handling.
+
+These tests pin the contract documented on ``ModelResponse.content``: on the
+plain-text (non-tool-call) path the adapter must return the model's text
+**verbatim**, with newlines preserved. They would fail if any adapter
+reintroduced the old ``.replace("\\n", " ")`` newline collapse.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+MULTILINE = "line one\nline two\nline three"
+
+
+class TestAnthropicAdapterPreservesNewlines:
+    """The Anthropic adapter must not collapse newlines in text responses."""
+
+    def test_multiline_text_roundtrips_verbatim(self):
+        """Multi-line model text comes back verbatim (no newline collapse)."""
+        from gimle.hugin.llm.models.anthropic import AnthropicModel
+
+        fake_response = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text=MULTILINE)],
+            usage=SimpleNamespace(input_tokens=3, output_tokens=5),
+            id="resp_test",
+        )
+
+        fake_client = MagicMock()
+        fake_client.with_options.return_value.messages.create.return_value = (
+            fake_response
+        )
+
+        model = AnthropicModel(model_name="claude-test")
+        with patch("anthropic.Anthropic", return_value=fake_client):
+            response = model.chat_completion(
+                system_prompt="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+            )
+
+        assert response.role == "assistant"
+        assert response.tool_call is None
+        assert response.content == MULTILINE
+        assert "\n" in response.content
+
+
+class TestOpenAIAdapterPreservesNewlines:
+    """The OpenAI adapter must not collapse newlines in text responses."""
+
+    def test_multiline_text_roundtrips_verbatim(self):
+        """Multi-line model text comes back verbatim (no newline collapse)."""
+        from gimle.hugin.llm.models.openai import OpenAIModel
+
+        message = SimpleNamespace(content=MULTILINE, tool_calls=None)
+        fake_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=message)],
+            usage=SimpleNamespace(prompt_tokens=3, completion_tokens=5),
+            id="resp_test",
+        )
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = fake_response
+
+        model = OpenAIModel(model_name="gpt-test")
+        with patch("openai.OpenAI", return_value=fake_client):
+            response = model.chat_completion(
+                system_prompt="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+            )
+
+        assert response.role == "assistant"
+        assert response.tool_call is None
+        assert response.content == MULTILINE
+        assert "\n" in response.content

--- a/tests/test_ollama_models.py
+++ b/tests/test_ollama_models.py
@@ -414,6 +414,41 @@ class TestOllamaModelHost:
             mock_client_cls.assert_called_once()
 
 
+class TestOllamaAdapterPreservesNewlines:
+    """The Ollama adapter must not collapse newlines in text responses."""
+
+    def test_multiline_text_roundtrips_verbatim(self):
+        """Multi-line model text comes back verbatim (newlines preserved)."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from gimle.hugin.llm.models.ollama import OllamaModel
+
+        multiline = "line one\nline two\nline three"
+        fake_response = SimpleNamespace(
+            message=SimpleNamespace(content=multiline, tool_calls=None),
+            prompt_eval_count=3,
+            eval_count=5,
+        )
+
+        # "test-model" avoids the qwen/llama/... resource-delay and option
+        # tweaks, keeping the no-tools path minimal.
+        model = OllamaModel(model_name="test-model")
+        model._client = MagicMock()
+        model._client.chat.return_value = fake_response
+
+        response = model.chat_completion(
+            system_prompt="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+        )
+
+        assert response.role == "assistant"
+        assert response.tool_call is None
+        assert response.content == multiline
+        assert "\n" in response.content
+
+
 if __name__ == "__main__":
     # Allow running this test file directly
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
All three LLM adapters silently stripped newlines from the assistant's free-text response on the plain-text (non-tool-call) path via an unconditional, undocumented `.replace("\n", " ")`. As a result `ModelResponse.content` was never returned verbatim for multi-line output — any consumer needing structured multi-line text (markdown, code blocks, lists, "one item per line") got a single space-joined line with no error or warning. Tool-call agents were unaffected (tool args return as a dict), which is why it went unnoticed.

This caused a real, silent failure: a bifrost LLM-proposer asked for candidates "one per line", parsed on `\n`, and got zero candidates because the adapter had collapsed the newlines.

Closes task 022.

## Changes
- Return assistant text verbatim on the plain-text path in `anthropic.py`, `openai.py`, `ollama.py` (drop the `.replace("\n", " ")`).
- Document the `ModelResponse.content` contract: verbatim text (newlines preserved) on the plain-text path; tool-args dict on the tool-call path.
- Add regression tests asserting multi-line text round-trips unchanged:
  - `tests/test_model_adapters.py` (Anthropic + OpenAI, mocking the provider client)
  - an Ollama case in `tests/test_ollama_models.py`
- Move task file `022` from `tasks/open/` to `tasks/closed/`.

The display/preview layers (`ui/components/text.py`, `cli/interactive/screens/artifacts_list.py`, `cli/rate_artifact.py`) already collapse newlines independently, so single-line rendering is unaffected.

## Testing
- `uv run pytest -q` → 629 passed, 12 skipped.
- New tests verified to fail if the `.replace("\n", " ")` collapse is reintroduced.
- `uv run pre-commit run --all-files`: black/isort/flake8 pass. mypy fails only on the pre-existing `openai/_client.py` internal error, unrelated to this change.