### PR TITLE
ci: CI on the Hetzner self-hosted runner (Part A phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, hetzner]
     strategy:
       matrix:
         python-version: ["3.12"]


### PR DESCRIPTION
Flips ci.yml to the registered ci-runner-1 hugin runner + PR-cancel concurrency. release.yml stays GitHub-hosted (publish credentials — secrets boundary). This PR's checks are the validation.