### PR TITLE
Add opt-in gimle-router task-correlation header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,21 @@ interaction JSON under `storage/interactions/`.
 HUGIN_CAPTURE_RENDERED_PROMPTS=1 uv run hugin run --task hello_world --task-path examples/basic_agent
 ```
 
+### gimle-router correlation header
+
+Set `HUGIN_GIMLE_ROUTER=1` to stamp every Anthropic/OpenAI request with an
+`x-gimle-task` header carrying the `session.id`, so a gimle-router gateway in
+front of the providers can group one edition's sub-agent calls (orchestrator,
+analyst, editor) as a single task. Off by default — a normal run sends nothing
+extra to the providers. Pair it with the SDK-native `ANTHROPIC_BASE_URL` /
+`OPENAI_BASE_URL` pointing at the router. Implementation:
+`src/gimle/hugin/llm/router_correlation.py` (Ollama is local and not routed, so
+it is not stamped).
+
+```bash
+HUGIN_GIMLE_ROUTER=1 ANTHROPIC_BASE_URL=http://127.0.0.1:4000 uv run hugin app financial_newspaper
+```
+
 ## Architecture Overview
 
 Hugin is an agent framework built around a state machine architecture with the following key components:

--- a/src/gimle/hugin/interaction/ask_oracle.py
+++ b/src/gimle/hugin/interaction/ask_oracle.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from gimle.hugin.interaction.ask_human import AskHuman
 from gimle.hugin.interaction.interaction import Interaction
 from gimle.hugin.llm.prompt.prompt import Prompt
+from gimle.hugin.llm.router_correlation import correlation_scope
 from gimle.hugin.utils.uuid import with_uuid
 
 if TYPE_CHECKING:
@@ -270,12 +271,17 @@ class AskOracle(Interaction):
             rendered_system_prompt = system_prompt
             rendered_user_message = render_user_message(self, reduced=False)
 
-        assistant_response = chat_completion(
-            system_prompt=system_prompt,
-            messages=interaction_messages,
-            tools=tools,
-            llm_model=llm_model,
-        )
+        # Tag every call of this edition with the session id so a router can
+        # group an edition's sub-agent calls (gimle-router x-gimle-task header,
+        # opt-in via HUGIN_GIMLE_ROUTER). session.id is the stable external
+        # correlation contract — changing its semantics changes router grouping.
+        with correlation_scope(self.stack.agent.session.id):
+            assistant_response = chat_completion(
+                system_prompt=system_prompt,
+                messages=interaction_messages,
+                tools=tools,
+                llm_model=llm_model,
+            )
         logger.debug(f"Assistant response: {assistant_response}")
         self.stack.add_interaction(
             OracleResponse(

--- a/src/gimle/hugin/llm/models/anthropic.py
+++ b/src/gimle/hugin/llm/models/anthropic.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import anthropic
 
+from gimle.hugin.llm.router_correlation import router_headers
 from gimle.hugin.tools.tool import Tool
 
 from .model import Model, ModelResponse
@@ -90,6 +91,7 @@ class AnthropicModel(Model):
                     system=system_prompt,
                     tools=tools_to_use,  # type: ignore[arg-type]
                     tool_choice=self.tool_choice,
+                    extra_headers=router_headers(),
                 )
             else:
                 response = client.with_options(max_retries=5).messages.create(
@@ -100,6 +102,7 @@ class AnthropicModel(Model):
                     max_tokens=self.max_tokens,
                     model=self.model_name,
                     system=system_prompt,
+                    extra_headers=router_headers(),
                 )
         except anthropic.APIError as error:
             logging.error(

--- a/src/gimle/hugin/llm/models/openai.py
+++ b/src/gimle/hugin/llm/models/openai.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
+from gimle.hugin.llm.router_correlation import router_headers
 from gimle.hugin.tools.tool import ParameterSchema, Tool
 
 from .model import Model, ModelResponse
@@ -97,6 +98,7 @@ class OpenAIModel(Model):
                 "model": self.model_name,
                 "messages": openai_messages,
                 "max_completion_tokens": self.max_tokens,
+                "extra_headers": router_headers(),
             }
 
             if self.temperature is not None:

--- a/src/gimle/hugin/llm/router_correlation.py
+++ b/src/gimle/hugin/llm/router_correlation.py
@@ -1,0 +1,75 @@
+"""Per-edition correlation header for gimle-router.
+
+One ``Session`` run is one "edition". When enabled, this stamps the same
+``x-gimle-task`` header on every Anthropic/OpenAI request of that edition so a
+router in front of the providers can group the edition's sub-agent calls
+(orchestrator, analyst, editor) under one id. ``x-gimle-task`` is gimle-router's
+task-id contract; its wire value here is the hugin ``session.id``.
+
+Opt-in: only emitted when ``HUGIN_GIMLE_ROUTER`` is truthy, so a default hugin
+deployment that never runs the router sends nothing extra to the providers
+(mirrors the ``HUGIN_CAPTURE_RENDERED_PROMPTS`` precedent).
+
+Mechanism: the value is bound once at the single LLM gateway
+(``AskOracle.step``) from ``session.id`` and read by the provider adapters when
+they build request headers — a request-scoped ``ContextVar`` carries it without
+threading a parameter through every model signature. The safety invariant is
+that the scope wraps ONLY the one synchronous, non-reentrant ``chat_completion``
+call (set immediately before, reset in ``finally``); do NOT widen it. That tight
+scope — not single-threadedness — is what stops one edition's id leaking into
+another's call; ``ContextVar`` is also per-thread, so the threaded interactive
+runner is safe too. Ollama is local and not fronted by the router, so its
+adapter is intentionally not stamped.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import os
+from contextlib import contextmanager
+from typing import Dict, Iterator, Optional
+
+# gimle-router's task-id header. Its wire value is the hugin Session id; the
+# router groups every call sharing this value as one edition.
+ROUTER_TASK_HEADER = "x-gimle-task"
+
+_ENABLE_FLAG = "HUGIN_GIMLE_ROUTER"
+
+_session_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "gimle_router_session_id", default=None
+)
+
+
+def _enabled() -> bool:
+    return os.getenv(_ENABLE_FLAG, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+@contextmanager
+def correlation_scope(session_id: Optional[str]) -> Iterator[None]:
+    """Bind ``session_id`` as the current edition for the block.
+
+    Wrap ONLY the synchronous gateway call — see the module note on not
+    widening this scope.
+    """
+    token = _session_id.set(session_id)
+    try:
+        yield
+    finally:
+        _session_id.reset(token)
+
+
+def router_headers() -> Dict[str, str]:
+    """Return the gimle-router correlation headers for the current edition.
+
+    The ``x-gimle-task`` header when the integration is enabled and a session
+    is in scope, else ``{}`` (so providers get nothing extra by default).
+    """
+    if not _enabled():
+        return {}
+    session_id = _session_id.get()
+    return {ROUTER_TASK_HEADER: session_id} if session_id else {}

--- a/tests/test_router_correlation.py
+++ b/tests/test_router_correlation.py
@@ -1,0 +1,197 @@
+"""Tests for the gimle-router correlation header.
+
+Covers the opt-in flag, the contextvar, adapter attachment, and the
+multi-agent grouping invariant the feature exists for.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gimle.hugin.agent.agent import Agent
+from gimle.hugin.interaction.ask_oracle import AskOracle
+from gimle.hugin.llm.router_correlation import (
+    ROUTER_TASK_HEADER,
+    correlation_scope,
+    router_headers,
+)
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    """Turn the opt-in integration on for a test."""
+    monkeypatch.setenv("HUGIN_GIMLE_ROUTER", "1")
+
+
+# --- the opt-in flag -------------------------------------------------------
+
+
+def test_disabled_by_default_emits_no_header():
+    """With no flag set, even inside a scope providers get nothing extra."""
+    with correlation_scope("edition-1"):
+        assert router_headers() == {}
+
+
+def test_enabled_emits_the_header(enabled):
+    """With the flag on, an in-scope call carries the x-gimle-task header."""
+    with correlation_scope("edition-1"):
+        assert router_headers() == {ROUTER_TASK_HEADER: "edition-1"}
+
+
+# --- the contextvar --------------------------------------------------------
+
+
+def test_no_header_outside_a_scope(enabled):
+    """No scope active means no header, even when enabled."""
+    assert router_headers() == {}
+
+
+def test_scope_resets_on_exit(enabled):
+    """The id is bound inside the block and cleared on exit."""
+    with correlation_scope("edition-1"):
+        assert router_headers()[ROUTER_TASK_HEADER] == "edition-1"
+    assert router_headers() == {}
+
+
+def test_nested_scopes_restore_the_outer_edition(enabled):
+    """Exiting an inner scope restores the outer edition's id."""
+    with correlation_scope("outer"):
+        with correlation_scope("inner"):
+            assert router_headers()[ROUTER_TASK_HEADER] == "inner"
+        assert router_headers()[ROUTER_TASK_HEADER] == "outer"
+
+
+def test_back_to_back_editions_do_not_leak(enabled):
+    """The core invariant: each edition sees only its own id, nothing lingers."""
+    with correlation_scope("edition-A"):
+        assert router_headers()[ROUTER_TASK_HEADER] == "edition-A"
+    with correlation_scope("edition-B"):
+        assert router_headers()[ROUTER_TASK_HEADER] == "edition-B"
+    assert router_headers() == {}
+
+
+def test_none_session_id_yields_no_header(enabled):
+    """A None id (unreachable in practice) is a safe no-header no-op."""
+    with correlation_scope(None):
+        assert router_headers() == {}
+
+
+# --- adapters attach it ----------------------------------------------------
+
+
+def _anthropic_create():
+    client = MagicMock()
+    create = client.with_options.return_value.messages.create
+    create.return_value = SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="hi")],
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+        id="r",
+    )
+    return client, create
+
+
+def _run_anthropic():
+    from gimle.hugin.llm.models.anthropic import AnthropicModel
+
+    client, create = _anthropic_create()
+    model = AnthropicModel(model_name="claude-test")
+    with patch("anthropic.Anthropic", return_value=client):
+        model.chat_completion(
+            system_prompt="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+        )
+    return create
+
+
+def test_anthropic_stamps_the_header_when_enabled_and_in_scope(enabled):
+    """The Anthropic adapter forwards the header on its create call."""
+    with correlation_scope("edition-7"):
+        create = _run_anthropic()
+    assert create.call_args.kwargs["extra_headers"] == {
+        ROUTER_TASK_HEADER: "edition-7"
+    }
+
+
+def test_anthropic_sends_no_header_outside_a_scope(enabled):
+    """The Anthropic adapter sends an empty header dict with no scope."""
+    create = _run_anthropic()
+    assert create.call_args.kwargs["extra_headers"] == {}
+
+
+def _run_openai():
+    from gimle.hugin.llm.models.openai import OpenAIModel
+
+    message = SimpleNamespace(content="hi", tool_calls=None)
+    client = MagicMock()
+    client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=message)],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+        id="r",
+    )
+    model = OpenAIModel(model_name="gpt-test")
+    with patch("openai.OpenAI", return_value=client):
+        model.chat_completion(
+            system_prompt="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+        )
+    return client.chat.completions.create
+
+
+def test_openai_stamps_the_header_when_enabled_and_in_scope(enabled):
+    """The OpenAI adapter forwards the header in its create kwargs."""
+    with correlation_scope("edition-9"):
+        create = _run_openai()
+    assert create.call_args.kwargs["extra_headers"] == {
+        ROUTER_TASK_HEADER: "edition-9"
+    }
+
+
+def test_openai_sends_no_header_outside_a_scope(enabled):
+    """The OpenAI adapter sends an empty header dict with no scope."""
+    create = _run_openai()
+    assert create.call_args.kwargs["extra_headers"] == {}
+
+
+# --- the gateway threads the session id, shared across an edition ----------
+
+
+@patch("gimle.hugin.llm.completion.chat_completion")
+def test_ask_oracle_stamps_the_session_id(
+    mock_chat_completion, enabled, mock_stack, mock_agent, sample_prompt
+):
+    """Bind the session id as the header for the call the gateway makes."""
+    seen = {}
+
+    def capture(**kwargs):
+        seen["headers"] = router_headers()
+        return {"role": "assistant", "content": "ok"}
+
+    mock_chat_completion.side_effect = capture
+    AskOracle(stack=mock_stack, prompt=sample_prompt, template_inputs={}).step()
+    assert seen["headers"] == {ROUTER_TASK_HEADER: mock_stack.agent.session.id}
+
+
+@patch("gimle.hugin.llm.completion.chat_completion")
+def test_sub_agents_of_one_edition_share_the_id(
+    mock_chat_completion, enabled, mock_stack, mock_agent, sample_prompt
+):
+    """Every sub-agent of one Session tags its calls with the same id."""
+    seen = []
+
+    def capture(**kwargs):
+        seen.append(router_headers())
+        return {"role": "assistant", "content": "ok"}
+
+    mock_chat_completion.side_effect = capture
+    AskOracle(stack=mock_stack, prompt=sample_prompt, template_inputs={}).step()
+    child = Agent(session=mock_agent.session, config=mock_agent.config)
+    child.agent_type = "default"
+    AskOracle(
+        stack=child.stack, prompt=sample_prompt, template_inputs={}
+    ).step()
+
+    expected = {ROUTER_TASK_HEADER: mock_agent.session.id}
+    assert seen == [expected, expected]


### PR DESCRIPTION
## Summary

Lets a gimle-router gateway in front of the LLM providers group one edition's sub-agent calls (orchestrator, analyst, editor) as a single task, by stamping a shared correlation header on every request of a `Session` run. This is the app-side half of the router's header-propagation release gate; without it, the router can only see individual calls, not whole editions.

Off by default — a normal hugin run sends nothing extra to the providers.

## Changes

- New `src/gimle/hugin/llm/router_correlation.py`: a request-scoped `ContextVar` carrying the current edition's `session.id`, plus `router_headers()` which returns `{"x-gimle-task": <session.id>}` only when `HUGIN_GIMLE_ROUTER` is truthy.
- `AskOracle.step` (the single LLM gateway) binds the scope from `self.stack.agent.session.id` around the `chat_completion` call.
- The Anthropic and OpenAI adapters pass `extra_headers=router_headers()` on their `create` calls. Ollama is local / not routed, so it is intentionally not stamped.
- Documented the `HUGIN_GIMLE_ROUTER` flag in `CLAUDE.md` (mirrors the `HUGIN_CAPTURE_RENDERED_PROMPTS` precedent). Pointing hugin at the router itself needs no code — the SDKs read `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` natively.

Design notes: opt-in default avoids sending a vendor header + internal UUID to providers for users who never run the router; a contextvar avoids threading a correlation id through every model signature; the scope wraps only the one synchronous gateway call, which (with per-thread contextvar isolation) is what prevents cross-edition leakage.

## Testing

- New `tests/test_router_correlation.py` (13 tests): the opt-in flag on/off, scope set/reset/nesting, back-to-back editions do not leak, both adapters attach the header when enabled and send `{}` with no scope, and the multi-agent grouping invariant (two sub-agents of one Session tag calls with the same id).
- `uv run pytest -q -m "not integration and not slow"` -> 685 passed, 42 skipped (only the live-Ollama test deselected — needs a running server).
- `uv run pre-commit run` on the changed files: black, isort, flake8 (+docstrings), mypy-strict, secret-detection all pass.
