### PR TITLE
Jinja renderer: literal-escape mechanism + consistent Undefined policy

### DIFF
--- a/src/gimle/hugin/apps/agent_builder/templates/builder_system.yaml
+++ b/src/gimle/hugin/apps/agent_builder/templates/builder_system.yaml
@@ -16,7 +16,7 @@ template: |
   **Template** (templates/name.yaml): System prompt with domain-specific expertise.
 
   **Task** (tasks/name.yaml): Prompt with Jinja2 parameter interpolation —
-  reference a "foo" parameter as foo.value inside double curly braces.
+  reference a "foo" parameter as {% raw %}{{ foo.value }}{% endraw %}.
   Parameters use strict schema: `{type: string, description: "...", required: true}`
 
   **Tools** (tools/name.py + name.yaml):

--- a/src/gimle/hugin/llm/prompt/jinja.py
+++ b/src/gimle/hugin/llm/prompt/jinja.py
@@ -3,7 +3,25 @@
 import re
 from typing import Any, Dict
 
-from jinja2 import Environment
+from jinja2 import ChainableUndefined, Environment
+
+# Sentinel tokens used to hide literal Jinja delimiters from the recursive
+# renderer. They wrap NUL bytes so they cannot collide with real prompt text,
+# and are restored to their original delimiters on the final pass.
+_LITERAL_DELIMITERS = {
+    "{{": "\x00jinja-open-var\x00",
+    "}}": "\x00jinja-close-var\x00",
+    "{%": "\x00jinja-open-block\x00",
+    "%}": "\x00jinja-close-block\x00",
+    "{#": "\x00jinja-open-comment\x00",
+    "#}": "\x00jinja-close-comment\x00",
+}
+
+# Match a ``{% raw %}…{% endraw %}`` block (whitespace/dash-trim tolerant).
+_RAW_BLOCK = re.compile(
+    r"\{%-?\s*raw\s*-?%\}(.*?)\{%-?\s*endraw\s*-?%\}",
+    re.DOTALL,
+)
 
 
 def contains_jinja(txt: str) -> bool:
@@ -21,16 +39,68 @@ def contains_jinja(txt: str) -> bool:
     return False
 
 
+def literal(value: Any) -> str:
+    """Mark text as literal so its Jinja delimiters are never rendered.
+
+    Use this for any value injected into a prompt as a ``template_inputs``
+    value whose content must reach the model verbatim — e.g. untrusted,
+    LLM-generated text. Any ``{{ … }}`` / ``{% … %}`` / ``{# … #}`` inside the
+    value is neutralised here and restored after the recursive render
+    completes, so it cannot be (mis)interpreted as a template on a later pass.
+
+    This is stronger than wrapping in ``{% raw %}``: the value could itself
+    contain ``{% endraw %}`` and break out of such a wrapper.
+    """
+    text = str(value)
+    for delimiter, sentinel in _LITERAL_DELIMITERS.items():
+        text = text.replace(delimiter, sentinel)
+    return text
+
+
+def _restore_literals(text: str) -> str:
+    """Restore sentinel tokens back to their literal Jinja delimiters."""
+    for delimiter, sentinel in _LITERAL_DELIMITERS.items():
+        text = text.replace(sentinel, delimiter)
+    return text
+
+
+def _protect_raw_blocks(template: str) -> str:
+    """Neutralise ``{% raw %}…{% endraw %}`` so it survives recursion.
+
+    Jinja honours ``{% raw %}`` within a single pass, but the recursive
+    renderer would re-evaluate the literal braces it emits on the next pass.
+    Stripping the markers and escaping the inner delimiters up front makes the
+    block survive every pass and be restored verbatim at the end.
+    """
+    return _RAW_BLOCK.sub(lambda m: literal(m.group(1)), template)
+
+
 def render_jinja(template: str, inputs: Dict[str, Any]) -> str:
-    """Render a Jinja template with the given inputs."""
-    env = Environment()
+    """Render a Jinja template with the given inputs.
+
+    Undefined variables — including attribute access on them — render to an
+    empty string (``ChainableUndefined``), so ``{{ x }}`` and ``{{ x.attr }}``
+    behave consistently when ``x`` is missing.
+    """
+    env = Environment(undefined=ChainableUndefined)
     for k, v in inputs.items():
         env.globals[k] = v
     return str(env.from_string(template).render().strip())
 
 
 def render_jinja_recursive(template: str, inputs: Dict[str, Any]) -> str:
-    """Recursively render a Jinja template until no more Jinja syntax remains."""
+    """Recursively render a Jinja template until no Jinja syntax remains.
+
+    Literal regions — ``{% raw %}`` blocks in the template and values marked
+    with :func:`literal` — are hidden from the recursion and restored to their
+    original delimiters once all real templating has resolved.
+    """
+    protected = _protect_raw_blocks(template)
+    return _restore_literals(_render_to_fixpoint(protected, inputs))
+
+
+def _render_to_fixpoint(template: str, inputs: Dict[str, Any]) -> str:
+    """Render repeatedly until no resolvable Jinja syntax is left."""
     if not contains_jinja(template):
         return template
-    return render_jinja_recursive(render_jinja(template, inputs), inputs)
+    return _render_to_fixpoint(render_jinja(template, inputs), inputs)

--- a/tasks/closed/020-jinja-renderer-escape-and-undefined.md
+++ b/tasks/closed/020-jinja-renderer-escape-and-undefined.md
@@ -1,7 +1,7 @@
 ---
 github_issue: null
 title: render_jinja_recursive can never emit literal Jinja syntax; reconsider Undefined behavior
-state: OPEN
+state: CLOSED
 labels: [enhancement, tech-debt, prompts]
 author: erikarne
 created: 2026-05-11
@@ -43,12 +43,37 @@ example.
 
 ## Success criteria
 
-- [ ] A template body can include literal `{{ … }}` text that reaches the
+- [x] A template body can include literal `{{ … }}` text that reaches the
       model verbatim, via a documented mechanism, with a test.
-- [ ] `{{ undefined.attr }}` behaves consistently with `{{ undefined }}`
-      (both silent, or both loud — decided and documented).
-- [ ] Existing prompt-rendering tests still pass.
+- [x] A value passed via `template_inputs` can be marked literal so that any
+      Jinja delimiters inside it reach the model verbatim and are never
+      re-evaluated, with a test (the injection case task 021 depends on).
+- [x] `{{ undefined.attr }}` behaves consistently with `{{ undefined }}`
+      (decided: **both silent** via `ChainableUndefined`).
+- [x] Existing prompt-rendering tests still pass.
+
+## Resolution
+
+Implemented in `src/gimle/hugin/llm/prompt/jinja.py`:
+
+- **Literal escape via sentinels.** `{% raw %}…{% endraw %}` blocks and values
+  marked with the new `literal()` helper have their delimiters swapped for NUL-
+  wrapped sentinel tokens *before* the recursive render, then restored on the
+  final pass — so literal Jinja survives recursion. `literal()` is stronger than
+  `{% raw %}` for untrusted input: it holds even if the value embeds
+  `{% endraw %}`. This is the seam task 021 ("dreaming") injects `{{ learnings }}`
+  through.
+- **Undefined policy = `ChainableUndefined`.** `{{ x }}` and `{{ x.attr }}` both
+  render to `''` when undefined — consistent, low blast radius (existing
+  `{% if optional.value %}` app templates and cold-start `{{ learnings }}` keep
+  working). `StrictUndefined` was considered (pairs with task 019) but rejected
+  for this PR as too disruptive.
+- **agent-builder example restored.** `builder_system.yaml` again shows the
+  literal `{% raw %}{{ foo.value }}{% endraw %}` example.
 
 ## Context
 
 Follow-up noted in `tasks/closed/017-template-name-rendering-silent-failure.md`.
+
+Unblocks `tasks/open/021-dreaming-memory-consolidation.md`, which injects
+LLM-generated `Learning` text as a `{{ learnings }}` value via `literal()`.

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -16,6 +16,7 @@ from gimle.hugin.interaction.oracle_response import OracleResponse
 from gimle.hugin.interaction.task_definition import TaskDefinition
 from gimle.hugin.llm.prompt.jinja import (
     contains_jinja,
+    literal,
     render_jinja,
     render_jinja_recursive,
 )
@@ -221,6 +222,82 @@ class TestJinja:
         result = render_jinja(template, inputs)
         # Note: render_jinja uses .strip() so trailing spaces are removed
         assert result == "Hello"
+
+
+class TestJinjaLiteralEscape:
+    """Literal Jinja must survive the recursive renderer.
+
+    Covers both the author-facing ``{% raw %}`` mechanism and the
+    programmatic ``literal()`` helper used to inject untrusted text as a
+    template-input value (the case task 021 "dreaming" depends on).
+    """
+
+    def test_raw_block_survives_recursion(self):
+        """A ``{% raw %}`` block reaches the output verbatim."""
+        template = "Example: {% raw %}{{ param.value }}{% endraw %}"
+        assert render_jinja_recursive(template, {}) == (
+            "Example: {{ param.value }}"
+        )
+
+    def test_raw_block_undefined_inside_not_evaluated(self):
+        """Literal braces are not re-rendered to '' on a later pass."""
+        template = "{% raw %}{{ missing }}{% endraw %}"
+        assert render_jinja_recursive(template, {}) == "{{ missing }}"
+
+    def test_raw_alongside_real_jinja(self):
+        """Real variables render; the raw block stays literal."""
+        template = "{{ name }} writes {% raw %}{{ x }}{% endraw %}"
+        result = render_jinja_recursive(template, {"name": "Ana"})
+        assert result == "Ana writes {{ x }}"
+
+    def test_literal_input_value_preserved(self):
+        """A value marked literal() keeps its braces through rendering."""
+        inputs = {"learnings": literal("Always check {{ foo }} first")}
+        result = render_jinja_recursive("Notes: {{ learnings }}", inputs)
+        assert result == "Notes: Always check {{ foo }} first"
+
+    def test_literal_input_value_endraw_breakout_attempt(self):
+        """literal() holds even if the value contains ``{% endraw %}``.
+
+        A plain ``{% raw %}`` wrapper around the value would be defeated by
+        an embedded ``{% endraw %}``; literal() escapes delimiters directly.
+        """
+        nasty = literal("{% endraw %}{{ secret }}")
+        result = render_jinja_recursive(
+            "{{ learnings }}", {"learnings": nasty, "secret": "X"}
+        )
+        assert result == "{% endraw %}{{ secret }}"
+
+    def test_literal_input_value_real_jinja_still_renders(self):
+        """Literal value stays literal while sibling variables render."""
+        inputs = {"learnings": literal("see {{ a }}"), "name": "Bo"}
+        result = render_jinja_recursive("{{ name }}: {{ learnings }}", inputs)
+        assert result == "Bo: see {{ a }}"
+
+
+class TestChainableUndefined:
+    """Undefined access is uniformly silent (renders to '')."""
+
+    def test_undefined_scalar_is_empty(self):
+        """``{{ x }}`` with x undefined renders empty."""
+        assert render_jinja("Hi {{ x }}", {}) == "Hi"
+
+    def test_undefined_attribute_is_empty(self):
+        """``{{ x.attr }}`` with x undefined renders empty (was raising)."""
+        assert render_jinja("Hi {{ x.attr }}", {}) == "Hi"
+
+    def test_undefined_deep_chain_is_empty(self):
+        """Deep undefined attribute chains render empty, not raise."""
+        assert render_jinja("Hi {{ x.a.b.c }}", {}) == "Hi"
+
+    def test_undefined_attribute_recursive_is_empty(self):
+        """Cold-start ``{{ learnings }}`` (undefined) renders empty."""
+        assert render_jinja_recursive("{{ learnings }}", {}) == ""
+
+    def test_optional_param_guard_still_works(self):
+        """The ``{% if optional.value %}`` app-template pattern still works."""
+        template = "{% if focus.value %}F: {{ focus.value }}{% endif %}done"
+        assert render_jinja_recursive(template, {}) == "done"
 
 
 class TestFormatDataFrame:


### PR DESCRIPTION
## Summary
The recursive prompt renderer rendered to a fixpoint of "no Jinja syntax left in the string", which had two consequences: a template could never emit **literal** `{{ }}` (a `{% raw %}` block survived only the first pass, then got re-evaluated), and the default `Undefined` was inconsistent — `{{ x }}` rendered to `''` but `{{ x.attr }}` raised `UndefinedError` (this is what broke in #42). This PR fixes both and adds the literal-input-value escape that task 021 ("dreaming") depends on.

Closes task 020. Unblocks task 021.

## Changes
- **Sentinel-based literal escape that survives recursion** (`src/gimle/hugin/llm/prompt/jinja.py`): `{% raw %}…{% endraw %}` blocks and values marked with the new `literal()` helper have their Jinja delimiters swapped for NUL-wrapped sentinel tokens *before* the recursive render, then restored on the final pass. `literal()` is stronger than a `{% raw %}` wrapper for untrusted text — it holds even if the value embeds `{% endraw %}`.
- **`ChainableUndefined` policy**: `{{ x }}` and `{{ x.attr }}` both render to `''` when undefined. Consistent and low blast radius — existing `{% if optional.value %}` app templates and cold-start `{{ learnings }}` keep working. (`StrictUndefined` was considered, pairs with task 019, but rejected here as too disruptive.)
- **Restored the literal example** in `apps/agent_builder/templates/builder_system.yaml` via `{% raw %}{{ foo.value }}{% endraw %}`.
- Moved task 020 to `tasks/closed/` with a resolution note.

## Testing
- `uv run pytest -q` → 637 passed, 12 skipped (8 new tests in `TestJinjaLiteralEscape` / `TestChainableUndefined`, written test-first).
- New tests cover: `{% raw %}` survives recursion, real jinja still renders alongside it, `literal()` preserves braces (incl. `{% endraw %}` breakout attempt), and `{{ undefined.attr }}` is now silent like `{{ undefined }}`.
- Verified the real `builder_system.yaml` body renders the literal `{{ foo.value }}` through the full recursive path.
- `pre-commit`: black/isort/flake8 pass; mypy fails only on the pre-existing `openai/_client.py` internal error, unrelated to this change.