### PR TITLE
Never silently drop a tool call in the LLM adapters

### DIFF
--- a/src/gimle/hugin/llm/models/anthropic.py
+++ b/src/gimle/hugin/llm/models/anthropic.py
@@ -122,15 +122,32 @@ MAX TOKENS:\n{self.max_tokens}"""
         logging.debug(
             f"Token usage {input_tokens=} {output_tokens=} for {response.id=}"
         )
-        # TODO support multiple tool calls in a single response
-
+        # The framework is single-tool-call by construction (ModelResponse
+        # carries one tool call), and the request sets
+        # disable_parallel_tool_use, so the provider returns at most one
+        # tool_use block. Keep the first deterministically; if a second ever
+        # arrives, warn rather than silently dropping it — a dropped call the
+        # model believes ran is a silent-data-loss bug.
         tool_use_content = None
         extra_content = []
+        dropped_tool_uses = []
         for content in response.content:
             if content.type == "tool_use":
-                tool_use_content = content
+                if tool_use_content is None:
+                    tool_use_content = content
+                else:
+                    dropped_tool_uses.append(content.name)
             elif hasattr(content, "text"):
                 extra_content.append(content.text)
+
+        if dropped_tool_uses and tool_use_content is not None:
+            logging.warning(
+                "Anthropic returned %d tool calls despite "
+                "disable_parallel_tool_use; kept '%s', dropped %s",
+                len(dropped_tool_uses) + 1,
+                tool_use_content.name,
+                dropped_tool_uses,
+            )
 
         if tool_use_content:
             return ModelResponse(

--- a/src/gimle/hugin/llm/models/ollama.py
+++ b/src/gimle/hugin/llm/models/ollama.py
@@ -1018,6 +1018,16 @@ TEMPERATURE:\n{self.temperature}"""
         logging.debug(f"Token usage {input_tokens=} {output_tokens=}")
 
         if response.message.tool_calls:
+            # Single-tool-call by construction (ModelResponse carries one).
+            # Keep the first deterministically; warn rather than silently
+            # dropping any extra a local model returned.
+            if len(response.message.tool_calls) > 1:
+                logging.warning(
+                    "Ollama returned %d tool calls; kept the first, "
+                    "dropped %d",
+                    len(response.message.tool_calls),
+                    len(response.message.tool_calls) - 1,
+                )
             tool_call = response.message.tool_calls[0]
 
             # Handle both dictionary format (from our parsing) and object format (from Ollama)

--- a/src/gimle/hugin/llm/models/openai.py
+++ b/src/gimle/hugin/llm/models/openai.py
@@ -107,6 +107,11 @@ class OpenAIModel(Model):
             if tools_to_use:
                 kwargs["tools"] = tools_to_use
                 kwargs["tool_choice"] = self.tool_choice
+                # The framework is single-tool-call by construction, so force
+                # one tool call at the request layer (matches Anthropic's
+                # disable_parallel_tool_use). Without this the model may return
+                # several and the parser below would keep only the first.
+                kwargs["parallel_tool_calls"] = False
 
             response = client.chat.completions.create(**kwargs)
 
@@ -138,7 +143,18 @@ class OpenAIModel(Model):
 
         # Check for tool calls
         if message.tool_calls:
-            tool_call = message.tool_calls[0]  # Handle first tool call
+            # Single-tool-call by construction (see parallel_tool_calls=False
+            # above). Keep the first deterministically; warn rather than
+            # silently dropping any extra the provider returned anyway.
+            if len(message.tool_calls) > 1:
+                logging.warning(
+                    "OpenAI returned %d tool calls despite "
+                    "parallel_tool_calls=False; kept '%s', dropped %s",
+                    len(message.tool_calls),
+                    message.tool_calls[0].function.name,
+                    [tc.function.name for tc in message.tool_calls[1:]],
+                )
+            tool_call = message.tool_calls[0]
             import json
 
             try:

--- a/tests/test_model_adapters.py
+++ b/tests/test_model_adapters.py
@@ -4,12 +4,160 @@ These tests pin the contract documented on ``ModelResponse.content``: on the
 plain-text (non-tool-call) path the adapter must return the model's text
 **verbatim**, with newlines preserved. They would fail if any adapter
 reintroduced the old ``.replace("\\n", " ")`` newline collapse.
+
+They also pin the *single-tool-call* contract: ``ModelResponse`` carries exactly
+one tool call, so every adapter forces one tool call at the request layer and
+must never *silently* drop a second one the provider returns anyway — it keeps
+the first deterministically and logs a warning naming the dropped calls.
 """
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 MULTILINE = "line one\nline two\nline three"
+
+
+def _tool_use(name, input, id):
+    """Build an Anthropic-style tool_use content block."""
+    return SimpleNamespace(type="tool_use", name=name, input=input, id=id)
+
+
+def _openai_tool_call(name, arguments, id):
+    """Build an OpenAI-style tool_call for the assistant message."""
+    return SimpleNamespace(
+        id=id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+class TestSingleToolCallContract:
+    """Every adapter is single-tool: forced at request, never dropped silently."""
+
+    def test_anthropic_request_disables_parallel_tool_use(self):
+        """The Anthropic request forces exactly one tool call."""
+        from gimle.hugin.llm.models.anthropic import AnthropicModel
+
+        fake_response = SimpleNamespace(
+            content=[_tool_use("read_file", {"path": "a"}, "t1")],
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+            id="r",
+        )
+        create = MagicMock(return_value=fake_response)
+        fake_client = MagicMock()
+        fake_client.with_options.return_value.messages.create = create
+
+        tool = SimpleNamespace(
+            name="read_file",
+            description="d",
+            parameters={"path": {"type": "string", "description": "p"}},
+        )
+        model = AnthropicModel(model_name="claude-test")
+        with patch("anthropic.Anthropic", return_value=fake_client):
+            model.chat_completion(
+                "sys", [{"role": "user", "content": "hi"}], [tool]
+            )
+
+        tool_choice = create.call_args.kwargs["tool_choice"]
+        assert tool_choice["disable_parallel_tool_use"] is True
+
+    def test_anthropic_keeps_first_tool_use_and_warns_on_extras(self, caplog):
+        """Two tool_use blocks → keep the first, warn (never silent drop)."""
+        from gimle.hugin.llm.models.anthropic import AnthropicModel
+
+        fake_response = SimpleNamespace(
+            content=[
+                _tool_use("ls", {"path": "."}, "t1"),
+                _tool_use("cat", {"path": "README"}, "t2"),
+            ],
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+            id="r",
+        )
+        fake_client = MagicMock()
+        fake_client.with_options.return_value.messages.create.return_value = (
+            fake_response
+        )
+
+        tool = SimpleNamespace(
+            name="ls",
+            description="d",
+            parameters={"path": {"type": "string", "description": "p"}},
+        )
+        model = AnthropicModel(model_name="claude-test")
+        with caplog.at_level(logging.WARNING):
+            with patch("anthropic.Anthropic", return_value=fake_client):
+                resp = model.chat_completion(
+                    "sys", [{"role": "user", "content": "hi"}], [tool]
+                )
+
+        assert resp.tool_call == "ls"
+        assert resp.tool_call_id == "t1"
+        assert "cat" in caplog.text
+
+    def test_openai_request_disables_parallel_tool_calls(self):
+        """The OpenAI request forces exactly one tool call."""
+        from gimle.hugin.llm.models.openai import OpenAIModel
+
+        message = SimpleNamespace(
+            content=None,
+            tool_calls=[_openai_tool_call("read_file", '{"path": "a"}', "t1")],
+        )
+        fake_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=message)],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+            id="r",
+        )
+        create = MagicMock(return_value=fake_response)
+        fake_client = MagicMock()
+        fake_client.chat.completions.create = create
+
+        tool = SimpleNamespace(
+            name="read_file",
+            description="d",
+            parameters={"path": {"type": "string", "description": "p"}},
+        )
+        model = OpenAIModel(model_name="gpt-test")
+        with patch("openai.OpenAI", return_value=fake_client):
+            model.chat_completion(
+                "sys", [{"role": "user", "content": "hi"}], [tool]
+            )
+
+        assert create.call_args.kwargs["parallel_tool_calls"] is False
+
+    def test_openai_keeps_first_tool_call_and_warns_on_extras(self, caplog):
+        """Two tool_calls → keep the first, warn (never silent drop)."""
+        from gimle.hugin.llm.models.openai import OpenAIModel
+
+        message = SimpleNamespace(
+            content=None,
+            tool_calls=[
+                _openai_tool_call("ls", '{"path": "."}', "t1"),
+                _openai_tool_call("cat", '{"path": "README"}', "t2"),
+            ],
+        )
+        fake_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=message)],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+            id="r",
+        )
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = fake_response
+
+        tool = SimpleNamespace(
+            name="ls",
+            description="d",
+            parameters={"path": {"type": "string", "description": "p"}},
+        )
+        model = OpenAIModel(model_name="gpt-test")
+        with caplog.at_level(logging.WARNING):
+            with patch("openai.OpenAI", return_value=fake_client):
+                resp = model.chat_completion(
+                    "sys", [{"role": "user", "content": "hi"}], [tool]
+                )
+
+        assert resp.tool_call == "ls"
+        assert resp.tool_call_id == "t1"
+        assert "cat" in caplog.text
 
 
 class TestAnthropicAdapterPreservesNewlines:


### PR DESCRIPTION
## Summary

The framework is single-tool-call by construction — `ModelResponse` carries exactly one `tool_call`, and the whole interaction stack below the adapter is single-tool. The Anthropic request already enforces this (`disable_parallel_tool_use`), but two gaps let a provider's extra tool call vanish without a trace: a call the model believes ran but never executed.

This is **Phase 0 of the bash-tool work (task 023)**. Bash agents batch commands heavily, so a silently dropped tool call is a correctness hazard, not a cosmetic one — this closes the gap before bash lands.

## Changes

- **OpenAI**: send `parallel_tool_calls=False` when tools are present (the native equivalent of Anthropic's `disable_parallel_tool_use`). Previously parallel calls were not disabled, so the model could return several and the parser kept only `tool_calls[0]`. Only added on tool calls, so text-only completions are unaffected.
- **Anthropic / OpenAI / Ollama**: keep the first tool call deterministically and log a warning naming the dropped ones. Previously Anthropic kept the *last* `tool_use` and OpenAI/Ollama the first, all with no signal.
- Replaced the stale `# TODO support multiple tool calls` note with the actual single-tool contract.

Settles an open question from the task plan: full multi-tool support (task 006) does **not** block bash — with parallel disabled the model is forced to one call at a time and adapts naturally.

### Compatibility note
`parallel_tool_calls` is a standard OpenAI chat-completions parameter, sent only when tools are present (which already requires tool-param support from the endpoint). Exposure to OpenAI-compatible proxies is minimal.

## Testing

- New `TestSingleToolCallContract` pins the request-layer flags (`disable_parallel_tool_use`, `parallel_tool_calls=False`) and the warn-and-keep-first behavior for both cloud adapters (TDD: 3 red -> implement -> 6 green).
- Full model/LLM suite green: `test_model_adapters`, `test_model`, `test_model_registry`, `test_llm_call`, `test_ollama_models` — 59 passed, pre-existing skips/xfails unchanged.
- Touched files pass black, isort, flake8, mypy.