### PR TITLE
Dreaming: offline memory consolidation into self-improving prompts

### DIFF
--- a/docs/src/concepts/dreaming.md
+++ b/docs/src/concepts/dreaming.md
@@ -1,0 +1,168 @@
+---
+layout: base.njk
+title: Dreaming
+---
+
+# Dreaming — agents that wake up smarter
+
+Dreaming is Hugin's offline **memory consolidation** loop. An agent runs
+normally and saves what it learns as artifacts (episodic memory). Later, a
+separate *dream* pass replays those scattered artifacts and distils them into
+**`Learning` artifacts** — durable, prose lessons scoped to the config/task
+that produced them. On the agent's next run, the relevant learnings are
+injected straight into its system prompt.
+
+No retraining; the agent improves by consolidating its own memory, the way
+sleep turns the day's experiences into lasting knowledge.
+
+```
+  run  ──────▶  episodic memory  ──────▶  dream  ──────▶  learnings
+   ▲            (insights it saved)    (consolidate)    (scoped to the config)
+   │                                                          │
+   └──────────────  injected into the next prompt  ◀──────────┘
+```
+
+## The three pieces
+
+### 1. `Learning` artifact
+
+A new artifact type that represents *semantic* memory — the consolidated
+takeaway rather than the raw experience. It carries:
+
+| Field | Purpose |
+|-------|---------|
+| `content` | The lesson, written as prose ready to drop into a prompt |
+| `scope_config` / `scope_task` | Who the lesson applies to |
+| `source_artifact_ids` | The episodic artifacts it was distilled from (evidence) |
+| `confidence` | The dream's self-assessed confidence in the lesson |
+| `derived_from` | Marker (`"dream"`) used to keep dreams from eating their own output |
+
+It's registered alongside `Text`/`Code` and stored like any other artifact, so
+the existing query/feedback machinery works on it for free.
+
+### 2. The dream
+
+A specialised Hugin agent that reads episodic artifacts grouped by their
+producing `(config, task)`, finds patterns, and writes new `Learning` artifacts
+back to storage. It runs offline, triggered by the `hugin dream` CLI command —
+not as part of the hot path, so it never slows down a normal run.
+
+The dream provenance-resolves artifacts by walking persisted agents *forward*
+(each agent record holds its config and its ordered interaction UUIDs), so it
+works **retroactively** on every artifact already in storage — not just ones
+created after dreaming shipped.
+
+### 3. Render-time injection
+
+The prompt renderer exposes a `{{ learnings }}` template variable. At render
+time it fetches the `Learning` artifacts scoped to the current agent's config
+(and current task, if scoped that narrowly), and substitutes them in. The
+injected text is treated as a literal value, so a learning that happens to
+contain `{{ … }}` is rendered verbatim rather than re-evaluated.
+
+A template that doesn't reference `{{ learnings }}` is **byte-for-byte
+unchanged** — opting in is local to a single template.
+
+## Opting a config in
+
+Add `{{ learnings }}` somewhere in your system template:
+
+```yaml
+# templates/assistant_system.yaml
+name: assistant_system
+template: |
+  You are a personal travel concierge for one returning traveler.
+
+  ## What you've learned about this traveler
+  {{ learnings }}
+
+  Whenever the traveler reveals a durable preference, record it with
+  `save_insight` so you can serve them better next time.
+```
+
+On the agent's first run the section is empty. After a dream pass over its
+saved insights, the next run renders something like:
+
+```
+## What you've learned about this traveler
+- The traveler prefers window seats; book a window seat by default.
+- The traveler is vegetarian; request a vegetarian meal by default.
+```
+
+## Running a dream
+
+```bash
+# Consolidate every config scope found in a storage path
+uv run hugin dream --storage-path ./storage
+
+# Just one config, without persisting (preview)
+uv run hugin dream --storage-path ./storage --config assistant --dry-run
+
+# Just one task
+uv run hugin dream --storage-path ./storage --task assist
+```
+
+The dream itself is bounded by `--max-steps` and picks an LLM via `--model`,
+exactly like `hugin run`. Because it reuses the existing storage layer, the
+same `--storage-path` you pass to a run is what the dream consolidates over —
+and what the next run injects from.
+
+## Seeing the loop work
+
+Set `HUGIN_CAPTURE_RENDERED_PROMPTS=1` on a run and the rendered system prompt
+(injection and all) is captured into each `OracleResponse` and visible in the
+monitor:
+
+```bash
+HUGIN_CAPTURE_RENDERED_PROMPTS=1 uv run hugin run \
+  --task assist --task-path examples/dreaming \
+  --storage-path ./storage/dreaming
+
+uv run hugin monitor --storage-path ./storage/dreaming
+```
+
+That's the audit trail for the closed loop: you can see, turn by turn, exactly
+which learnings reached the model.
+
+## Scope
+
+Learnings are **scoped** to where they came from, not global:
+
+- A learning whose source artifacts were produced by config `assistant` is
+  injected into future runs of `assistant`. It will not affect any other
+  config.
+- A learning can be narrowed further to a specific `task`, so it only applies
+  when that task is being executed.
+
+This keeps the blast radius of any individual learning small, which matters
+because the loop is autonomous — there is no human-in-the-loop step between
+"the dream produced this learning" and "the next run sees it in its prompt".
+
+## Guardrails
+
+The autonomy is bounded by three mechanical guardrails, not by approval steps:
+
+- **No dreams-eating-dreams.** Each dream excludes prior `Learning` artifacts
+  from its input. Consolidation runs on real experience, not on its own past
+  conclusions — otherwise small errors would amplify across cycles.
+- **Injection budget.** The selector caps how many learnings can land in a
+  prompt (top-N by rating and recency), so prompts can't grow unboundedly
+  across dream cycles.
+- **Scope.** Per-config / per-task scoping keeps a bad learning from
+  contaminating unrelated agents.
+
+The dream also self-rates each learning it produces (via `ArtifactFeedback`,
+`source="agent"`), creating a quality signal that the selector can use. A
+correction loop that gates injection on independent ratings is a natural next
+step but isn't part of v1.
+
+## See also
+
+- The working [`examples/dreaming`](https://github.com/gimlelabs/gimle-hugin/tree/main/examples/dreaming)
+  example — a travel concierge that learns about a returning traveler across
+  runs.
+- [Stacks & Interactions](/concepts/stacks/) — the episodic memory dreaming
+  consolidates over.
+- [Tools](/concepts/tools/) — `save_insight` is how an agent contributes to
+  episodic memory; `save_learning` is how the dream contributes to semantic
+  memory.

--- a/docs/src/concepts/index.md
+++ b/docs/src/concepts/index.md
@@ -33,6 +33,10 @@ Hugin is built around three core principles:
     <h3><a href="/concepts/tools/">Tools</a></h3>
     <p>Functions that agents can call. Built-in tools for common operations, plus easy custom tool development.</p>
   </div>
+  <div class="feature">
+    <h3><a href="/concepts/dreaming/">Dreaming</a></h3>
+    <p>Offline memory consolidation: distil scattered insights into scoped learnings that get injected back into the next run's prompt.</p>
+  </div>
 </div>
 
 ## Architecture Overview
@@ -70,7 +74,8 @@ Run multiple agents in a session with shared state via namespaces. Agents can co
 
 ### Memory Model
 - **Dynamic Context** (short-term): The interaction stack itself, rendered at each LLM call
-- **Artifacts** (long-term): Persistent storage via `save_insight`, `query_artifacts`, and `get_artifact_content` tools
+- **Artifacts** (long-term, episodic): Persistent storage via `save_insight`, `query_artifacts`, and `get_artifact_content` tools
+- **Learnings** (long-term, semantic): Consolidated lessons produced by [Dreaming](/concepts/dreaming/) and injected into the next run's prompt
 
 ### Visual Debugging
 The agent monitor provides real-time visualization of agent flows, tool calls, and decision trees.

--- a/docs/src/examples/index.md
+++ b/docs/src/examples/index.md
@@ -42,6 +42,7 @@ Start here to understand the basic structure.
 | [artifacts](https://github.com/gimlelabs/gimle-hugin/tree/main/examples/artifacts) | Long-term memory | `save_insight`, `query_artifacts` |
 | [custom_artifacts](https://github.com/gimlelabs/gimle-hugin/tree/main/examples/custom_artifacts) | Custom artifact types | `@Artifact.register`, UI components |
 | [artifact_feedback](https://github.com/gimlelabs/gimle-hugin/tree/main/examples/artifact_feedback) | Artifact rating and feedback | `rate_artifact`, feedback-driven ranking |
+| [dreaming](https://github.com/gimlelabs/gimle-hugin/tree/main/examples/dreaming) | Offline memory consolidation across runs | `hugin dream`, `Learning` artifacts, `{{ learnings }}` injection |
 
 ## Multi-Agent
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,6 +72,7 @@ We highly recommend either running the examples in interactive mode (`hugin run 
 | [simple_branching](simple_branching/) | Basic stack branching | `create_branch` tool, parallel execution |
 | [custom_artifacts](custom_artifacts/) | Custom artifact types | `@Artifact.register`, `@ComponentRegistry.register` |
 | [artifact_feedback](artifact_feedback/) | Artifact rating and feedback | `rate_artifact`, feedback-driven ranking |
+| [dreaming](dreaming/) | Self-improving memory loop | `hugin dream`, consolidated `{{ learnings }}` injected into prompts |
 
 ## Learning Path
 

--- a/examples/dreaming/README.md
+++ b/examples/dreaming/README.md
@@ -1,0 +1,105 @@
+# Dreaming — an agent that wakes up smarter
+
+This example shows the **dreaming** loop: an agent saves what it learns during a
+run, an offline "dream" consolidates those scattered notes into durable
+**learnings**, and those learnings are injected back into the agent's prompt on
+its next run. No retraining — the agent improves by consolidating its own
+memory, the way sleep turns the day's experiences into lasting knowledge.
+
+```
+  run  ──────▶  episodic memory  ──────▶  dream  ──────▶  learnings
+   ▲            (insights it saved)    (consolidate)    (scoped to the config)
+   │                                                          │
+   └──────────────  injected into the next prompt  ◀──────────┘
+```
+
+The agent here is a **travel concierge** for one returning traveler. On its
+first run it knows nothing about them. It learns their preferences, dreams, and
+on the next run it already knows them.
+
+## The pieces
+
+- **Episodic memory** — the concierge calls `save_insight` whenever the traveler
+  reveals a durable preference ("window seats only", "vegetarian"). These are
+  ordinary artifacts, scoped by who produced them.
+- **The dream** — `hugin dream` replays those insights and distils them into
+  `Learning` artifacts, scoped to the `assistant` config.
+- **Injection** — the system prompt
+  ([templates/assistant_system.yaml](templates/assistant_system.yaml)) contains a
+  `{{ learnings }}` block. Any config/task whose template references it receives
+  its scoped learnings at render time; one that doesn't is unchanged.
+
+## Try it (needs `ANTHROPIC_API_KEY`)
+
+From the repo root. We keep everything in one storage path so the dream and the
+next run can see the first run's memory.
+
+**1. First run — the concierge meets the traveler (and learns).**
+
+```bash
+uv run hugin run \
+  --task assist --task-path examples/dreaming \
+  --storage-path ./storage/dreaming
+```
+
+It will handle the request and `save_insight` the preferences it heard. At this
+point its system prompt's "What you've learned" section is **empty**.
+
+**2. Dream — consolidate the day's memory into learnings.**
+
+```bash
+# Preview without writing anything:
+uv run hugin dream --storage-path ./storage/dreaming --config assistant --dry-run
+
+# Then for real:
+uv run hugin dream --storage-path ./storage/dreaming --config assistant
+```
+
+**3. Next run — the concierge already knows the traveler.**
+
+```bash
+HUGIN_CAPTURE_RENDERED_PROMPTS=1 uv run hugin run \
+  --task assist --task-path examples/dreaming \
+  --storage-path ./storage/dreaming \
+  --parameters '{"request": "Plan me a weekend in Rome."}'
+```
+
+This time the request says nothing about seats or meals — but the concierge
+books a window seat and a vegetarian meal anyway, because the learning is now in
+its prompt.
+
+## See the learning land in the prompt
+
+`HUGIN_CAPTURE_RENDERED_PROMPTS=1` records the exact system prompt sent to the
+model each turn. Open the run and look at the "What you've learned about this
+traveler" section before vs. after the dream:
+
+```bash
+uv run hugin monitor --storage-path ./storage/dreaming
+# or the terminal browser:
+uv run hugin interactive --storage-path ./storage/dreaming
+```
+
+You'll see it go from empty to something like:
+
+```
+## What you've learned about this traveler
+- The traveler prefers window seats; book a window seat by default.
+- The traveler is vegetarian; request a vegetarian meal by default.
+```
+
+## How the scope works
+
+Learnings are scoped to the **config** that produced the source memories (here,
+`assistant`), so they're injected into that config's future runs — not globally.
+A learning can also be narrowed to a specific task. Dreaming deliberately
+excludes its own past learnings from each new dream, so it consolidates real
+experience rather than re-consolidating its own conclusions.
+
+## What's deliberately left out (v1)
+
+The dream self-rates each learning, but those ratings don't yet gate injection
+(no correction loop), and the injection budget is a simple top-N. Those are the
+natural next steps; the closed loop above is the foundation.
+
+See `tasks/closed/021-dreaming-memory-consolidation.md` for the full design.

--- a/examples/dreaming/configs/assistant.yaml
+++ b/examples/dreaming/configs/assistant.yaml
@@ -1,0 +1,12 @@
+name: assistant
+description: >-
+  A personal travel concierge that records durable preferences as insights and,
+  after a "dream", has them consolidated into learnings injected on future runs.
+system_template: assistant_system
+llm_model: sonnet-latest
+tools:
+  - builtins.save_insight:save_insight
+  - builtins.query_artifacts:query_artifacts
+  - builtins.finish:finish
+interactive: false
+options: {}

--- a/examples/dreaming/tasks/assist.yaml
+++ b/examples/dreaming/tasks/assist.yaml
@@ -1,0 +1,23 @@
+name: assist
+description: Help the traveler with a request and remember durable preferences.
+parameters:
+  request:
+    type: string
+    description: The traveler's request, possibly revealing a preference.
+    required: false
+    default: >-
+      Book me a flight to Lisbon next month. And please — I only ever fly in
+      window seats, and I'm vegetarian.
+prompt: |
+  The traveler says:
+
+  {{ request.value }}
+
+  Help them with this request. If they reveal a durable preference, record it
+  with `save_insight` (one insight per preference, in plain language). When you
+  are done, call `finish`.
+system_template: assistant_system
+llm_model: sonnet-latest
+tools:
+  - builtins.save_insight:save_insight
+  - builtins.finish:finish

--- a/examples/dreaming/templates/assistant_system.yaml
+++ b/examples/dreaming/templates/assistant_system.yaml
@@ -1,0 +1,15 @@
+name: assistant_system
+template: |
+  You are a personal travel concierge for one returning traveler.
+
+  ## What you've learned about this traveler
+  {{ learnings }}
+
+  If the section above is empty, you don't yet know this traveler's
+  preferences. Help them anyway, and whenever they reveal a durable preference
+  (for example "prefers window seats", "is vegetarian", "always travels with a
+  dog", "hates red-eye flights"), record it with `save_insight` so you can
+  serve them better next time.
+
+  Keep replies short and concrete. When you have handled the request, call the
+  `finish` tool.

--- a/src/gimle/hugin/artifacts/__init__.py
+++ b/src/gimle/hugin/artifacts/__init__.py
@@ -4,6 +4,14 @@ from gimle.hugin.artifacts.artifact import Artifact
 from gimle.hugin.artifacts.code import Code
 from gimle.hugin.artifacts.feedback import ArtifactFeedback
 from gimle.hugin.artifacts.image import Image
+from gimle.hugin.artifacts.learning import Learning
 from gimle.hugin.artifacts.text import Text
 
-__all__ = ["Artifact", "ArtifactFeedback", "Code", "Image", "Text"]
+__all__ = [
+    "Artifact",
+    "ArtifactFeedback",
+    "Code",
+    "Image",
+    "Learning",
+    "Text",
+]

--- a/src/gimle/hugin/artifacts/learning.py
+++ b/src/gimle/hugin/artifacts/learning.py
@@ -1,0 +1,42 @@
+"""Learning Artifact: a consolidated lesson distilled by the dream.
+
+A ``Learning`` is the *semantic* memory type produced by offline consolidation
+(the "dreaming" pass): many episodic artifacts are replayed and distilled into a
+reusable lesson that is injected back into the producing config/task's prompt on
+the next run. See ``src/gimle/hugin/dreaming/``.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from gimle.hugin.artifacts.artifact import Artifact
+from gimle.hugin.utils.uuid import with_uuid
+
+
+@with_uuid
+@Artifact.register("Learning")
+@dataclass
+class Learning(Artifact):
+    """A consolidated lesson scoped to the config/task it applies to.
+
+    Attributes:
+        content: The lesson, in prose ready to drop into a prompt.
+        scope_config: The config name this learning improves (or None).
+        scope_task: The task name this learning improves (or None for
+            config-wide learnings).
+        scope_app: An optional coarser app/world scope key (v2).
+        source_artifact_ids: The episodic artifacts this was distilled from
+            (evidence / traceability).
+        confidence: The dream's self-assessed confidence in [0, 1].
+        derived_from: Provenance marker; "dream" for consolidated learnings.
+            Used to exclude learnings from the dream's own input
+            (no dreams-eating-dreams).
+    """
+
+    content: str
+    scope_config: Optional[str] = None
+    scope_task: Optional[str] = None
+    scope_app: Optional[str] = None
+    source_artifact_ids: List[str] = field(default_factory=list)
+    confidence: float = 0.0
+    derived_from: str = "dream"

--- a/src/gimle/hugin/cli/cli.py
+++ b/src/gimle/hugin/cli/cli.py
@@ -234,6 +234,40 @@ def cmd_rate(args: argparse.Namespace) -> int:
     )
 
 
+def cmd_dream(args: argparse.Namespace) -> int:
+    """Consolidate episodic memory into scoped Learning artifacts."""
+    from pathlib import Path
+
+    import gimle.hugin.dreaming as dreaming_pkg
+    from gimle.hugin.agent.environment import Environment
+    from gimle.hugin.dreaming.consolidate import run_dream
+    from gimle.hugin.storage.local import LocalStorage
+
+    storage_path = args.storage_path or "./storage"
+    agent_dir = Path(dreaming_pkg.__file__).resolve().parent / "agent"
+    storage = LocalStorage(base_path=storage_path)
+    environment = Environment.load(str(agent_dir), storage=storage)
+
+    if args.model:
+        environment.config_registry.get("dreamer").llm_model = args.model
+
+    results = run_dream(
+        environment,
+        config=args.config,
+        task=args.task,
+        max_steps=args.max_steps or 20,
+        dry_run=args.dry_run,
+    )
+
+    verb = "would save" if args.dry_run else "saved"
+    print(f"Dream complete: {verb} {len(results)} learning(s).")
+    for result in results:
+        scope = result.get("scope_config") or "?"
+        task_scope = result.get("scope_task") or "*"
+        print(f"  - {scope}/{task_scope}: {result.get('id')}")
+    return 0
+
+
 def cmd_install_models(args: argparse.Namespace) -> int:
     """Install Ollama models."""
     from gimle.hugin.cli.install_ollama_models import main as install_main
@@ -402,6 +436,40 @@ Examples:
         "--comment", help="Optional comment explaining the rating"
     )
     rate_parser.set_defaults(func=cmd_rate)
+
+    # dream command (offline memory consolidation)
+    dream_parser = subparsers.add_parser(
+        "dream",
+        help="Consolidate episodic memory into learnings",
+        description=(
+            "Replay saved insights and distil them into scoped Learning "
+            "artifacts that are injected into future prompts."
+        ),
+    )
+    dream_parser.add_argument(
+        "-s", "--storage-path", help="Path to agent storage"
+    )
+    dream_parser.add_argument(
+        "--config", help="Consolidate a single config scope (default: all)"
+    )
+    dream_parser.add_argument(
+        "--task", help="Restrict to a single task within the scope"
+    )
+    dream_parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=20,
+        help="Per-scope step budget for the dream worker",
+    )
+    dream_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Produce learnings but persist nothing",
+    )
+    dream_parser.add_argument(
+        "--model", help="Override the dream worker's llm_model"
+    )
+    dream_parser.set_defaults(func=cmd_dream)
 
     # apps command (list apps)
     apps_parser = subparsers.add_parser(

--- a/src/gimle/hugin/dreaming/__init__.py
+++ b/src/gimle/hugin/dreaming/__init__.py
@@ -1,0 +1,9 @@
+"""Dreaming: offline memory consolidation that feeds learnings back into prompts.
+
+Episodic artifacts (insights saved during agent runs) are replayed offline and
+distilled into ``Learning`` artifacts scoped to the config/task that produced
+them. Those learnings are injected into the producing config/task's prompt on
+the next run via the ``{{ learnings }}`` template block — a self-improving loop.
+
+See ``tasks/closed/021-dreaming-memory-consolidation.md``.
+"""

--- a/src/gimle/hugin/dreaming/agent/configs/dreamer.yaml
+++ b/src/gimle/hugin/dreaming/agent/configs/dreamer.yaml
@@ -1,0 +1,13 @@
+name: dreamer
+description: >-
+  Offline dream worker that consolidates a config's episodic artifacts into
+  scoped Learning artifacts (memory consolidation, task 021).
+system_template: dreamer_system
+llm_model: sonnet-latest
+tools:
+  - dreaming.save_learning:save_learning
+  - builtins.query_artifacts:query_artifacts
+  - builtins.get_artifact_content:get_artifact_content
+  - builtins.finish:finish
+interactive: false
+options: {}

--- a/src/gimle/hugin/dreaming/agent/templates/dreamer_system.yaml
+++ b/src/gimle/hugin/dreaming/agent/templates/dreamer_system.yaml
@@ -1,0 +1,21 @@
+name: dreamer_system
+template: |
+  You are the dream: an offline memory-consolidation process for a Hugin agent.
+
+  Your job is to replay the episodic memories (insights) produced by one agent
+  configuration and distil them into a small number of durable, reusable
+  LEARNINGS that will be injected into that configuration's future prompts.
+
+  Principles:
+  - Consolidate, don't copy. A learning is a general lesson drawn from across
+    several memories, not a restatement of one.
+  - Be specific and actionable. Prefer "validate dates before parsing; null
+    dates silently produce empty results" over "be careful with data".
+  - Prefer quality over quantity. A few high-confidence learnings beat many
+    weak ones. If the memories show no durable pattern, save nothing.
+  - Cite your evidence: pass the source artifact ids each learning came from.
+  - Set an honest confidence in [0, 1].
+
+  For each lesson, call dreaming.save_learning(content, source_artifact_ids,
+  confidence). The scope (which config/task this applies to) is attached
+  automatically. When you have saved all worthwhile learnings, call finish.

--- a/src/gimle/hugin/dreaming/consolidate.py
+++ b/src/gimle/hugin/dreaming/consolidate.py
@@ -1,0 +1,132 @@
+"""Run the offline dream: consolidate episodic artifacts into Learnings.
+
+Drives one dream-worker agent per config scope. For each scope the episodic
+artifacts (provenance-grouped) are fetched and embedded into the worker's task
+prompt; the worker synthesises patterns and calls ``dreaming.save_learning``,
+which stamps the scope and self-rates the result.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from gimle.hugin.agent.agent import Agent
+from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.session import Session
+from gimle.hugin.agent.task import Task
+from gimle.hugin.dreaming.provenance import (
+    ArtifactProvenance,
+    group_by_config,
+    scan_provenance,
+)
+
+logger = logging.getLogger(__name__)
+
+DREAMER_CONFIG_NAME = "dreamer"
+DREAM_SCOPE_KEY = "dream_scope"
+DREAM_DRY_RUN_KEY = "dream_dry_run"
+DREAM_RESULTS_KEY = "dream_results"
+
+
+def _episodic_block(
+    environment: Environment, provenances: List[ArtifactProvenance]
+) -> str:
+    """Fetch the episodic artifacts' content as a readable block."""
+    engine = environment.query_engine
+    lines: List[str] = []
+    for provenance in provenances:
+        content = engine.get_artifact_content(provenance.artifact_id) or ""
+        task_label = provenance.task or "general"
+        lines.append(
+            f"- [{provenance.artifact_id}] (task: {task_label})\n  {content}"
+        )
+    return "\n".join(lines)
+
+
+def _consolidate_prompt(config_name: str, episodic_block: str) -> str:
+    """Build the dream worker's task prompt for one scope."""
+    return (
+        f"You are consolidating the episodic memories produced by the "
+        f"'{config_name}' agent configuration into reusable learnings.\n\n"
+        f"Episodic memories (insights saved during past runs):\n"
+        f"{episodic_block}\n\n"
+        f"Find cross-cutting patterns, recurring mistakes, and durable lessons. "
+        f"For each distinct lesson, call dreaming.save_learning with the lesson "
+        f"as prose ready to drop into a prompt, the source artifact ids it came "
+        f"from, and your confidence (0-1). Keep each learning specific and "
+        f"actionable. When done, call finish."
+    )
+
+
+def run_dream(
+    environment: Environment,
+    config: Optional[str] = None,
+    task: Optional[str] = None,
+    max_steps: int = 20,
+    dry_run: bool = False,
+) -> List[Dict[str, Any]]:
+    """Consolidate episodic memory into Learnings for one or all config scopes.
+
+    Args:
+        environment: Environment whose storage holds the corpus and whose
+            config registry provides the ``dreamer`` worker config.
+        config: Restrict to a single config scope (default: all scopes found).
+        task: Restrict to a single task within the scope (default: all).
+        max_steps: Per-scope step budget for the worker agent.
+        dry_run: Produce learnings but persist nothing.
+
+    Returns:
+        A list of result records (one per saved learning), as collected by
+        ``dreaming.save_learning``.
+    """
+    storage = environment.storage
+    if storage is None:
+        raise ValueError("run_dream requires an environment with storage")
+
+    dreamer_config = environment.config_registry.get(DREAMER_CONFIG_NAME)
+
+    session = Session(environment=environment)
+    grouped = group_by_config(scan_provenance(storage, session))
+    target_configs = [config] if config is not None else sorted(grouped)
+
+    environment.env_vars[DREAM_RESULTS_KEY] = []
+
+    for config_name in target_configs:
+        provenances = grouped.get(config_name, [])
+        if task is not None:
+            provenances = [p for p in provenances if p.task == task]
+        if not provenances:
+            logger.info(
+                "dream: no episodic artifacts for config '%s'", config_name
+            )
+            continue
+
+        environment.env_vars[DREAM_SCOPE_KEY] = {
+            "config": config_name,
+            "task": task,
+            "app": None,
+        }
+        environment.env_vars[DREAM_DRY_RUN_KEY] = dry_run
+
+        worker_task = Task(
+            name="consolidate",
+            description=f"Consolidate memories for {config_name}",
+            parameters={},
+            prompt=_consolidate_prompt(
+                config_name, _episodic_block(environment, provenances)
+            ),
+            tools=[],
+        )
+        agent = Agent.create_from_task(session, dreamer_config, worker_task)
+        logger.info(
+            "dream: consolidating '%s' (%d episodic artifacts)",
+            config_name,
+            len(provenances),
+        )
+        steps = 0
+        while steps < max_steps and agent.step():
+            steps += 1
+
+    results: List[Dict[str, Any]] = environment.env_vars.get(
+        DREAM_RESULTS_KEY, []
+    )
+    return results

--- a/src/gimle/hugin/dreaming/provenance.py
+++ b/src/gimle/hugin/dreaming/provenance.py
@@ -1,0 +1,164 @@
+"""Attribute episodic artifacts to the config/task that produced them.
+
+Forward scan: walk persisted agents (each carries its config, its ordered
+interaction UUIDs, and its config-state history) to build an
+``interaction_uuid -> (config, task)`` index, then join the raw artifact records
+(which carry their producing interaction's UUID) to it. This works retroactively
+over the existing corpus with no change to the write path.
+
+A persisted interaction has no back-pointer to its agent, so the join goes
+through the agent scan rather than artifact -> interaction -> agent in isolation.
+"""
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from gimle.hugin.agent.agent import Agent
+from gimle.hugin.agent.session import Session
+from gimle.hugin.interaction.task_definition import TaskDefinition
+from gimle.hugin.storage.storage import Storage
+
+logger = logging.getLogger(__name__)
+
+# Artifact types that are dream output, not episodic memory. Excluded from the
+# dream's own input (no dreams-eating-dreams).
+LEARNING_TYPE = "Learning"
+
+Scope = Tuple[Optional[str], Optional[str]]
+
+
+@dataclass
+class ArtifactProvenance:
+    """The config/task an episodic artifact was produced under."""
+
+    artifact_id: str
+    artifact_type: str
+    config: Optional[str]
+    task: Optional[str]
+    interaction_id: Optional[str]
+
+
+def _config_by_position(agent: Agent) -> Dict[int, Optional[str]]:
+    """Map each stack position to the config active when it was created.
+
+    Agents without a config state machine ran under a single config for their
+    whole life. State-machine agents switched configs mid-run; ``_config_history``
+    records, per transition, the interaction after which the new state took
+    effect — so an interaction at position ``p`` ran under the most recent
+    transition recorded strictly before ``p``.
+    """
+    interactions = agent.stack.interactions
+    n = len(interactions)
+    final_config = agent.config.name
+    history = agent.config_history
+    if not history:
+        return {i: final_config for i in range(n)}
+
+    positions = {str(it.uuid): i for i, it in enumerate(interactions)}
+    transitions: List[Tuple[int, Optional[str]]] = []
+    for entry in history:
+        interaction_id = entry.get("interaction_id")
+        state = entry.get("state")
+        if interaction_id is None:
+            transition_position = -1  # initial state, applies from the start
+        else:
+            resolved = positions.get(str(interaction_id))
+            if resolved is None:
+                continue
+            transition_position = resolved
+        transitions.append((transition_position, state))
+    transitions.sort(key=lambda t: t[0])
+
+    result: Dict[int, Optional[str]] = {}
+    for position in range(n):
+        active: Optional[str] = final_config
+        for transition_position, state in transitions:
+            if transition_position < position:
+                active = state
+            else:
+                break
+        result[position] = active
+    return result
+
+
+def _interaction_scope_index(agent: Agent) -> Dict[str, Scope]:
+    """Build ``interaction_uuid -> (config, task)`` for one agent.
+
+    Task is attributed to the most recent ``TaskDefinition`` at or before each
+    interaction (a stack can hold several when sub-agents are reused).
+    """
+    config_by_position = _config_by_position(agent)
+    index: Dict[str, Scope] = {}
+    current_task: Optional[str] = None
+    for position, interaction in enumerate(agent.stack.interactions):
+        if isinstance(interaction, TaskDefinition) and interaction.task:
+            current_task = interaction.task.name
+        index[str(interaction.uuid)] = (
+            config_by_position.get(position),
+            current_task,
+        )
+    return index
+
+
+def build_interaction_index(
+    storage: Storage, session: Session
+) -> Dict[str, Scope]:
+    """Scan all agents into a global ``interaction_uuid -> (config, task)`` map."""
+    index: Dict[str, Scope] = {}
+    for agent_uuid in storage.list_agents():
+        try:
+            agent = storage.load_agent(agent_uuid, session)
+        except Exception as error:  # corrupted/partial agents are skipped
+            logger.warning("dream: skipping agent %s: %s", agent_uuid, error)
+            continue
+        index.update(_interaction_scope_index(agent))
+    return index
+
+
+def scan_provenance(
+    storage: Storage, session: Session
+) -> List[ArtifactProvenance]:
+    """Attribute every episodic artifact to its producing config/task.
+
+    ``Learning`` artifacts are excluded so the dream consolidates episodic
+    memory, not its own prior output.
+    """
+    interaction_index = build_interaction_index(storage, session)
+    provenances: List[ArtifactProvenance] = []
+    for artifact_id in storage.list_artifacts():
+        try:
+            record = storage.load_artifact_record(artifact_id)
+        except Exception as error:
+            logger.warning(
+                "dream: skipping artifact %s: %s", artifact_id, error
+            )
+            continue
+        artifact_type = record.get("type", "")
+        if artifact_type == LEARNING_TYPE:
+            continue
+        data = record.get("data", {})
+        interaction_id = data.get("interaction")
+        config, task = interaction_index.get(interaction_id, (None, None))
+        provenances.append(
+            ArtifactProvenance(
+                artifact_id=artifact_id,
+                artifact_type=artifact_type,
+                config=config,
+                task=task,
+                interaction_id=interaction_id,
+            )
+        )
+    return provenances
+
+
+def group_by_config(
+    provenances: List[ArtifactProvenance],
+) -> Dict[str, List[ArtifactProvenance]]:
+    """Group episodic artifacts by producing config (unattributed dropped)."""
+    groups: Dict[str, List[ArtifactProvenance]] = defaultdict(list)
+    for provenance in provenances:
+        if provenance.config is not None:
+            groups[provenance.config].append(provenance)
+    return dict(groups)

--- a/src/gimle/hugin/dreaming/selector.py
+++ b/src/gimle/hugin/dreaming/selector.py
@@ -106,7 +106,8 @@ def select_learnings(
             continue
         artifact_ratings = ratings.get(artifact_id, [])
         count = len(artifact_ratings)
-        average = sum(artifact_ratings) / count if count else 0.0
+        # Unrated learnings rank neutrally — neither boosted nor buried.
+        average = sum(artifact_ratings) / count if count else NEUTRAL_RATING
         selected.append(
             SelectedLearning(
                 artifact_id=artifact_id,
@@ -121,10 +122,7 @@ def select_learnings(
         )
 
     def sort_key(item: SelectedLearning) -> tuple:
-        effective_rating = (
-            item.average_rating if item.rating_count else NEUTRAL_RATING
-        )
-        return (effective_rating, item.created_at or "")
+        return (item.average_rating, item.created_at or "")
 
     selected.sort(key=sort_key, reverse=True)
     if budget >= 0:

--- a/src/gimle/hugin/dreaming/selector.py
+++ b/src/gimle/hugin/dreaming/selector.py
@@ -1,0 +1,143 @@
+"""Select the ``Learning`` artifacts that apply to a render context.
+
+The keyword ``ArtifactQueryEngine`` filters by type and searches content, not by
+metadata predicates, so learning selection is a dedicated scan over the raw
+artifact records filtering by ``scope_config`` / ``scope_task`` / ``scope_app``.
+Results are ranked by rating then recency and truncated to a budget, so injected
+prompts cannot grow unboundedly across consolidation cycles.
+"""
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from gimle.hugin.storage.storage import Storage
+
+logger = logging.getLogger(__name__)
+
+LEARNING_TYPE = "Learning"
+# Rating a learning starts at before anyone has rated it: neutral, so a fresh
+# learning is neither boosted nor buried relative to rated peers.
+NEUTRAL_RATING = 3.0
+# Max learnings injected per render (top-N budget). Bounds prompt growth.
+DEFAULT_BUDGET = 5
+
+
+@dataclass
+class SelectedLearning:
+    """A learning chosen for injection, with its ranking signal."""
+
+    artifact_id: str
+    content: str
+    scope_config: Optional[str]
+    scope_task: Optional[str]
+    scope_app: Optional[str]
+    average_rating: float
+    rating_count: int
+    created_at: Optional[str]
+
+
+def _ratings_map(storage: Storage) -> Dict[str, List[int]]:
+    """Pre-load feedback ratings grouped by artifact id."""
+    ratings: Dict[str, List[int]] = defaultdict(list)
+    for feedback_uuid in storage.list_feedback():
+        try:
+            feedback = storage.load_feedback(feedback_uuid)
+            ratings[feedback.artifact_id].append(feedback.rating)
+        except (ValueError, OSError) as error:
+            logger.warning("Skipping feedback %s: %s", feedback_uuid, error)
+    return dict(ratings)
+
+
+def _matches_scope(
+    data: Dict,
+    config: Optional[str],
+    task: Optional[str],
+    app: Optional[str],
+) -> bool:
+    """Whether a learning's scope applies to the given render context.
+
+    Every scope field the learning sets must equal the context value, and the
+    learning must actually target this config or app (a fully unscoped learning
+    is never injected).
+    """
+    scope_config = data.get("scope_config")
+    scope_task = data.get("scope_task")
+    scope_app = data.get("scope_app")
+    if scope_config is not None and scope_config != config:
+        return False
+    if scope_task is not None and scope_task != task:
+        return False
+    if scope_app is not None and scope_app != app:
+        return False
+    return (scope_config is not None and scope_config == config) or (
+        scope_app is not None and scope_app == app
+    )
+
+
+def select_learnings(
+    storage: Storage,
+    config: Optional[str] = None,
+    task: Optional[str] = None,
+    app: Optional[str] = None,
+    budget: int = DEFAULT_BUDGET,
+) -> List[SelectedLearning]:
+    """Return the applicable learnings for a context, ranked and budget-capped.
+
+    Sorted by average rating (neutral when unrated) then recency, then truncated
+    to ``budget`` (top-N). Higher-rated, fresher learnings win; low-rated ones
+    decay out of selection.
+    """
+    ratings = _ratings_map(storage)
+    selected: List[SelectedLearning] = []
+    for artifact_id in storage.list_artifacts():
+        try:
+            record = storage.load_artifact_record(artifact_id)
+        except Exception as error:
+            logger.warning(
+                "dream: skipping artifact %s: %s", artifact_id, error
+            )
+            continue
+        if record.get("type") != LEARNING_TYPE:
+            continue
+        data = record.get("data", {})
+        if not _matches_scope(data, config, task, app):
+            continue
+        artifact_ratings = ratings.get(artifact_id, [])
+        count = len(artifact_ratings)
+        average = sum(artifact_ratings) / count if count else 0.0
+        selected.append(
+            SelectedLearning(
+                artifact_id=artifact_id,
+                content=data.get("content", ""),
+                scope_config=data.get("scope_config"),
+                scope_task=data.get("scope_task"),
+                scope_app=data.get("scope_app"),
+                average_rating=average,
+                rating_count=count,
+                created_at=data.get("created_at"),
+            )
+        )
+
+    def sort_key(item: SelectedLearning) -> tuple:
+        effective_rating = (
+            item.average_rating if item.rating_count else NEUTRAL_RATING
+        )
+        return (effective_rating, item.created_at or "")
+
+    selected.sort(key=sort_key, reverse=True)
+    if budget >= 0:
+        selected = selected[:budget]
+    return selected
+
+
+def render_learnings_block(learnings: List[SelectedLearning]) -> str:
+    """Format selected learnings as a plain-text block for prompt injection.
+
+    Returns "" when there are none, so a ``{{ learnings }}`` cold start renders
+    cleanly empty.
+    """
+    if not learnings:
+        return ""
+    return "\n".join(f"- {item.content}" for item in learnings)

--- a/src/gimle/hugin/llm/prompt/renderer.py
+++ b/src/gimle/hugin/llm/prompt/renderer.py
@@ -8,6 +8,7 @@ from pandas import DataFrame, read_parquet
 
 from gimle.hugin.llm.prompt.jinja import (
     contains_jinja,
+    literal,
     render_jinja_recursive,
 )
 
@@ -15,6 +16,9 @@ if TYPE_CHECKING:
     from gimle.hugin.agent.agent import Agent
 
 logger = logging.getLogger(__name__)
+
+# Template variable carrying consolidated "dreaming" learnings (task 021).
+LEARNINGS_KEY = "learnings"
 
 
 def format_df_to_string(
@@ -141,7 +145,64 @@ class PromptRenderer:
         template_inputs = {
             k: v for k, v in template_inputs.items() if v is not None
         }
+        template_inputs = self._inject_learnings(prompt_text, template_inputs)
         return render_jinja_recursive(prompt_text, template_inputs)
+
+    def _inject_learnings(
+        self, prompt_text: str, template_inputs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Inject consolidated learnings for the current config/task scope.
+
+        Opt-in and non-destructive: only templates that reference
+        ``{{ learnings }}`` pay any cost, and a caller-provided ``learnings``
+        value is never overridden. The injected text is wrapped with
+        :func:`literal` so any Jinja-looking content in a learning reaches the
+        model verbatim instead of being re-evaluated (task 020).
+        """
+        if LEARNINGS_KEY in template_inputs:
+            return template_inputs
+        if LEARNINGS_KEY not in prompt_text:
+            return template_inputs
+        try:
+            block = self._learnings_for_scope()
+        except Exception as error:  # never let injection break rendering
+            logger.warning("Failed to inject learnings: %s", error)
+            return template_inputs
+        template_inputs[LEARNINGS_KEY] = literal(block)
+        return template_inputs
+
+    def _learnings_for_scope(self) -> str:
+        """Select + format learnings for the agent's current config/task.
+
+        Cached per (config, task) on the agent so each run scans storage once.
+        """
+        storage = getattr(self.agent.environment, "storage", None)
+        if storage is None:
+            return ""
+        config = self.agent.config.name
+        task: Optional[str] = None
+        try:
+            task_obj = self.agent.stack.get_task_definition(
+                current_interaction_uuid=self.interaction_uuid,
+                branch=self.branch,
+            )
+            if task_obj is not None:
+                task = task_obj.name
+        except Exception:
+            task = None
+
+        cache = self.agent.__dict__.setdefault("_dream_learnings_cache", {})
+        key = (config, task)
+        if key not in cache:
+            from gimle.hugin.dreaming.selector import (
+                render_learnings_block,
+                select_learnings,
+            )
+
+            cache[key] = render_learnings_block(
+                select_learnings(storage, config=config, task=task)
+            )
+        return str(cache[key])
 
     def render_task_prompt(
         self, template_inputs: Dict[str, Any], reduced: Optional[bool] = False

--- a/src/gimle/hugin/storage/local.py
+++ b/src/gimle/hugin/storage/local.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, cast
 
 from gimle.hugin.agent.agent import Agent
 from gimle.hugin.agent.session import Session
@@ -111,6 +111,13 @@ class LocalStorage(Storage):
                 stack=stack,
                 load_interaction=load_interaction,
             )
+
+    def load_artifact_record(self, uuid: str) -> Dict[str, Any]:
+        """Load the raw stored artifact record without hydration."""
+        if not self.base_path:
+            raise ValueError("Artifacts not found in local memory storage")
+        with open(self.base_path / "artifacts" / uuid, "r") as f:
+            return cast(Dict[str, Any], json.load(f))
 
     def _save_artifact(self, artifact: Artifact) -> None:
         """Save an artifact to the local filesystem."""

--- a/src/gimle/hugin/storage/local.py
+++ b/src/gimle/hugin/storage/local.py
@@ -112,7 +112,7 @@ class LocalStorage(Storage):
                 load_interaction=load_interaction,
             )
 
-    def load_artifact_record(self, uuid: str) -> Dict[str, Any]:
+    def _load_artifact_record(self, uuid: str) -> Dict[str, Any]:
         """Load the raw stored artifact record without hydration."""
         if not self.base_path:
             raise ValueError("Artifacts not found in local memory storage")

--- a/src/gimle/hugin/storage/storage.py
+++ b/src/gimle/hugin/storage/storage.py
@@ -72,17 +72,23 @@ class Storage(ABC):
         return cast(Artifact, self.store[cache_key])
 
     @abstractmethod
+    def _load_artifact_record(self, uuid: str) -> Dict[str, Any]:
+        raise NotImplementedError("Subclasses must implement this method")
+
     def load_artifact_record(self, uuid: str) -> Dict[str, Any]:
         """Load the raw stored record for an artifact (no hydration).
 
         Returns the persisted ``{"type", "data"}`` dict, including
         ``data["interaction"]`` (the producing interaction's UUID) and
-        ``data["created_at"]``. Used by the dreaming provenance scan to
-        attribute artifacts to their config/task without hydrating the full
-        interaction chain (``load_artifact`` with ``stack=None`` drops the
-        interaction reference).
+        ``data["created_at"]``. Used by the dreaming provenance scan and
+        learning selector to read artifact metadata in bulk without hydrating
+        the full interaction chain (``load_artifact`` with ``stack=None`` drops
+        the interaction reference). Cached like ``load_artifact``.
         """
-        raise NotImplementedError("Subclasses must implement this method")
+        cache_key = f"artifact_record:{uuid}"
+        if cache_key not in self.store:
+            self.store[cache_key] = self._load_artifact_record(uuid)
+        return cast(Dict[str, Any], self.store[cache_key])
 
     @abstractmethod
     def _save_artifact(self, artifact: Artifact) -> None:

--- a/src/gimle/hugin/storage/storage.py
+++ b/src/gimle/hugin/storage/storage.py
@@ -72,6 +72,19 @@ class Storage(ABC):
         return cast(Artifact, self.store[cache_key])
 
     @abstractmethod
+    def load_artifact_record(self, uuid: str) -> Dict[str, Any]:
+        """Load the raw stored record for an artifact (no hydration).
+
+        Returns the persisted ``{"type", "data"}`` dict, including
+        ``data["interaction"]`` (the producing interaction's UUID) and
+        ``data["created_at"]``. Used by the dreaming provenance scan to
+        attribute artifacts to their config/task without hydrating the full
+        interaction chain (``load_artifact`` with ``stack=None`` drops the
+        interaction reference).
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
     def _save_artifact(self, artifact: Artifact) -> None:
         raise NotImplementedError("Subclasses must implement this method")
 

--- a/src/gimle/hugin/tools/__init__.py
+++ b/src/gimle/hugin/tools/__init__.py
@@ -19,5 +19,8 @@ from gimle.hugin.tools.builtins.read_file import read_file  # noqa: F401
 from gimle.hugin.tools.builtins.save_code import save_code  # noqa: F401
 from gimle.hugin.tools.builtins.save_file import save_file  # noqa: F401
 from gimle.hugin.tools.builtins.save_insight import save_insight  # noqa: F401
+from gimle.hugin.tools.builtins.save_learning import (  # noqa: F401
+    save_learning,
+)
 from gimle.hugin.tools.builtins.save_text import save_text  # noqa: F401
 from gimle.hugin.tools.builtins.search_files import search_files  # noqa: F401

--- a/src/gimle/hugin/tools/builtins/save_learning.py
+++ b/src/gimle/hugin/tools/builtins/save_learning.py
@@ -1,0 +1,132 @@
+"""Save learning builtin tool: persist a consolidated 'dreaming' learning.
+
+Used by the dream worker (``hugin dream``). Mirrors ``save_insight`` but writes
+a ``Learning`` artifact, stamps its scope from the dream run context
+(``environment.env_vars["dream_scope"]``), and self-rates it via
+``ArtifactFeedback`` (``source="agent"``).
+"""
+
+import logging
+import traceback
+from typing import TYPE_CHECKING, List, Optional
+
+from gimle.hugin.artifacts.feedback import ArtifactFeedback
+from gimle.hugin.artifacts.learning import Learning
+from gimle.hugin.tools.tool import Tool, ToolResponse
+
+if TYPE_CHECKING:
+    from gimle.hugin.interaction.stack import Stack
+
+# env_vars keys the dream run uses to communicate with this tool.
+DREAM_SCOPE_KEY = "dream_scope"
+DREAM_DRY_RUN_KEY = "dream_dry_run"
+DREAM_RESULTS_KEY = "dream_results"
+
+
+def _confidence_to_rating(confidence: float) -> int:
+    """Map a [0, 1] confidence to a 1-5 ArtifactFeedback rating."""
+    clamped = max(0.0, min(1.0, confidence))
+    return max(1, min(5, round(1 + clamped * 4)))
+
+
+@Tool.register(
+    name="dreaming.save_learning",
+    description=(
+        "Save a consolidated learning distilled from episodic artifacts. "
+        "The scope (config/task) is taken from the dream run automatically. "
+        "Provide the lesson as prose ready to drop into a prompt, the source "
+        "artifact ids it was distilled from, and your confidence (0-1)."
+    ),
+    parameters={
+        "content": {
+            "type": "string",
+            "description": "The lesson, in prose ready to drop into a prompt",
+            "required": True,
+        },
+        "source_artifact_ids": {
+            "type": "array",
+            "description": "Artifact ids this learning was distilled from",
+            "required": False,
+        },
+        "confidence": {
+            "type": "number",
+            "description": "Self-assessed confidence in the learning, 0-1",
+            "required": False,
+            "default": 0.7,
+        },
+    },
+    is_interactive=False,
+)
+def save_learning(
+    content: str,
+    stack: "Stack",
+    source_artifact_ids: Optional[List[str]] = None,
+    confidence: float = 0.7,
+) -> ToolResponse:
+    """Save a consolidated learning as a scoped Learning artifact.
+
+    Args:
+        content: The lesson, in prose ready for prompt injection.
+        stack: The stack (passed automatically).
+        source_artifact_ids: Episodic artifact ids the lesson was distilled from.
+        confidence: Self-assessed confidence in [0, 1].
+
+    Returns:
+        ToolResponse with the new learning's id and its stamped scope.
+    """
+    try:
+        environment = stack.agent.environment
+        env_vars = getattr(environment, "env_vars", None) or {}
+        scope = env_vars.get(DREAM_SCOPE_KEY) or {}
+
+        interaction = stack.interactions[-1]
+        learning = Learning(
+            interaction=interaction,
+            content=content,
+            scope_config=scope.get("config"),
+            scope_task=scope.get("task"),
+            scope_app=scope.get("app"),
+            source_artifact_ids=list(source_artifact_ids or []),
+            confidence=float(confidence),
+        )
+        interaction.add_artifact(learning)
+
+        # Persist immediately and self-rate (autonomy keeps the quality gate;
+        # source="agent" so human ratings remain distinguishable). --dry-run
+        # produces the learning but writes nothing.
+        dry_run = bool(env_vars.get(DREAM_DRY_RUN_KEY))
+        if not dry_run and environment.storage is not None:
+            environment.storage.save_artifact(learning)
+            environment.storage.save_feedback(
+                ArtifactFeedback(
+                    artifact_id=learning.id,
+                    rating=_confidence_to_rating(float(confidence)),
+                    source="agent",
+                    agent_id=stack.agent.id,
+                )
+            )
+
+        # Report back to the dream orchestrator (works for dry runs too).
+        if isinstance(env_vars, dict):
+            env_vars.setdefault(DREAM_RESULTS_KEY, []).append(
+                {
+                    "id": learning.id,
+                    "scope_config": learning.scope_config,
+                    "scope_task": learning.scope_task,
+                    "dry_run": dry_run,
+                }
+            )
+
+        return ToolResponse(
+            is_error=False,
+            content={
+                "learning": learning.id,
+                "scope_config": learning.scope_config,
+                "scope_task": learning.scope_task,
+                "scope_app": learning.scope_app,
+            },
+        )
+
+    except Exception as e:
+        logging.error(f"Error saving learning: {e} {traceback.format_exc()}")
+        return ToolResponse(is_error=True, content={"error": str(e)})

--- a/tasks/closed/021-dreaming-memory-consolidation.md
+++ b/tasks/closed/021-dreaming-memory-consolidation.md
@@ -1,7 +1,7 @@
 ---
 github_issue: null
 title: "Dreaming: offline memory consolidation that feeds learnings back into prompts"
-state: OPEN
+state: CLOSED
 labels: [enhancement, memory, prompts, agents]
 author: erikarne
 created: 2026-05-21
@@ -197,23 +197,34 @@ These were decided up front; the rest of the task builds on them:
 - **Cost shape:** a naive dream re-reads the whole artifact store; consider
   incremental ("only artifacts since last dream") via a watermark.
 
+## v1 + v2 scope (decided, implemented)
+
+Built in one PR after task 020 (the literal-input-value escape this depends on):
+
+- **Provenance = forward scan** (retroactive over the existing corpus), with
+  per-interaction config attribution via `_config_history` (handles
+  state-machine agents). No write-path change.
+- **Scope = per-config**, with optional `scope_task` narrowing and a `scope_app`
+  key. Selector matches `scope_config`/`scope_task`/`scope_app`.
+- **Autonomy:** the dream self-rates (`source="agent"`); feedback-collapse
+  correction is intentionally **deferred** — get the loop working first.
+- **Injection budget:** top-N (default 5). Char/token budget deferred.
+
 ## Success criteria
 
-- [ ] `Learning` artifact type exists, serialises/deserialises, and is
-      registered.
-- [ ] New artifacts (insights + learnings) record producing config + task;
-      verified by a test that reads the provenance back from storage.
-- [ ] `hugin dream --storage-path …` runs end-to-end, reads episodic artifacts,
-      and writes scoped `Learning` artifacts.
-- [ ] A config/task whose template references `{{ learnings }}` receives its
-      scoped learnings at render time; one that doesn't is byte-for-byte
-      unchanged. Verified via `HUGIN_CAPTURE_RENDERED_PROMPTS`.
-- [ ] The dream's input excludes prior `Learning` artifacts (no
+- [x] `Learning` artifact type exists, serialises/deserialises, and is
+      registered. (`artifacts/learning.py`)
+- [x] Episodic artifacts are attributed to producing config + task; verified by
+      a test that reads provenance back from storage. (`dreaming/provenance.py`)
+- [x] `hugin dream --storage-path …` runs end-to-end, reads episodic artifacts,
+      and writes scoped `Learning` artifacts. (`dreaming/consolidate.py`, CLI)
+- [x] A template referencing `{{ learnings }}` receives its scoped learnings at
+      render time; one that doesn't is byte-for-byte unchanged. (`renderer.py`)
+- [x] The dream's input excludes prior `Learning` artifacts (no
       dreams-eating-dreams), with a test.
-- [ ] Injection respects a budget (top-N / char cap), with a test.
-- [ ] An end-to-end loop test: run agent → dream → re-render shows the learning
-      present in the prompt.
-- [ ] Existing artifact / prompt-rendering tests still pass.
+- [x] Injection respects a top-N budget, with a test.
+- [x] End-to-end loop test: run -> dream -> re-render shows the learning.
+- [x] Existing artifact / prompt-rendering tests still pass (665 passed).
 
 ## Context
 

--- a/tests/memory_storage.py
+++ b/tests/memory_storage.py
@@ -66,6 +66,12 @@ class MemoryStorage(Storage):
             load_interaction=load_interaction,
         )
 
+    def load_artifact_record(self, uuid: str) -> Dict[str, Any]:
+        """Load the raw stored artifact record without hydration."""
+        if uuid not in self._artifacts:
+            raise ValueError(f"Artifact {uuid} not found in storage")
+        return self._artifacts[uuid]
+
     def _save_artifact(self, artifact: Artifact) -> None:
         """Save an artifact to memory."""
         self._artifacts[artifact.uuid] = artifact.to_dict()

--- a/tests/memory_storage.py
+++ b/tests/memory_storage.py
@@ -66,7 +66,7 @@ class MemoryStorage(Storage):
             load_interaction=load_interaction,
         )
 
-    def load_artifact_record(self, uuid: str) -> Dict[str, Any]:
+    def _load_artifact_record(self, uuid: str) -> Dict[str, Any]:
         """Load the raw stored artifact record without hydration."""
         if uuid not in self._artifacts:
             raise ValueError(f"Artifact {uuid} not found in storage")

--- a/tests/test_dream_end_to_end.py
+++ b/tests/test_dream_end_to_end.py
@@ -1,0 +1,182 @@
+"""End-to-end dreaming loop: run -> dream -> re-render shows the learning."""
+
+from typing import List
+from unittest.mock import Mock, patch
+
+import gimle.hugin.tools  # noqa: F401  (registers dreaming.save_learning)
+from gimle.hugin.agent.agent import Agent
+from gimle.hugin.agent.config import Config
+from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.session import Session
+from gimle.hugin.agent.task import Task
+from gimle.hugin.artifacts.text import Text
+from gimle.hugin.dreaming.consolidate import run_dream
+from gimle.hugin.llm.models.model import Model, ModelResponse
+from gimle.hugin.llm.prompt.renderer import PromptRenderer
+
+from .memory_storage import MemoryStorage
+
+LESSON = "Always check for null dates before parsing."
+
+
+class ScriptedModel(Model):
+    """A model that replays a fixed list of responses, then repeats the last."""
+
+    def __init__(self, responses: List[ModelResponse]):
+        """Store the scripted responses to replay."""
+        super().__init__(
+            {
+                "model": "test-model",
+                "temperature": 0,
+                "max_tokens": 100,
+                "tool_choice": {"type": "auto"},
+            }
+        )
+        self._responses = responses
+        self._index = 0
+
+    def chat_completion(self, system_prompt, messages, tools=None):
+        """Return the next scripted response, repeating the last."""
+        response = self._responses[min(self._index, len(self._responses) - 1)]
+        self._index += 1
+        return response
+
+
+def _make_researcher_agent(storage):
+    session = Session(environment=Environment(storage=storage))
+    config = Config(
+        name="researcher",
+        description="d",
+        system_template="system",
+        llm_model="test-model",
+    )
+    task = Task(
+        name="analyze", description="", parameters={}, prompt="p", tools=[]
+    )
+    return Agent.create_from_task(session, config, task)
+
+
+def _seed_episodic_memory(storage):
+    """Simulate a prior researcher run that saved one insight."""
+    agent = _make_researcher_agent(storage)
+    task_def = agent.stack.interactions[0]
+    artifact = Text(
+        interaction=task_def,
+        content="When dates are null the parser silently returns nothing.",
+    )
+    task_def.add_artifact(artifact)
+    storage.save_agent(agent)
+
+
+def test_run_dream_then_reinjects_learning():
+    """Run -> dream -> re-render shows the consolidated learning."""
+    storage = MemoryStorage()
+    _seed_episodic_memory(storage)
+
+    # Dream environment with a dreamer worker config registered.
+    dream_env = Environment(storage=storage)
+    dream_env.config_registry.register(
+        Config(
+            name="dreamer",
+            description="dream worker",
+            system_template="You are the dream worker.",
+            llm_model="test-model",
+            tools=[
+                "dreaming.save_learning:save_learning",
+                "builtins.finish:finish",
+            ],
+        )
+    )
+
+    # The worker calls save_learning once, then finishes with plain text.
+    scripted = ScriptedModel(
+        [
+            ModelResponse(
+                role="assistant",
+                content={
+                    "content": LESSON,
+                    "confidence": 0.9,
+                    "source_artifact_ids": [],
+                },
+                tool_call="save_learning",
+                tool_call_id="tc-1",
+            ),
+            ModelResponse(role="assistant", content="Consolidation complete."),
+        ]
+    )
+    registry = Mock()
+    registry.get_model.return_value = scripted
+    registry.get_provider.return_value = None
+
+    with patch(
+        "gimle.hugin.llm.completion.get_model_registry",
+        return_value=registry,
+    ):
+        results = run_dream(dream_env, config="researcher", max_steps=15)
+
+    # A scoped learning was produced.
+    assert len(results) == 1
+    assert results[0]["scope_config"] == "researcher"
+
+    # Re-rendering a researcher prompt that opts into {{ learnings }} now
+    # contains the consolidated lesson.
+    researcher = _make_researcher_agent(storage)
+    rendered = PromptRenderer(researcher).render_prompt(
+        "Lessons learned:\n{{ learnings }}", {}
+    )
+    assert LESSON in rendered
+
+    # A prompt that does not reference learnings is unaffected.
+    plain = PromptRenderer(researcher).render_prompt("No learnings here.", {})
+    assert plain == "No learnings here."
+
+
+def test_dry_run_persists_nothing():
+    """A dry run produces a result but persists no Learning."""
+    storage = MemoryStorage()
+    _seed_episodic_memory(storage)
+
+    dream_env = Environment(storage=storage)
+    dream_env.config_registry.register(
+        Config(
+            name="dreamer",
+            description="dream worker",
+            system_template="You are the dream worker.",
+            llm_model="test-model",
+            tools=[
+                "dreaming.save_learning:save_learning",
+                "builtins.finish:finish",
+            ],
+        )
+    )
+
+    scripted = ScriptedModel(
+        [
+            ModelResponse(
+                role="assistant",
+                content={"content": LESSON, "confidence": 0.9},
+                tool_call="save_learning",
+                tool_call_id="tc-1",
+            ),
+            ModelResponse(role="assistant", content="done"),
+        ]
+    )
+    registry = Mock()
+    registry.get_model.return_value = scripted
+    registry.get_provider.return_value = None
+
+    with patch(
+        "gimle.hugin.llm.completion.get_model_registry",
+        return_value=registry,
+    ):
+        results = run_dream(
+            dream_env, config="researcher", max_steps=15, dry_run=True
+        )
+
+    # The worker produced a learning, but nothing was persisted.
+    assert len(results) == 1
+    assert results[0]["dry_run"] is True
+    learning_records = [
+        storage.load_artifact_record(a) for a in storage.list_artifacts()
+    ]
+    assert not any(r["type"] == "Learning" for r in learning_records)

--- a/tests/test_dream_injection.py
+++ b/tests/test_dream_injection.py
@@ -1,0 +1,114 @@
+"""Tests for render-time injection of consolidated learnings."""
+
+import pytest
+
+from gimle.hugin.agent.agent import Agent
+from gimle.hugin.agent.config import Config
+from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.session import Session
+from gimle.hugin.agent.task import Task
+from gimle.hugin.artifacts.learning import Learning
+from gimle.hugin.interaction.task_definition import TaskDefinition
+from gimle.hugin.llm.prompt.renderer import PromptRenderer
+
+from .memory_storage import MemoryStorage
+
+
+@pytest.fixture
+def agent_on_storage():
+    """Return an agent with a TaskDefinition, backed by MemoryStorage."""
+    storage = MemoryStorage()
+    session = Session(environment=Environment(storage=storage))
+    config = Config(
+        llm_model="test-model",
+        system_template="system",
+        name="researcher",
+        description="d",
+    )
+    agent = Agent(session=session, config=config)
+    task = Task(
+        name="analyze", description="", parameters={}, prompt="p", tools=[]
+    )
+    task_def = TaskDefinition(stack=agent.stack, task=task)
+    agent.stack.add_interaction(task_def)
+    storage.save_interaction(task_def)
+    return agent, storage, task_def
+
+
+def _save_learning(storage, interaction, content, **scope):
+    storage.save_artifact(
+        Learning(interaction=interaction, content=content, **scope)
+    )
+
+
+class TestLearningInjection:
+    """A {{ learnings }} template receives its scoped learnings; others don't."""
+
+    def test_injected_when_referenced(self, agent_on_storage):
+        """A {{ learnings }} template receives its scoped learnings."""
+        agent, storage, task_def = agent_on_storage
+        _save_learning(
+            storage,
+            task_def,
+            "Validate dates first.",
+            scope_config="researcher",
+        )
+
+        out = PromptRenderer(agent).render_prompt("Notes:\n{{ learnings }}", {})
+        assert "Validate dates first." in out
+
+    def test_not_injected_without_reference(self, agent_on_storage):
+        """A template without {{ learnings }} is left unchanged."""
+        agent, storage, task_def = agent_on_storage
+        _save_learning(
+            storage,
+            task_def,
+            "Validate dates first.",
+            scope_config="researcher",
+        )
+
+        out = PromptRenderer(agent).render_prompt("Just a plain prompt.", {})
+        assert out == "Just a plain prompt."
+        assert "Validate dates first." not in out
+
+    def test_caller_value_not_overridden(self, agent_on_storage):
+        """A caller-provided learnings value is not overridden."""
+        agent, storage, task_def = agent_on_storage
+        _save_learning(
+            storage, task_def, "From storage.", scope_config="researcher"
+        )
+
+        out = PromptRenderer(agent).render_prompt(
+            "{{ learnings }}", {"learnings": "explicit override"}
+        )
+        assert out == "explicit override"
+
+    def test_other_config_learning_not_injected(self, agent_on_storage):
+        """A learning for another config is not injected."""
+        agent, storage, task_def = agent_on_storage
+        _save_learning(
+            storage, task_def, "Other scope.", scope_config="someone_else"
+        )
+
+        out = PromptRenderer(agent).render_prompt("{{ learnings }}", {})
+        assert "Other scope." not in out
+
+    def test_cold_start_renders_empty(self, agent_on_storage):
+        """With no learnings, {{ learnings }} renders empty."""
+        agent, _storage, _task_def = agent_on_storage
+
+        out = PromptRenderer(agent).render_prompt("Notes: {{ learnings }}", {})
+        assert out == "Notes:"
+
+    def test_literal_jinja_in_learning_preserved(self, agent_on_storage):
+        """A learning containing {{ ... }} reaches output verbatim (task 020)."""
+        agent, storage, task_def = agent_on_storage
+        _save_learning(
+            storage,
+            task_def,
+            "Reference a param as {{ foo.value }}.",
+            scope_config="researcher",
+        )
+
+        out = PromptRenderer(agent).render_prompt("{{ learnings }}", {})
+        assert "{{ foo.value }}" in out

--- a/tests/test_dream_local_storage.py
+++ b/tests/test_dream_local_storage.py
@@ -1,0 +1,140 @@
+"""End-to-end dreaming loop against real on-disk LocalStorage.
+
+The other dream tests use in-memory MemoryStorage. This one exercises the disk
+path: JSON serialization of Learning artifacts + feedback, the raw
+``load_artifact_record`` reader against real files, and cross-handle
+persistence (a fresh LocalStorage handle reads what the dream wrote).
+"""
+
+from typing import List
+from unittest.mock import Mock, patch
+
+import gimle.hugin.tools  # noqa: F401  (registers dreaming.save_learning)
+from gimle.hugin.agent.agent import Agent
+from gimle.hugin.agent.config import Config
+from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.session import Session
+from gimle.hugin.agent.task import Task
+from gimle.hugin.artifacts.text import Text
+from gimle.hugin.dreaming.consolidate import run_dream
+from gimle.hugin.llm.models.model import Model, ModelResponse
+from gimle.hugin.llm.prompt.renderer import PromptRenderer
+from gimle.hugin.storage.local import LocalStorage
+
+LESSON = "Always check for null dates before parsing."
+
+
+class _Scripted(Model):
+    """Replay a fixed list of responses, repeating the last."""
+
+    def __init__(self, responses: List[ModelResponse]):
+        """Store the scripted responses."""
+        super().__init__(
+            {
+                "model": "m",
+                "temperature": 0,
+                "max_tokens": 50,
+                "tool_choice": {"type": "auto"},
+            }
+        )
+        self._responses = responses
+        self._index = 0
+
+    def chat_completion(self, system_prompt, messages, tools=None):
+        """Return the next scripted response."""
+        response = self._responses[min(self._index, len(self._responses) - 1)]
+        self._index += 1
+        return response
+
+
+def _researcher_agent(storage):
+    session = Session(environment=Environment(storage=storage))
+    return Agent.create_from_task(
+        session,
+        Config(
+            name="researcher",
+            description="d",
+            system_template="system",
+            llm_model="m",
+        ),
+        Task(
+            name="analyze", description="", parameters={}, prompt="p", tools=[]
+        ),
+    )
+
+
+def test_dream_loop_on_local_storage(tmp_path):
+    """Run -> dream -> re-render works through real on-disk LocalStorage."""
+    base = str(tmp_path / "storage")
+
+    # Seed a real episodic insight on disk under config 'researcher'.
+    storage = LocalStorage(base_path=base)
+    agent = _researcher_agent(storage)
+    task_def = agent.stack.interactions[0]
+    task_def.add_artifact(
+        Text(
+            interaction=task_def,
+            content="When dates are null the parser returns nothing.",
+        )
+    )
+    storage.save_agent(agent)
+
+    # The raw-record reader works against real JSON files on disk.
+    (artifact_id,) = storage.list_artifacts()
+    assert storage.load_artifact_record(artifact_id)["type"] == "Text"
+
+    # Dream over the on-disk storage with a scripted worker model.
+    dream_env = Environment(storage=LocalStorage(base_path=base))
+    dream_env.config_registry.register(
+        Config(
+            name="dreamer",
+            description="d",
+            system_template="You are the dream worker.",
+            llm_model="m",
+            tools=[
+                "dreaming.save_learning:save_learning",
+                "builtins.finish:finish",
+            ],
+        )
+    )
+    scripted = _Scripted(
+        [
+            ModelResponse(
+                role="assistant",
+                content={
+                    "content": LESSON,
+                    "confidence": 0.9,
+                    "source_artifact_ids": [],
+                },
+                tool_call="save_learning",
+                tool_call_id="tc-1",
+            ),
+            ModelResponse(role="assistant", content="done."),
+        ]
+    )
+    registry = Mock()
+    registry.get_model.return_value = scripted
+    registry.get_provider.return_value = None
+    with patch(
+        "gimle.hugin.llm.completion.get_model_registry",
+        return_value=registry,
+    ):
+        results = run_dream(dream_env, config="researcher", max_steps=15)
+    assert len(results) == 1
+
+    # A fresh storage handle (no in-memory carryover) reads the Learning back
+    # from disk and a new agent injects it into a {{ learnings }} prompt.
+    fresh = LocalStorage(base_path=base)
+    learnings = [
+        record
+        for a in fresh.list_artifacts()
+        for record in [fresh.load_artifact_record(a)]
+        if record["type"] == "Learning"
+    ]
+    assert len(learnings) == 1
+    assert learnings[0]["data"]["scope_config"] == "researcher"
+
+    rendered = PromptRenderer(_researcher_agent(fresh)).render_prompt(
+        "Lessons:\n{{ learnings }}", {}
+    )
+    assert LESSON in rendered

--- a/tests/test_dream_provenance.py
+++ b/tests/test_dream_provenance.py
@@ -1,0 +1,104 @@
+"""Tests for the dreaming provenance forward-scan."""
+
+from gimle.hugin.agent.agent import Agent
+from gimle.hugin.agent.config import Config
+from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.session import Session
+from gimle.hugin.agent.task import Task
+from gimle.hugin.artifacts.learning import Learning
+from gimle.hugin.artifacts.text import Text
+from gimle.hugin.dreaming.provenance import (
+    group_by_config,
+    scan_provenance,
+)
+
+from .memory_storage import MemoryStorage
+
+
+def _session(storage):
+    return Session(environment=Environment(storage=storage))
+
+
+def _agent_with_insight(session, storage, config_name, task_name, text):
+    """Create + persist an agent that saved one Text insight."""
+    config = Config(
+        llm_model="test-model",
+        system_template="system",
+        name=config_name,
+        description="d",
+    )
+    task = Task(
+        name=task_name,
+        description="",
+        parameters={},
+        prompt="do it",
+        tools=[],
+    )
+    agent = Agent.create_from_task(session, config, task)
+    task_def = agent.stack.interactions[0]
+    artifact = Text(interaction=task_def, content=text)
+    task_def.add_artifact(artifact)
+    storage.save_agent(agent)
+    return agent, artifact
+
+
+class TestProvenanceScan:
+    """Forward scan attributes episodic artifacts to config/task."""
+
+    def test_attributes_artifact_to_config_and_task(self):
+        """An episodic artifact is attributed to its config and task."""
+        storage = MemoryStorage()
+        _, artifact = _agent_with_insight(
+            _session(storage),
+            storage,
+            "researcher",
+            "analyze_sales",
+            "Null dates break the parser.",
+        )
+
+        provenances = scan_provenance(storage, _session(storage))
+
+        match = [p for p in provenances if p.artifact_id == artifact.id]
+        assert len(match) == 1
+        assert match[0].config == "researcher"
+        assert match[0].task == "analyze_sales"
+
+    def test_groups_by_config(self):
+        """Episodic artifacts group by producing config."""
+        storage = MemoryStorage()
+        session = _session(storage)
+        _agent_with_insight(session, storage, "alpha", "t1", "a1")
+        _agent_with_insight(session, storage, "alpha", "t2", "a2")
+        _agent_with_insight(session, storage, "beta", "t3", "b1")
+
+        groups = group_by_config(scan_provenance(storage, _session(storage)))
+
+        assert set(groups) == {"alpha", "beta"}
+        assert len(groups["alpha"]) == 2
+        assert len(groups["beta"]) == 1
+
+    def test_excludes_learnings_from_scan(self):
+        """Learning artifacts are not episodic input (no dreams-eating-dreams)."""
+        storage = MemoryStorage()
+        session = _session(storage)
+        agent, _ = _agent_with_insight(
+            session, storage, "researcher", "analyze", "episodic insight"
+        )
+
+        # Attach a Learning to the same interaction and persist it.
+        task_def = agent.stack.interactions[0]
+        learning = Learning(
+            interaction=task_def,
+            content="a prior consolidated lesson",
+            scope_config="researcher",
+        )
+        task_def.add_artifact(learning)
+        storage.save_agent(agent)
+
+        provenances = scan_provenance(storage, _session(storage))
+        ids = {p.artifact_id for p in provenances}
+        types = {p.artifact_type for p in provenances}
+
+        assert learning.id not in ids
+        assert "Learning" not in types
+        assert "Text" in types

--- a/tests/test_dream_selector.py
+++ b/tests/test_dream_selector.py
@@ -1,0 +1,160 @@
+"""Tests for the dreaming learning selector."""
+
+import pytest
+
+from gimle.hugin.agent.agent import Agent
+from gimle.hugin.agent.config import Config
+from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.session import Session
+from gimle.hugin.agent.task import Task
+from gimle.hugin.artifacts.feedback import ArtifactFeedback
+from gimle.hugin.artifacts.learning import Learning
+from gimle.hugin.dreaming.selector import (
+    render_learnings_block,
+    select_learnings,
+)
+from gimle.hugin.interaction.task_definition import TaskDefinition
+
+from .memory_storage import MemoryStorage
+
+
+@pytest.fixture
+def storage_and_interaction():
+    """Return a MemoryStorage plus a persisted interaction for learnings."""
+    storage = MemoryStorage()
+    session = Session(environment=Environment(storage=storage))
+    config = Config(
+        llm_model="test-model",
+        system_template="system",
+        name="host",
+        description="d",
+    )
+    agent = Agent(session=session, config=config)
+    task = Task(name="t", description="", parameters={}, prompt="p", tools=[])
+    interaction = TaskDefinition(stack=agent.stack, task=task)
+    storage.save_interaction(interaction)
+    return storage, interaction
+
+
+def _save_learning(storage, interaction, content, **scope):
+    learning = Learning(interaction=interaction, content=content, **scope)
+    storage.save_artifact(learning)
+    return learning
+
+
+def _rate(storage, artifact_id, rating, source="human"):
+    storage.save_feedback(
+        ArtifactFeedback(artifact_id=artifact_id, rating=rating, source=source)
+    )
+
+
+class TestScopeFiltering:
+    """Selection respects scope_config / scope_task / scope_app."""
+
+    def test_config_scoped_learning_matches_config(
+        self, storage_and_interaction
+    ):
+        """A config-scoped learning matches only its config."""
+        storage, interaction = storage_and_interaction
+        _save_learning(
+            storage, interaction, "lesson", scope_config="researcher"
+        )
+
+        assert len(select_learnings(storage, config="researcher")) == 1
+        assert select_learnings(storage, config="other") == []
+
+    def test_task_specific_only_matches_that_task(
+        self, storage_and_interaction
+    ):
+        """A task-specific learning matches only that task."""
+        storage, interaction = storage_and_interaction
+        _save_learning(
+            storage,
+            interaction,
+            "lesson",
+            scope_config="researcher",
+            scope_task="analyze_sales",
+        )
+
+        assert (
+            len(
+                select_learnings(
+                    storage, config="researcher", task="analyze_sales"
+                )
+            )
+            == 1
+        )
+        # Config-wide selection (no task) must not pull a task-specific learning.
+        assert select_learnings(storage, config="researcher", task=None) == []
+
+    def test_config_wide_learning_matches_any_task(
+        self, storage_and_interaction
+    ):
+        """A config-wide learning matches any task in the config."""
+        storage, interaction = storage_and_interaction
+        _save_learning(
+            storage, interaction, "lesson", scope_config="researcher"
+        )
+
+        result = select_learnings(storage, config="researcher", task="anything")
+        assert len(result) == 1
+
+    def test_app_scoped_learning_matches_app(self, storage_and_interaction):
+        """An app-scoped learning matches only its app."""
+        storage, interaction = storage_and_interaction
+        _save_learning(
+            storage, interaction, "world fact", scope_app="the_hugins"
+        )
+
+        assert len(select_learnings(storage, app="the_hugins")) == 1
+        assert select_learnings(storage, app="other_world") == []
+
+    def test_unscoped_learning_never_selected(self, storage_and_interaction):
+        """A fully unscoped learning is never selected."""
+        storage, interaction = storage_and_interaction
+        _save_learning(storage, interaction, "global lesson")
+
+        assert select_learnings(storage, config="researcher") == []
+
+
+class TestRankingAndBudget:
+    """Higher-rated, fresher learnings win; budget caps the count."""
+
+    def test_sorted_by_rating(self, storage_and_interaction):
+        """Higher-rated learnings sort first."""
+        storage, interaction = storage_and_interaction
+        low = _save_learning(storage, interaction, "low", scope_config="r")
+        high = _save_learning(storage, interaction, "high", scope_config="r")
+        _rate(storage, low.id, 1)
+        _rate(storage, high.id, 5)
+
+        result = select_learnings(storage, config="r")
+        assert [item.content for item in result] == ["high", "low"]
+
+    def test_budget_caps_results(self, storage_and_interaction):
+        """The budget caps how many learnings are returned."""
+        storage, interaction = storage_and_interaction
+        for i in range(5):
+            _save_learning(
+                storage, interaction, f"lesson-{i}", scope_config="r"
+            )
+
+        assert len(select_learnings(storage, config="r", budget=2)) == 2
+
+
+class TestRenderBlock:
+    """The injected text block formatting."""
+
+    def test_empty_when_no_learnings(self):
+        """An empty selection renders an empty block."""
+        assert render_learnings_block([]) == ""
+
+    def test_bulleted_list(self, storage_and_interaction):
+        """Selected learnings render as a bulleted list."""
+        storage, interaction = storage_and_interaction
+        _save_learning(storage, interaction, "first", scope_config="r")
+        _save_learning(storage, interaction, "second", scope_config="r")
+
+        block = render_learnings_block(select_learnings(storage, config="r"))
+        assert "- first" in block
+        assert "- second" in block

--- a/tests/test_dreaming_example.py
+++ b/tests/test_dreaming_example.py
@@ -1,0 +1,153 @@
+"""Integration test for the dreaming example (examples/dreaming).
+
+Exercises the real example config/task/template and the real builtin dream
+worker, with scripted models so it runs offline and deterministically:
+
+    run (save_insight) -> dream (save_learning) -> re-render shows the learning
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import List
+from unittest.mock import Mock, patch
+
+import pytest
+
+import gimle.hugin.dreaming as dreaming_pkg
+import gimle.hugin.tools  # noqa: F401  (registers dreaming.save_learning)
+from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.session import Session
+from gimle.hugin.dreaming.consolidate import run_dream
+from gimle.hugin.llm.models.model import Model, ModelResponse
+from gimle.hugin.llm.prompt.renderer import PromptRenderer
+from gimle.hugin.storage.local import LocalStorage
+
+EXAMPLE_PATH = "examples/dreaming"
+PREFERENCE = "prefers a window seat"
+
+
+class _Scripted(Model):
+    """Replay a fixed list of responses, repeating the last."""
+
+    def __init__(self, responses: List[ModelResponse]):
+        """Store the scripted responses."""
+        super().__init__(
+            {
+                "model": "m",
+                "temperature": 0,
+                "max_tokens": 50,
+                "tool_choice": {"type": "auto"},
+            }
+        )
+        self._responses = responses
+        self._index = 0
+
+    def chat_completion(self, system_prompt, messages, tools=None):
+        """Return the next scripted response."""
+        response = self._responses[min(self._index, len(self._responses) - 1)]
+        self._index += 1
+        return response
+
+
+def _registry(model):
+    registry = Mock()
+    registry.get_model.return_value = model
+    registry.get_provider.return_value = None
+    return registry
+
+
+@pytest.fixture
+def storage_path():
+    """Provide a temporary on-disk storage path, cleaned up after the test."""
+    temp_dir = tempfile.mkdtemp(prefix="dreaming_example_")
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _render_assistant_system(storage_base):
+    """Render the example assistant's system prompt against the storage."""
+    env = Environment.load(
+        EXAMPLE_PATH, storage=LocalStorage(base_path=storage_base)
+    )
+    session = Session(environment=env)
+    agent = session.create_agent_from_task(
+        env.config_registry.get("assistant"),
+        env.task_registry.get("assist"),
+    )
+    return PromptRenderer(agent).render_system_prompt()
+
+
+def test_dreaming_example_closed_loop(storage_path):
+    """The example's run -> dream -> re-render loop injects the learning."""
+    # Cold: before any dream, the "what you've learned" section is empty.
+    cold = _render_assistant_system(storage_path)
+    assert PREFERENCE not in cold
+
+    # Day 1: run the example assistant; it saves the preference as an insight.
+    env = Environment.load(
+        EXAMPLE_PATH, storage=LocalStorage(base_path=storage_path)
+    )
+    session = Session(environment=env)
+    agent = session.create_agent_from_task(
+        env.config_registry.get("assistant"),
+        env.task_registry.get("assist"),
+    )
+    assistant_model = _Scripted(
+        [
+            ModelResponse(
+                role="assistant",
+                content={
+                    "insight": "The traveler prefers a window seat.",
+                    "format": "markdown",
+                },
+                tool_call="save_insight",
+                tool_call_id="tc-insight",
+            ),
+            ModelResponse(role="assistant", content="All set — booked!"),
+        ]
+    )
+    with patch(
+        "gimle.hugin.llm.completion.get_model_registry",
+        return_value=_registry(assistant_model),
+    ):
+        for _ in range(20):
+            if not agent.step():
+                break
+    env.storage.save_session(session)
+    assert env.storage.list_artifacts(), "the run saved no episodic insight"
+
+    # Night: dream over the storage using the real builtin dream worker.
+    dreamer_dir = str(Path(dreaming_pkg.__file__).resolve().parent / "agent")
+    dream_env = Environment.load(
+        dreamer_dir, storage=LocalStorage(base_path=storage_path)
+    )
+    dream_model = _Scripted(
+        [
+            ModelResponse(
+                role="assistant",
+                content={
+                    "content": (
+                        "The traveler prefers a window seat; book one by "
+                        "default."
+                    ),
+                    "confidence": 0.9,
+                    "source_artifact_ids": [],
+                },
+                tool_call="save_learning",
+                tool_call_id="tc-learning",
+            ),
+            ModelResponse(role="assistant", content="Consolidation complete."),
+        ]
+    )
+    with patch(
+        "gimle.hugin.llm.completion.get_model_registry",
+        return_value=_registry(dream_model),
+    ):
+        results = run_dream(dream_env, config="assistant", max_steps=15)
+    assert len(results) == 1
+    assert results[0]["scope_config"] == "assistant"
+
+    # Day 2: the same assistant config now renders the learning into its prompt.
+    warm = _render_assistant_system(storage_path)
+    assert PREFERENCE in warm

--- a/tests/test_learning_artifact.py
+++ b/tests/test_learning_artifact.py
@@ -1,0 +1,82 @@
+"""Tests for the Learning artifact (consolidated 'dreaming' memory)."""
+
+from gimle.hugin.agent.task import Task
+
+# Import Learning to ensure it is registered in the artifact registry.
+from gimle.hugin.artifacts.artifact import Artifact
+from gimle.hugin.artifacts.learning import Learning
+from gimle.hugin.interaction.task_definition import TaskDefinition
+
+from .memory_storage import MemoryStorage
+
+
+def _task_def(stack):
+    task = Task(
+        name="test_task",
+        description="Test",
+        parameters={},
+        prompt="Do something",
+        tools=[],
+    )
+    return TaskDefinition(stack=stack, task=task)
+
+
+class TestLearningArtifact:
+    """Learning creation, defaults, and registration."""
+
+    def test_registered_under_learning(self):
+        """Learning is registered so from_dict can resolve it by type."""
+        assert Artifact.get_type("Learning") is Learning
+
+    def test_defaults(self, mock_stack):
+        """Scope/provenance fields default sensibly."""
+        learning = Learning(
+            interaction=_task_def(mock_stack),
+            content="Always validate dates first.",
+        )
+        assert learning.scope_config is None
+        assert learning.scope_task is None
+        assert learning.scope_app is None
+        assert learning.source_artifact_ids == []
+        assert learning.confidence == 0.0
+        assert learning.derived_from == "dream"
+
+    def test_distinct_default_lists(self, mock_stack):
+        """Each Learning gets its own source_artifact_ids list."""
+        a = Learning(interaction=_task_def(mock_stack), content="a")
+        b = Learning(interaction=_task_def(mock_stack), content="b")
+        a.source_artifact_ids.append("x")
+        assert b.source_artifact_ids == []
+
+
+class TestLearningSerialization:
+    """Learning round-trips through to_dict / from_dict."""
+
+    def test_round_trip_preserves_fields(self, mock_stack):
+        """All scope/provenance fields survive serialization."""
+        storage = MemoryStorage()
+        task_def = _task_def(mock_stack)
+        storage.save_interaction(task_def)
+        learning = Learning(
+            interaction=task_def,
+            content="Prefer ';' delimiters over newlines for list output.",
+            scope_config="research_assistant",
+            scope_task="analyze_sales",
+            scope_app="the_hugins",
+            source_artifact_ids=["art-1", "art-2"],
+            confidence=0.8,
+        )
+
+        data = learning.to_dict()
+        assert data["type"] == "Learning"
+
+        restored = Artifact.from_dict(data, storage=storage, stack=mock_stack)
+        assert isinstance(restored, Learning)
+        assert restored.uuid == learning.uuid
+        assert restored.content == learning.content
+        assert restored.scope_config == "research_assistant"
+        assert restored.scope_task == "analyze_sales"
+        assert restored.scope_app == "the_hugins"
+        assert restored.source_artifact_ids == ["art-1", "art-2"]
+        assert restored.confidence == 0.8
+        assert restored.derived_from == "dream"

--- a/tests/test_save_learning_tool.py
+++ b/tests/test_save_learning_tool.py
@@ -1,0 +1,98 @@
+"""Tests for the dreaming.save_learning builtin tool."""
+
+import pytest
+
+from gimle.hugin.agent.agent import Agent
+from gimle.hugin.agent.config import Config
+from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.session import Session
+from gimle.hugin.agent.task import Task
+from gimle.hugin.interaction.task_definition import TaskDefinition
+from gimle.hugin.tools.builtins.save_learning import save_learning
+from gimle.hugin.tools.tool import Tool
+
+from .memory_storage import MemoryStorage
+
+
+@pytest.fixture
+def dream_stack():
+    """Return a stack whose environment carries a dream scope."""
+    storage = MemoryStorage()
+    env = Environment(
+        storage=storage,
+        env_vars={
+            "dream_scope": {
+                "config": "researcher",
+                "task": "analyze_sales",
+                "app": None,
+            }
+        },
+    )
+    session = Session(environment=env)
+    config = Config(
+        llm_model="test-model",
+        system_template="system",
+        name="dreamer",
+        description="d",
+    )
+    agent = Agent(session=session, config=config)
+    task = Task(name="t", description="", parameters={}, prompt="p", tools=[])
+    task_def = TaskDefinition(stack=agent.stack, task=task)
+    agent.stack.add_interaction(task_def)
+    return agent.stack, storage
+
+
+def test_tool_is_registered():
+    """The tool is discoverable under its registered name."""
+    assert Tool.get_tool("dreaming.save_learning") is not None
+
+
+def test_save_learning_stamps_scope_from_run(dream_stack):
+    """The tool stamps scope from the dream run context."""
+    stack, storage = dream_stack
+
+    response = save_learning(
+        content="Validate dates before parsing.",
+        stack=stack,
+        source_artifact_ids=["art-1", "art-2"],
+        confidence=0.8,
+    )
+
+    assert response.is_error is False
+    learning_id = response.content["learning"]
+
+    record = storage.load_artifact_record(learning_id)
+    assert record["type"] == "Learning"
+    assert record["data"]["scope_config"] == "researcher"
+    assert record["data"]["scope_task"] == "analyze_sales"
+    assert record["data"]["source_artifact_ids"] == ["art-1", "art-2"]
+    assert record["data"]["derived_from"] == "dream"
+
+
+def test_save_learning_self_rates(dream_stack):
+    """The tool self-rates the learning via agent feedback."""
+    stack, storage = dream_stack
+
+    response = save_learning(content="A lesson.", stack=stack, confidence=0.8)
+    learning_id = response.content["learning"]
+
+    feedback_ids = storage.list_feedback(learning_id)
+    assert len(feedback_ids) == 1
+    feedback = storage.load_feedback(feedback_ids[0])
+    assert feedback.source == "agent"
+    # 0.8 -> 1 + 0.8*4 = 4.2 -> 4
+    assert feedback.rating == 4
+
+
+def test_saved_learning_is_selectable(dream_stack):
+    """A saved learning is immediately selectable for its scope."""
+    from gimle.hugin.dreaming.selector import select_learnings
+
+    stack, storage = dream_stack
+    save_learning(content="Selectable lesson.", stack=stack, confidence=0.9)
+
+    selected = select_learnings(
+        storage, config="researcher", task="analyze_sales"
+    )
+    assert len(selected) == 1
+    assert selected[0].content == "Selectable lesson."


### PR DESCRIPTION
## Summary
Implements task 021: an offline "dreaming" pass that replays episodic artifacts (insights saved during agent runs) and distils them into scoped `Learning` artifacts, which are injected back into the producing config/task's prompt on the next run — a closed, self-improving loop. Builds on #53 (task 020), which provides the literal-input-value escape this relies on.

Covers the agreed **v1 + v2** scope in one PR.

## Changes
- **`Learning` artifact** (`artifacts/learning.py`): `content` + `scope_config`/`scope_task`/`scope_app` + `source_artifact_ids` + `confidence` + `derived_from`. Registered alongside Text/Code.
- **Provenance forward-scan** (`dreaming/provenance.py`): walks persisted agents to attribute each episodic artifact to its producing `(config, task)`, with per-interaction config attribution via `_config_history` (handles state-machine agents). Works **retroactively** on the existing corpus; excludes `Learning`s (no dreams-eating-dreams). Backed by a new lightweight `Storage.load_artifact_record` raw reader (cached like `load_artifact`).
- **Selector** (`dreaming/selector.py`): scope matching + rating/recency ranking + top-N budget.
- **Render-time injection** (`llm/prompt/renderer.py`): opt-in `{{ learnings }}` block, cached per-agent, wrapped with `literal()` (task 020) so learning text can never be re-evaluated as a template. Templates that don't reference `{{ learnings }}` are byte-for-byte unchanged and pay no storage cost.
- **`dreaming.save_learning` tool**: stamps scope from the dream run, self-rates (`source="agent"`), supports `--dry-run`.
- **Dream worker agent** (`dreaming/agent/`) + `run_dream` orchestration + **`hugin dream`** CLI subcommand (`--config`/`--task`/`--dry-run`/`--max-steps`/`--model`).

### Deferred (by design, discussed)
Feedback-collapse correction (gating injection on independent ratings), char/token injection budget, dedup/superseding, and an incremental watermark. The dream self-rates but those ratings are recorded, not yet used as a corrective gate.

## Testing
- 28 new tests across artifact/provenance/selector/injection/tool/end-to-end. The end-to-end test drives a scripted model through **run → dream → re-render** and asserts the consolidated learning appears in the prompt; a dry-run test asserts nothing is persisted.
- Full suite: **665 passed, 12 skipped**.
- `hugin dream --help` and a dry-run over empty storage verified; the dreamer env loads from packaged YAML.
- `pre-commit`: black/isort/flake8 pass; new modules are mypy-clean (the only mypy failure is the pre-existing `openai/_client.py` internal error, unrelated).
- A staff-engineer code review was run on the diff; both findings (consistent neutral rating for unrated learnings; caching the raw-record reads) are addressed in the second commit.

## Usage
```bash
# Consolidate all config scopes found in a storage path
uv run hugin dream --storage-path ./storage

# A single scope, without persisting
uv run hugin dream --storage-path ./storage --config research_assistant --dry-run
```
Opt a config/task into receiving learnings by referencing `{{ learnings }}` in its template.

Closes task 021.