### PR TITLE
Add bash tool with a pluggable, local-first execution sandbox (Phase 1)

### DIFF
--- a/examples/bash_agent/README.md
+++ b/examples/bash_agent/README.md
@@ -1,0 +1,37 @@
+# bash_agent
+
+An agent that can run shell commands in a sandboxed workspace via the
+`builtins.bash` tool.
+
+```bash
+uv run hugin run --task explore --task-path examples/bash_agent
+```
+
+## What it shows
+
+- Wiring the `bash` tool into a config with `tools: [builtins.bash:bash]`.
+- Configuring the sandbox under `options.bash`: which `backend` runs the shell
+  and the `policy` that guards it.
+
+## The backend is a choice — and `local` is not a sandbox
+
+`options.bash.backend` names *where* the shell runs. The three backends are
+peers:
+
+- `local` (used here) runs on the host and has **no isolation boundary**. Fine
+  for a trusted, illustrative task like this one; do not point it at untrusted
+  work.
+- `docker` runs in a hardened container (the boundary is the container).
+- `ssh` runs on a remote machine (the boundary is that disposable machine).
+
+The `policy` block is a guardrail against *accidents* (it blocks `rm -rf /`,
+`dd`, `git push --force`, …), not a security boundary. It deliberately does not
+try to stop interpreter-based execution — the runtime does that. See
+`tasks/open/023-bash-tool` for the full design.
+
+## Per-agent, per-branch workspaces
+
+Each agent (and each branch) gets its own working directory under the session's
+sandbox, so parallel agents don't clobber each other. Command output is
+truncated tail-biased if large, with the full output written to
+`.hugin/last_output.txt` in the workspace.

--- a/examples/bash_agent/configs/bash_agent.yaml
+++ b/examples/bash_agent/configs/bash_agent.yaml
@@ -1,0 +1,19 @@
+name: bash_agent
+description: An agent that can run shell commands in a sandboxed workspace
+system_template: bash_system
+llm_model: sonnet-latest
+tools:
+  - builtins.bash:bash
+  - builtins.finish:finish
+interactive: false
+options:
+  bash:
+    # Where the shell runs. `local` has NO isolation boundary — it runs on the
+    # host. That is acceptable for this example (a trusted, illustrative task);
+    # for untrusted work choose the `docker` or `ssh` backend instead.
+    backend: local
+    policy:
+      # Permissive denylist: a guardrail against accidents, not a security
+      # boundary. The runtime is the boundary — see tasks/open/023-bash-tool.
+      mode: denylist
+      timeout_s: 15

--- a/examples/bash_agent/tasks/explore.yaml
+++ b/examples/bash_agent/tasks/explore.yaml
@@ -1,0 +1,20 @@
+name: explore
+description: Explore the workspace and report what is there
+system_template: bash_system
+llm_model: sonnet-latest
+parameters:
+  goal:
+    type: string
+    description: What to do in the workspace
+    required: false
+    default: >-
+      Create a file notes.txt containing the text "hello from bash", then read
+      it back to confirm its contents.
+prompt: |
+  {{ goal.value }}
+
+  Use the bash tool to accomplish this. When done, call the finish tool with a
+  short summary of what you did.
+tools:
+  - builtins.bash:bash
+  - builtins.finish:finish

--- a/examples/bash_agent/templates/bash_system.yaml
+++ b/examples/bash_agent/templates/bash_system.yaml
@@ -1,0 +1,10 @@
+name: bash_system
+template: |
+  You are an agent that can run shell commands to explore and work with files.
+
+  You have a `bash` tool. It runs in your own private workspace directory.
+  Prefer small, direct commands (ls, cat, rg, sed, python3). Remember that each
+  bash call is a fresh shell — `cd`/`export` do not persist between calls, so
+  use the `cwd` argument and write files to keep state.
+
+  When you have finished the task, call the finish tool.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ authors = [{name = "gimlelabs", email = "noreply@github.com"}]
 keywords = ["agents", "agentic-framework", "llm", "ai", "anthropic"]
 dependencies = [
     "anthropic>=0.72.0",
+    "bashlex>=0.18",
     "jinja2>=3.1.6",
     "markdown>=3.7.0",
     "ollama>=0.6.1",

--- a/src/gimle/hugin/agent/session.py
+++ b/src/gimle/hugin/agent/session.py
@@ -12,6 +12,7 @@ from gimle.hugin.utils.uuid import with_uuid
 if TYPE_CHECKING:
     from gimle.hugin.agent.task import Task
     from gimle.hugin.interaction.interaction import Interaction
+    from gimle.hugin.sandbox.manager import SandboxManager
     from gimle.hugin.storage.storage import Storage
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,9 @@ class Session:
         # Update state's session reference if it was passed in without one
         if self.state._session is None:
             self.state._session = self
+        # The session owns at most one sandbox (the bash tool creates it lazily
+        # on first use). Not serialized: a resumed session recreates it.
+        self.sandbox: Optional["SandboxManager"] = None
 
     @property
     def id(self) -> str:
@@ -193,6 +197,26 @@ class Session:
         if self.storage:
             self.storage.save_session(self)
         return step_count
+
+    def close(self) -> None:
+        """Release session-owned resources (currently the sandbox).
+
+        Idempotent and safe to call on a session that never created a sandbox.
+        This is the in-process teardown seam; because it is skipped on an
+        abrupt exit (SIGKILL, laptop sleep), it is a complement to — not a
+        replacement for — the out-of-band reaper.
+        """
+        if self.sandbox is not None:
+            self.sandbox.close()
+            self.sandbox = None
+
+    def __enter__(self) -> "Session":
+        """Enter a context that guarantees ``close`` on exit."""
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        """Close the session when leaving the context."""
+        self.close()
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the session to a dictionary.

--- a/src/gimle/hugin/cli/cli.py
+++ b/src/gimle/hugin/cli/cli.py
@@ -284,6 +284,61 @@ def cmd_version(args: argparse.Namespace) -> int:
     return 0
 
 
+DEFAULT_SANDBOX_ROOT = "./storage/sandboxes"
+
+
+def reap_sandboxes_quietly(root: str = DEFAULT_SANDBOX_ROOT) -> None:
+    """Best-effort reap of abandoned local sandbox workspaces at startup.
+
+    The primary teardown mechanism: it runs on every ``hugin`` invocation so an
+    abrupt exit (SIGKILL, sleep) that skipped ``Session.close`` still self-heals
+    within one invocation. Never raises — cleanup must not break the command.
+    """
+    try:
+        import time
+
+        from gimle.hugin.sandbox.reaper import reap_local_workspaces
+
+        reap_local_workspaces(root, now=time.time())
+    except Exception:  # cleanup is best-effort and must never break a command
+        pass
+
+
+def cmd_sandbox(args: argparse.Namespace) -> int:
+    """List or prune local sandbox workspaces."""
+    import time
+
+    from gimle.hugin.sandbox.reaper import (
+        list_local_workspaces,
+        reap_local_workspaces,
+    )
+
+    root = args.root or DEFAULT_SANDBOX_ROOT
+    now = time.time()
+
+    if args.action == "prune":
+        reaped = reap_local_workspaces(root, now=now)
+        if reaped:
+            print(f"Reaped {len(reaped)} abandoned workspace(s):")
+            for name in reaped:
+                print(f"  {name}")
+        else:
+            print("No abandoned workspaces to reap.")
+        return 0
+
+    # default: list
+    infos = list_local_workspaces(root, now=now)
+    if not infos:
+        print(f"No sandbox workspaces under {root}")
+        return 0
+    print(f"{'SESSION':<40} {'PID':>8}  {'OWNER':<7} {'AGE':>8}")
+    for info in infos:
+        owner = "alive" if info.alive else "dead"
+        pid = str(info.pid) if info.pid is not None else "-"
+        print(f"{info.name:<40} {pid:>8}  {owner:<7} {int(info.age_s):>7}s")
+    return 0
+
+
 def main() -> int:
     """Run the Hugin CLI."""
     parser = argparse.ArgumentParser(
@@ -508,8 +563,32 @@ Examples:
     )
     version_parser.set_defaults(func=cmd_version)
 
+    # sandbox command
+    sandbox_parser = subparsers.add_parser(
+        "sandbox",
+        help="Inspect or clean up local sandbox workspaces",
+        description="List or prune the per-session workspaces the bash tool "
+        "creates on the local backend.",
+    )
+    sandbox_parser.add_argument(
+        "action",
+        nargs="?",
+        choices=["list", "prune"],
+        default="list",
+        help="'list' shows workspaces; 'prune' removes abandoned ones",
+    )
+    sandbox_parser.add_argument(
+        "--root",
+        default=None,
+        help=f"Sandbox root (default: {DEFAULT_SANDBOX_ROOT})",
+    )
+    sandbox_parser.set_defaults(func=cmd_sandbox)
+
     # Parse arguments
     args = parser.parse_args()
+
+    # Self-heal: reap abandoned local sandbox workspaces on every invocation.
+    reap_sandboxes_quietly()
 
     # Load .env file if --env flag is set
     if args.env:

--- a/src/gimle/hugin/cli/run_agent.py
+++ b/src/gimle/hugin/cli/run_agent.py
@@ -596,21 +596,26 @@ def run_interactive(
         print(f"    Monitor:   http://localhost:{monitor_port}")
     print()
 
-    step_count, last_error = run_steps_with_spinner(
-        step_fn=session.step,
-        save_fn=lambda: storage.save_session(session),
-        max_steps=max_steps,
-        prefix="    ",
-        clear_width=40,
-        session=session,
-        interactive=True,
-        step_delay=getattr(args, "step_delay", 0.0),
-    )
-    if last_error:
-        logging.error("Error during agent step", exc_info=last_error)
+    # Tear the session's sandbox down deterministically once stepping is over
+    # (or on an abrupt exit mid-step), rather than leaving it to the reaper.
+    try:
+        step_count, last_error = run_steps_with_spinner(
+            step_fn=session.step,
+            save_fn=lambda: storage.save_session(session),
+            max_steps=max_steps,
+            prefix="    ",
+            clear_width=40,
+            session=session,
+            interactive=True,
+            step_delay=getattr(args, "step_delay", 0.0),
+        )
+        if last_error:
+            logging.error("Error during agent step", exc_info=last_error)
 
-    # Final save
-    storage.save_session(session)
+        # Final save
+        storage.save_session(session)
+    finally:
+        session.close()
 
     # Show result on a new screen
     show_header("Agent Finished", f"Task: {task_name}")
@@ -1043,21 +1048,26 @@ Examples:
         print(f"Monitor:   run `hugin monitor -s {storage_path}`")
     print()
 
-    step_count, last_error = run_steps_with_spinner(
-        step_fn=session.step,
-        save_fn=lambda: storage.save_session(session),
-        max_steps=args.max_steps,
-        prefix="",
-        clear_width=30,
-        session=session,
-        interactive=not args.non_interactive,
-        step_delay=args.step_delay,
-    )
-    if last_error:
-        logging.error("Error during agent step", exc_info=last_error)
+    # Tear the session's sandbox down deterministically once stepping is over
+    # (or on an abrupt exit mid-step), rather than leaving it to the reaper.
+    try:
+        step_count, last_error = run_steps_with_spinner(
+            step_fn=session.step,
+            save_fn=lambda: storage.save_session(session),
+            max_steps=args.max_steps,
+            prefix="",
+            clear_width=30,
+            session=session,
+            interactive=not args.non_interactive,
+            step_delay=args.step_delay,
+        )
+        if last_error:
+            logging.error("Error during agent step", exc_info=last_error)
 
-    # Final save
-    storage.save_session(session)
+        # Final save
+        storage.save_session(session)
+    finally:
+        session.close()
 
     # Show result
     agent_word = "Agent" if len(session.agents) == 1 else "Agents"

--- a/src/gimle/hugin/sandbox/__init__.py
+++ b/src/gimle/hugin/sandbox/__init__.py
@@ -11,7 +11,9 @@ The pieces are deliberately orthogonal (see ``tasks/open/023-bash-tool``):
 Backends and the tool that drives them land in later phases.
 """
 
+from gimle.hugin.sandbox.fake import FakeSandbox
 from gimle.hugin.sandbox.local import LocalSandbox
+from gimle.hugin.sandbox.manager import SandboxManager
 from gimle.hugin.sandbox.policy import (
     Allow,
     Decision,
@@ -25,6 +27,7 @@ from gimle.hugin.sandbox.sandbox import (
     PolicyDenied,
     Sandbox,
     SandboxSpec,
+    create_sandbox,
 )
 
 __all__ = [
@@ -33,10 +36,13 @@ __all__ = [
     "Deny",
     "Escalate",
     "ExecResult",
+    "FakeSandbox",
     "LocalSandbox",
     "Policy",
     "PolicyDenied",
     "Sandbox",
+    "SandboxManager",
     "SandboxSpec",
+    "create_sandbox",
     "evaluate",
 ]

--- a/src/gimle/hugin/sandbox/__init__.py
+++ b/src/gimle/hugin/sandbox/__init__.py
@@ -11,6 +11,7 @@ The pieces are deliberately orthogonal (see ``tasks/open/023-bash-tool``):
 Backends and the tool that drives them land in later phases.
 """
 
+from gimle.hugin.sandbox.local import LocalSandbox
 from gimle.hugin.sandbox.policy import (
     Allow,
     Decision,
@@ -32,6 +33,7 @@ __all__ = [
     "Deny",
     "Escalate",
     "ExecResult",
+    "LocalSandbox",
     "Policy",
     "PolicyDenied",
     "Sandbox",

--- a/src/gimle/hugin/sandbox/__init__.py
+++ b/src/gimle/hugin/sandbox/__init__.py
@@ -22,6 +22,7 @@ from gimle.hugin.sandbox.policy import (
     Policy,
     evaluate,
 )
+from gimle.hugin.sandbox.reaper import reap_local_workspaces
 from gimle.hugin.sandbox.sandbox import (
     ExecResult,
     PolicyDenied,
@@ -45,4 +46,5 @@ __all__ = [
     "SandboxSpec",
     "create_sandbox",
     "evaluate",
+    "reap_local_workspaces",
 ]

--- a/src/gimle/hugin/sandbox/__init__.py
+++ b/src/gimle/hugin/sandbox/__init__.py
@@ -22,7 +22,11 @@ from gimle.hugin.sandbox.policy import (
     Policy,
     evaluate,
 )
-from gimle.hugin.sandbox.reaper import reap_local_workspaces
+from gimle.hugin.sandbox.reaper import (
+    WorkspaceInfo,
+    list_local_workspaces,
+    reap_local_workspaces,
+)
 from gimle.hugin.sandbox.sandbox import (
     ExecResult,
     PolicyDenied,
@@ -44,7 +48,9 @@ __all__ = [
     "Sandbox",
     "SandboxManager",
     "SandboxSpec",
+    "WorkspaceInfo",
     "create_sandbox",
     "evaluate",
+    "list_local_workspaces",
     "reap_local_workspaces",
 ]

--- a/src/gimle/hugin/sandbox/__init__.py
+++ b/src/gimle/hugin/sandbox/__init__.py
@@ -1,0 +1,40 @@
+"""Sandbox subsystem: pluggable command execution with a policy guardrail.
+
+The pieces are deliberately orthogonal (see ``tasks/open/023-bash-tool``):
+
+- ``policy`` — a pure ``evaluate(command, policy) -> Decision`` guardrail
+  against accidents. It is **not** a security boundary; the runtime you choose
+  (container / disposable remote) is.
+- ``sandbox`` — the ``Sandbox`` execution-backend protocol (``ExecResult``,
+  ``SandboxSpec``) that concrete backends implement.
+
+Backends and the tool that drives them land in later phases.
+"""
+
+from gimle.hugin.sandbox.policy import (
+    Allow,
+    Decision,
+    Deny,
+    Escalate,
+    Policy,
+    evaluate,
+)
+from gimle.hugin.sandbox.sandbox import (
+    ExecResult,
+    PolicyDenied,
+    Sandbox,
+    SandboxSpec,
+)
+
+__all__ = [
+    "Allow",
+    "Decision",
+    "Deny",
+    "Escalate",
+    "ExecResult",
+    "Policy",
+    "PolicyDenied",
+    "Sandbox",
+    "SandboxSpec",
+    "evaluate",
+]

--- a/src/gimle/hugin/sandbox/audit.py
+++ b/src/gimle/hugin/sandbox/audit.py
@@ -1,0 +1,67 @@
+"""Command audit log: what the agent ran, and how it turned out.
+
+A security-sensitive tool needs an answer to "which commands did agent X run,
+and how many were denied?" at 2am. ``CommandAudit`` keeps outcome counters in
+memory always, and — when given a file path — also appends each command as a
+JSON line for post-mortem. Writing is best-effort: a failed append is logged
+and swallowed, never allowed to fail the command it was recording.
+
+Outcomes partition every attempt: ``run`` (executed to completion, any exit
+code), ``timed_out``, ``infra_error``, ``denied``, ``escalated``.
+"""
+
+import json
+import logging
+import os
+import time
+from collections import Counter
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class CommandAudit:
+    """Append-only audit of bash commands plus outcome counters."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        """Record to ``path`` (JSONL) if given; always keep in-memory counters."""
+        self.path = path
+        self.counters: Counter = Counter()
+
+    def record(
+        self,
+        *,
+        session_id: str,
+        agent_id: str,
+        command: str,
+        outcome: str,
+        exit_code: Optional[int] = None,
+        duration_s: Optional[float] = None,
+        truncated: bool = False,
+        timed_out: bool = False,
+        oom_killed: bool = False,
+        reason: Optional[str] = None,
+    ) -> None:
+        """Count the outcome and, if a path is set, append a JSON line."""
+        self.counters[outcome] += 1
+        if not self.path:
+            return
+        entry = {
+            "ts": time.time(),
+            "session_id": session_id,
+            "agent_id": agent_id,
+            "command": command,
+            "outcome": outcome,
+            "exit_code": exit_code,
+            "duration_s": duration_s,
+            "truncated": truncated,
+            "timed_out": timed_out,
+            "oom_killed": oom_killed,
+            "reason": reason,
+        }
+        try:
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
+            with open(self.path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(entry) + "\n")
+        except OSError as error:  # best-effort; never fail the command over it
+            logger.debug("could not write audit entry: %s", error)

--- a/src/gimle/hugin/sandbox/fake.py
+++ b/src/gimle/hugin/sandbox/fake.py
@@ -1,0 +1,88 @@
+"""``FakeSandbox`` — an in-memory backend for testing everything above exec.
+
+It records the calls it receives and returns a canned :class:`ExecResult`, so
+the tool, the manager, and the policy-to-response mapping can all be tested
+with no subprocess, no container, and no daemon.
+"""
+
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from gimle.hugin.sandbox.policy import Policy
+from gimle.hugin.sandbox.sandbox import ExecResult, Sandbox
+
+
+@dataclass
+class _ExecCall:
+    command: str
+    policy: Policy
+    cwd: str
+    timeout_s: int
+    max_output_bytes: int
+
+
+class FakeSandbox(Sandbox):
+    """A Sandbox that records calls and returns a pre-set result."""
+
+    def __init__(
+        self,
+        result: Optional[ExecResult] = None,
+        raises: Optional[Exception] = None,
+    ) -> None:
+        """Return ``result`` (or a benign default) from every exec, or raise."""
+        self._result = result or ExecResult(
+            exit_code=0,
+            stdout="ok",
+            stderr="",
+            duration_s=0.0,
+        )
+        self._raises = raises
+        self.started = False
+        self.stopped = False
+        self.calls: List[_ExecCall] = []
+        self.files: Dict[str, bytes] = {}
+
+    def start(self) -> None:
+        """Record that the sandbox was started."""
+        self.started = True
+
+    def stop(self) -> None:
+        """Record that the sandbox was stopped."""
+        self.stopped = True
+
+    def workspace_for(self, agent_id: str, branch: Optional[str]) -> str:
+        """Return a deterministic fake workspace path for the pair."""
+        return os.path.join(
+            "/workspace", "agents", agent_id, branch or "default"
+        )
+
+    def exec(
+        self,
+        command: str,
+        *,
+        policy: Policy,
+        cwd: str,
+        timeout_s: int,
+        max_output_bytes: int = 16_000,
+    ) -> ExecResult:
+        """Record the call and return the canned result (or raise)."""
+        self.calls.append(
+            _ExecCall(command, policy, cwd, timeout_s, max_output_bytes)
+        )
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+    def put_file(self, path: str, content: bytes) -> None:
+        """Store ``content`` in the in-memory file map."""
+        self.files[path] = content
+
+    def get_file(self, path: str) -> bytes:
+        """Return previously stored content for ``path``."""
+        return self.files[path]
+
+    @property
+    def last_call(self) -> Optional[_ExecCall]:
+        """The most recent exec call, or None if exec was never called."""
+        return self.calls[-1] if self.calls else None

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -31,6 +31,10 @@ from gimle.hugin.sandbox.sandbox import (
 
 logger = logging.getLogger(__name__)
 
+# Warn once per process that the local backend is not a sandbox — an operator
+# selecting ``backend: local`` should see it, not have to read a docstring.
+_isolation_warned = False
+
 _SPILL_RELATIVE = os.path.join(".hugin", "last_output.txt")
 # Owner stamp read by the reaper to decide whether a workspace is abandoned.
 OWNER_FILE = ".hugin_owner.json"
@@ -94,6 +98,15 @@ class LocalSandbox(Sandbox):
             os.path.join(workspace_root, session_id)
         )
         self._bash = shutil.which("bash") or "/bin/bash"
+        global _isolation_warned
+        if not _isolation_warned:
+            logger.warning(
+                "LocalSandbox has NO isolation boundary: commands run as host "
+                "subprocesses with your PATH and full filesystem access, and "
+                "policy 'workspace_only'/'network' are NOT enforced. Use the "
+                "docker or ssh backend for untrusted input."
+            )
+            _isolation_warned = True
 
     # -- lifecycle --
 

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -16,8 +16,9 @@ import os
 import shutil
 import signal
 import subprocess
+import threading
 import time
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Tuple
 
 from gimle.hugin.sandbox.policy import Allow, Policy, evaluate
 from gimle.hugin.sandbox.sandbox import (
@@ -33,6 +34,18 @@ logger = logging.getLogger(__name__)
 _SPILL_RELATIVE = os.path.join(".hugin", "last_output.txt")
 # Owner stamp read by the reaper to decide whether a workspace is abandoned.
 OWNER_FILE = ".hugin_owner.json"
+
+# Hard ceiling on output *buffered in this process* per command, across stdout
+# and stderr combined. The model only ever sees ``max_output_bytes`` after
+# truncation; this larger cap bounds parent memory (and the spill file) so a
+# runaway ``yes`` / ``cat /dev/zero`` cannot OOM the orchestrator before the
+# per-command truncation runs. Past it, the process group is killed.
+_MAX_CAPTURE_BYTES = 2_000_000
+
+# How long to wait, after killing the group, for the reader threads to drain
+# and the process to be reaped — bounded so an escaped child that ``setsid``'d
+# away and still holds the stdout pipe can never hang ``exec`` indefinitely.
+_DRAIN_GRACE_S = 0.5
 
 
 class LocalSandbox(Sandbox):
@@ -112,22 +125,22 @@ class LocalSandbox(Sandbox):
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
             start_new_session=True,  # own process group, so we can kill it all
         )
-        timed_out = False
-        try:
-            stdout, stderr = proc.communicate(timeout=effective_timeout)
-        except subprocess.TimeoutExpired:
-            timed_out = True
-            self._kill_group(proc)
-            stdout, stderr = proc.communicate()
+        full_stdout, full_stderr, timed_out, capped = self._capture(
+            proc, effective_timeout
+        )
         duration = time.monotonic() - started
 
-        full_stdout, full_stderr = stdout or "", stderr or ""
+        if capped:
+            full_stderr += (
+                f"\n[hugin: output exceeded {_MAX_CAPTURE_BYTES} bytes; "
+                "process terminated]"
+            )
+
         out, out_trunc = truncate_output(full_stdout, max_output_bytes)
         err, err_trunc = truncate_output(full_stderr, max_output_bytes)
-        truncated = out_trunc or err_trunc
+        truncated = out_trunc or err_trunc or capped
         if truncated:
             self._spill(cwd, full_stdout, full_stderr)
 
@@ -141,6 +154,76 @@ class LocalSandbox(Sandbox):
             oom_killed=False,  # a bare subprocess cannot bound or detect OOM
         )
 
+    def _capture(
+        self, proc: "subprocess.Popen", timeout_s: int
+    ) -> Tuple[str, str, bool, bool]:
+        """Drain the process's output under a byte ceiling and a wall-clock cap.
+
+        Reads stdout and stderr concurrently into buffers bounded by
+        :data:`_MAX_CAPTURE_BYTES`, and kills the whole process group when the
+        command exceeds either the output ceiling or ``timeout_s``. After the
+        kill it waits only ``_DRAIN_GRACE_S`` for the readers, so a child that
+        escaped the group and still holds the pipe cannot block the caller.
+
+        Returns ``(stdout, stderr, timed_out, capped)``.
+        """
+        buffers: Dict[str, bytearray] = {"out": bytearray(), "err": bytearray()}
+        total = [0]
+        lock = threading.Lock()
+        capped = threading.Event()
+
+        def reader(stream: object, key: str) -> None:
+            try:
+                while True:
+                    chunk = stream.read(65536)  # type: ignore[attr-defined]
+                    if not chunk:
+                        break
+                    with lock:
+                        total[0] += len(chunk)
+                        room = _MAX_CAPTURE_BYTES - len(buffers[key])
+                        if room > 0:
+                            buffers[key].extend(chunk[:room])
+                        over = total[0] > _MAX_CAPTURE_BYTES
+                    if over:
+                        capped.set()
+            except (OSError, ValueError):  # pipe closed under us on kill
+                pass
+
+        threads: List[threading.Thread] = []
+        for stream, key in ((proc.stdout, "out"), (proc.stderr, "err")):
+            if stream is None:
+                continue
+            thread = threading.Thread(
+                target=reader, args=(stream, key), daemon=True
+            )
+            thread.start()
+            threads.append(thread)
+
+        timed_out = False
+        deadline = time.monotonic() + timeout_s
+        while True:
+            if proc.poll() is not None:
+                break
+            if capped.is_set():
+                break
+            if time.monotonic() >= deadline:
+                timed_out = True
+                break
+            time.sleep(0.02)
+
+        if proc.poll() is None:
+            self._kill_group(proc)
+        for thread in threads:
+            thread.join(timeout=_DRAIN_GRACE_S)
+        try:
+            proc.wait(timeout=1.0)
+        except subprocess.TimeoutExpired:  # escaped child; leave it to the OS
+            pass
+
+        stdout = bytes(buffers["out"]).decode("utf-8", "replace")
+        stderr = bytes(buffers["err"]).decode("utf-8", "replace")
+        return stdout, stderr, timed_out, capped.is_set()
+
     def _scrubbed_env(self, cwd: str) -> Dict[str, str]:
         """Build a minimal env: no inherited secrets, HOME in the workspace."""
         return {
@@ -152,11 +235,18 @@ class LocalSandbox(Sandbox):
 
     @staticmethod
     def _kill_group(proc: "subprocess.Popen") -> None:
-        """SIGKILL the command's whole process group (children included)."""
+        """SIGKILL the command's whole process group (children included).
+
+        ``start_new_session=True`` makes the child a group leader whose pgid
+        equals its pid, so we target ``proc.pid`` directly rather than
+        ``os.getpgid(proc.pid)`` — the latter raises if the leader has already
+        exited while group members remain, silently leaving them alive. The
+        unreaped process still holds its pid, so the group id is stable here.
+        """
         try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except ProcessLookupError:
-            pass  # already gone
+            os.killpg(proc.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass  # already gone, or not ours to kill
 
     def _spill(self, cwd: str, stdout: str, stderr: str) -> None:
         """Write full output to the workspace so the agent can read past the cap."""

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -1,0 +1,182 @@
+"""``LocalSandbox`` — run commands as subprocesses on the host.
+
+This backend has **no isolation boundary**, and the design says so plainly: it
+is the zero-dependency option for iterating and trusted tasks, not a sandbox.
+It still does the honest, useful things it can: enforce policy fail-closed, run
+in a per-agent workspace, scrub the environment (no inherited secrets, ``HOME``
+pointed at the workspace), kill the whole process group on timeout, cap output,
+and confine file access to the workspace. What it cannot do — bound CPU/memory,
+contain a determined command, stop ``/dev/tcp`` egress — is the container's job,
+not this backend's.
+"""
+
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import time
+from typing import Dict, Optional
+
+from gimle.hugin.sandbox.policy import Allow, Policy, evaluate
+from gimle.hugin.sandbox.sandbox import (
+    ExecResult,
+    PolicyDenied,
+    Sandbox,
+    SandboxSpec,
+    truncate_output,
+)
+
+logger = logging.getLogger(__name__)
+
+_SPILL_RELATIVE = os.path.join(".hugin", "last_output.txt")
+
+
+class LocalSandbox(Sandbox):
+    """Execute commands as host subprocesses under a per-session workspace."""
+
+    def __init__(
+        self,
+        spec: SandboxSpec,
+        session_id: str,
+        workspace_root: str = "./storage/sandboxes",
+    ) -> None:
+        """Bind this sandbox to ``session_id`` under ``workspace_root``."""
+        self._spec = spec
+        self._session_root = os.path.abspath(
+            os.path.join(workspace_root, session_id)
+        )
+        self._bash = shutil.which("bash") or "/bin/bash"
+
+    # -- lifecycle --
+
+    def start(self) -> None:
+        """Create the session workspace root. Idempotent."""
+        os.makedirs(self._session_root, exist_ok=True)
+
+    def stop(self) -> None:
+        """No persistent resource to release. Idempotent, safe if unstarted."""
+
+    # -- workspaces --
+
+    def workspace_for(self, agent_id: str, branch: Optional[str]) -> str:
+        """Return this ``(agent, branch)`` directory, creating it if absent."""
+        path = os.path.join(
+            self._session_root, "agents", agent_id, branch or "default"
+        )
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    # -- execution --
+
+    def exec(
+        self,
+        command: str,
+        *,
+        policy: Policy,
+        cwd: str,
+        timeout_s: int,
+        max_output_bytes: int = 16_000,
+    ) -> ExecResult:
+        """Run ``command`` through ``bash -c``; enforce policy fail-closed."""
+        decision = evaluate(command, policy)
+        if not isinstance(decision, Allow):
+            raise PolicyDenied(getattr(decision, "reason", "command refused"))
+
+        effective_timeout = min(timeout_s, policy.max_timeout_s)
+        env = self._scrubbed_env(cwd)
+
+        started = time.monotonic()
+        proc = subprocess.Popen(
+            [self._bash, "-c", command],
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,  # own process group, so we can kill it all
+        )
+        timed_out = False
+        try:
+            stdout, stderr = proc.communicate(timeout=effective_timeout)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            self._kill_group(proc)
+            stdout, stderr = proc.communicate()
+        duration = time.monotonic() - started
+
+        full_stdout, full_stderr = stdout or "", stderr or ""
+        out, out_trunc = truncate_output(full_stdout, max_output_bytes)
+        err, err_trunc = truncate_output(full_stderr, max_output_bytes)
+        truncated = out_trunc or err_trunc
+        if truncated:
+            self._spill(cwd, full_stdout, full_stderr)
+
+        return ExecResult(
+            exit_code=proc.returncode if proc.returncode is not None else -1,
+            stdout=out,
+            stderr=err,
+            duration_s=duration,
+            truncated=truncated,
+            timed_out=timed_out,
+            oom_killed=False,  # a bare subprocess cannot bound or detect OOM
+        )
+
+    def _scrubbed_env(self, cwd: str) -> Dict[str, str]:
+        """Build a minimal env: no inherited secrets, HOME in the workspace."""
+        return {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": cwd,
+            "LANG": os.environ.get("LANG", "C.UTF-8"),
+            "TERM": "dumb",
+        }
+
+    @staticmethod
+    def _kill_group(proc: "subprocess.Popen") -> None:
+        """SIGKILL the command's whole process group (children included)."""
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass  # already gone
+
+    def _spill(self, cwd: str, stdout: str, stderr: str) -> None:
+        """Write full output to the workspace so the agent can read past the cap."""
+        try:
+            spill_path = os.path.join(cwd, _SPILL_RELATIVE)
+            os.makedirs(os.path.dirname(spill_path), exist_ok=True)
+            with open(spill_path, "w", encoding="utf-8") as handle:
+                handle.write(stdout)
+                if stderr:
+                    handle.write("\n--- stderr ---\n")
+                    handle.write(stderr)
+        except OSError as error:  # best-effort; never fail the command over it
+            logger.debug("could not spill full output: %s", error)
+
+    # -- files --
+
+    def put_file(self, path: str, content: bytes) -> None:
+        """Write ``content`` to ``path`` inside the workspace."""
+        target = self._confine(path)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "wb") as handle:
+            handle.write(content)
+
+    def get_file(self, path: str) -> bytes:
+        """Read ``path`` from the workspace, refusing a symlink escape."""
+        target = self._confine(path)
+        with open(target, "rb") as handle:
+            return handle.read()
+
+    def _confine(self, path: str) -> str:
+        """Resolve ``path`` within the session workspace or raise PolicyDenied.
+
+        ``realpath`` dereferences symlinks first, so a link planted inside the
+        workspace that points outside it resolves to an outside path and is
+        rejected — the harvest/escape hole the security review flagged.
+        """
+        root = os.path.realpath(self._session_root)
+        candidate = path if os.path.isabs(path) else os.path.join(root, path)
+        resolved = os.path.realpath(candidate)
+        if resolved != root and not resolved.startswith(root + os.sep):
+            raise PolicyDenied(f"path escapes the workspace: {path}")
+        return resolved

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -10,6 +10,7 @@ contain a determined command, stop ``/dev/tcp`` egress — is the container's jo
 not this backend's.
 """
 
+import json
 import logging
 import os
 import shutil
@@ -30,6 +31,8 @@ from gimle.hugin.sandbox.sandbox import (
 logger = logging.getLogger(__name__)
 
 _SPILL_RELATIVE = os.path.join(".hugin", "last_output.txt")
+# Owner stamp read by the reaper to decide whether a workspace is abandoned.
+OWNER_FILE = ".hugin_owner.json"
 
 
 class LocalSandbox(Sandbox):
@@ -51,8 +54,24 @@ class LocalSandbox(Sandbox):
     # -- lifecycle --
 
     def start(self) -> None:
-        """Create the session workspace root. Idempotent."""
+        """Create the session workspace root and stamp its owner. Idempotent."""
         os.makedirs(self._session_root, exist_ok=True)
+        self._write_owner_stamp()
+
+    def _write_owner_stamp(self) -> None:
+        """Record the owning PID so the reaper can spot an abandoned workspace.
+
+        Written once (the created time is preserved across restarts) and
+        best-effort — a workspace we cannot stamp is simply reaped by age.
+        """
+        stamp = os.path.join(self._session_root, OWNER_FILE)
+        if os.path.exists(stamp):
+            return
+        try:
+            with open(stamp, "w", encoding="utf-8") as handle:
+                json.dump({"pid": os.getpid(), "created": time.time()}, handle)
+        except OSError as error:  # best-effort; the reaper falls back to age
+            logger.debug("could not write owner stamp: %s", error)
 
     def stop(self) -> None:
         """No persistent resource to release. Idempotent, safe if unstarted."""

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -35,6 +35,37 @@ _SPILL_RELATIVE = os.path.join(".hugin", "last_output.txt")
 # Owner stamp read by the reaper to decide whether a workspace is abandoned.
 OWNER_FILE = ".hugin_owner.json"
 
+
+def process_start_time(pid: int) -> Optional[str]:
+    """Return an opaque token identifying this PID's process *incarnation*.
+
+    Paired with the PID in the owner stamp, this lets the reaper tell the
+    original owner from an unrelated process that later recycled the same PID —
+    without which a dead workspace whose PID got reused is kept forever (a leak)
+    or, worse, a live one is deleted. Best-effort and dependency-free: Linux
+    reads ``/proc/<pid>/stat`` (field 22, start time in clock ticks); macOS/BSD
+    shell out to ``ps -o lstart=``. Returns ``None`` when it cannot be
+    determined, in which case callers fall back to PID-only liveness.
+    """
+    try:
+        stat_path = f"/proc/{pid}/stat"
+        if os.path.exists(stat_path):
+            with open(stat_path, encoding="utf-8") as handle:
+                data = handle.read()
+            # comm (field 2) may contain spaces/parens; split after the last ')'
+            after_comm = data[data.rfind(")") + 2 :].split()
+            return after_comm[19]  # field 22 overall -> starttime
+        result = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        return result.stdout.strip() or None
+    except (OSError, ValueError, IndexError, subprocess.SubprocessError):
+        return None
+
+
 # Hard ceiling on output *buffered in this process* per command, across stdout
 # and stderr combined. The model only ever sees ``max_output_bytes`` after
 # truncation; this larger cap bounds parent memory (and the spill file) so a
@@ -72,17 +103,30 @@ class LocalSandbox(Sandbox):
         self._write_owner_stamp()
 
     def _write_owner_stamp(self) -> None:
-        """Record the owning PID so the reaper can spot an abandoned workspace.
+        """Record the owning PID + start time so the reaper spots abandonment.
 
-        Written once (the created time is preserved across restarts) and
-        best-effort — a workspace we cannot stamp is simply reaped by age.
+        Rewritten on **every** ``start()`` with the current live PID — a
+        resumed session (same session id, new process) must re-stamp, or the
+        stale dead PID would make the reaper delete the running session's
+        workspace. Best-effort: a workspace we cannot stamp is reaped by age.
         """
         stamp = os.path.join(self._session_root, OWNER_FILE)
-        if os.path.exists(stamp):
-            return
+        pid = os.getpid()
+        record = {
+            "pid": pid,
+            "start_time": process_start_time(pid),
+            "created": time.time(),
+        }
+        try:  # preserve the original creation time, if any, for debugging
+            with open(stamp, encoding="utf-8") as handle:
+                existing = json.load(handle)
+            if isinstance(existing, dict) and "created" in existing:
+                record["created"] = existing["created"]
+        except (OSError, ValueError):
+            pass
         try:
             with open(stamp, "w", encoding="utf-8") as handle:
-                json.dump({"pid": os.getpid(), "created": time.time()}, handle)
+                json.dump(record, handle)
         except OSError as error:  # best-effort; the reaper falls back to age
             logger.debug("could not write owner stamp: %s", error)
 

--- a/src/gimle/hugin/sandbox/manager.py
+++ b/src/gimle/hugin/sandbox/manager.py
@@ -1,0 +1,49 @@
+"""``SandboxManager`` — one sandbox per session, lazily started, torn down once.
+
+The manager owns the lifecycle so the tool doesn't have to: it lazily creates
+and starts the backend on first use (a session that never runs a command never
+pays for one) and closes it exactly once. The session-level teardown seam
+(``Session.close``) and out-of-band reaping wire into ``close`` in a later unit;
+here the manager is the single object that holds the live backend handle.
+"""
+
+import logging
+from typing import Optional
+
+from gimle.hugin.sandbox.sandbox import Sandbox, SandboxSpec, create_sandbox
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxManager:
+    """Lazily own one :class:`Sandbox` for a session."""
+
+    def __init__(
+        self,
+        spec: SandboxSpec,
+        session_id: str,
+        workspace_root: str = "./storage/sandboxes",
+        sandbox: Optional[Sandbox] = None,
+    ) -> None:
+        """Bind to ``session_id``; ``sandbox`` pre-injects a backend (tests)."""
+        self._spec = spec
+        self._session_id = session_id
+        self._workspace_root = workspace_root
+        self._sandbox = sandbox
+
+    def get(self) -> Sandbox:
+        """Return the session's sandbox, creating and starting it on first use."""
+        if self._sandbox is None:
+            self._sandbox = create_sandbox(
+                self._spec, self._session_id, self._workspace_root
+            )
+        self._sandbox.start()  # idempotent
+        return self._sandbox
+
+    def close(self) -> None:
+        """Tear the sandbox down. Idempotent; safe if never started."""
+        if self._sandbox is not None:
+            try:
+                self._sandbox.stop()
+            except Exception as error:  # teardown must never raise upward
+                logger.warning("sandbox stop failed: %s", error)

--- a/src/gimle/hugin/sandbox/manager.py
+++ b/src/gimle/hugin/sandbox/manager.py
@@ -8,8 +8,10 @@ here the manager is the single object that holds the live backend handle.
 """
 
 import logging
+import os
 from typing import Optional
 
+from gimle.hugin.sandbox.audit import CommandAudit
 from gimle.hugin.sandbox.sandbox import Sandbox, SandboxSpec, create_sandbox
 
 logger = logging.getLogger(__name__)
@@ -24,19 +26,41 @@ class SandboxManager:
         session_id: str,
         workspace_root: str = "./storage/sandboxes",
         sandbox: Optional[Sandbox] = None,
+        record_audit_to_file: bool = False,
     ) -> None:
-        """Bind to ``session_id``; ``sandbox`` pre-injects a backend (tests)."""
+        """Bind to ``session_id``; ``sandbox`` pre-injects a backend (tests).
+
+        ``record_audit_to_file`` additionally persists the command audit as a
+        JSONL file under the session workspace; off by default so pre-injected
+        managers (tests, in-process apps) keep counters without touching disk.
+        """
         self._spec = spec
         self._session_id = session_id
         self._workspace_root = workspace_root
         self._sandbox = sandbox
+        audit_path = None
+        if record_audit_to_file:
+            audit_path = os.path.join(
+                workspace_root, session_id, ".hugin", "audit.jsonl"
+            )
+        self.audit = CommandAudit(audit_path)
 
     def get(self) -> Sandbox:
         """Return the session's sandbox, creating and starting it on first use."""
         if self._sandbox is None:
-            self._sandbox = create_sandbox(
-                self._spec, self._session_id, self._workspace_root
-            )
+            try:
+                sandbox = create_sandbox(
+                    self._spec, self._session_id, self._workspace_root
+                )
+                sandbox.start()
+            except Exception:
+                # Bringing a backend up is the classic ops failure (daemon
+                # down, host unreachable); count it so the rate is visible.
+                self.audit.counters["sandbox_start_failures"] += 1
+                raise
+            self._sandbox = sandbox
+            self.audit.counters["sandbox_starts"] += 1
+            return self._sandbox
         self._sandbox.start()  # idempotent
         return self._sandbox
 

--- a/src/gimle/hugin/sandbox/policy.py
+++ b/src/gimle/hugin/sandbox/policy.py
@@ -18,16 +18,33 @@ What the engine guarantees:
 - **Fails closed:** a command ``bashlex`` cannot parse is denied, never allowed.
 - **Walks the whole AST:** a denied binary hidden behind ``&&``/``|`` or inside
   ``$(...)`` is still found.
+- **Peels wrappers:** a denied binary run *through* a wrapper that executes its
+  argument (``env dd``, ``timeout 60 dd``, ``nice -n 19 dd``, ``xargs … reboot``,
+  ``sudo reboot``, ``find … -exec shutdown``) is resolved to the command it
+  actually runs and judged as that command — in every mode. This is best-effort
+  on exotic flag grammars, not bulletproof; the runtime is still the boundary.
 - **Rejects execution-hijacking assignments** (``LD_PRELOAD`` and friends) on
   every backend.
 - **Opt-in strict mode** (``allow_shell_features=False``) additionally blocks
-  the shell escape hatches (command/process substitution, ``eval``/``source``,
-  interpreter ``-c``, and wrappers like ``timeout`` that run their argument).
+  the shell escape hatches: command/process substitution, ``eval``/``source``,
+  and running an interpreter with ``-c``/``-e`` — including when that
+  interpreter is reached through a wrapper (``env python3 -c …``).
 """
 
 import logging
+import re
 from dataclasses import dataclass, field, fields
-from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import bashlex
 
@@ -128,8 +145,9 @@ _INTERPRETERS = frozenset(
     }
 )
 
-# Binaries that run their argument as a command, so a nested interpreter must be
-# looked through in strict mode.
+# Binaries that run one of their arguments as a command. A denied binary run
+# through one of these must be looked through — the wrapper is peeled down to
+# the command it actually executes (``env dd`` -> ``dd``).
 _WRAPPERS = frozenset(
     {
         "timeout",
@@ -144,8 +162,39 @@ _WRAPPERS = frozenset(
         "time",
         "chrt",
         "watch",
+        "sudo",
+        "doas",
     }
 )
+
+# Per-wrapper option flags that consume the *following* token as their value,
+# so the peeler skips both and doesn't mistake the value for the command.
+_WRAPPER_VALUE_FLAGS: Dict[str, FrozenSet[str]] = {
+    "timeout": frozenset({"-s", "--signal", "-k", "--kill-after"}),
+    "nice": frozenset({"-n", "--adjustment"}),
+    "ionice": frozenset({"-c", "-n", "-p", "-u"}),
+    "xargs": frozenset(
+        {"-a", "-E", "-I", "-i", "-L", "-l", "-n", "-P", "-s", "-d"}
+    ),
+    "env": frozenset(
+        {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
+    ),
+    "stdbuf": frozenset({"-i", "-o", "-e"}),
+    "watch": frozenset({"-n", "--interval"}),
+    "sudo": frozenset(
+        {"-u", "--user", "-g", "--group", "-p", "-C", "-U", "-r"}
+    ),
+    "doas": frozenset({"-u", "-C"}),
+}
+
+# Wrappers that take a leading POSITIONAL (non-flag) argument before the
+# command — ``timeout <duration> cmd``, ``chrt <priority> cmd``.
+_WRAPPER_POSITIONALS: Dict[str, int] = {"timeout": 1, "chrt": 1}
+
+# ``find`` primaries whose following token begins a command to run.
+_FIND_EXEC_PRIMARIES = frozenset({"-exec", "-execdir", "-ok", "-okdir"})
+
+_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 
 # --- policy ---
@@ -323,6 +372,93 @@ def _has_interpreter_dash_c(ctx: _CommandContext) -> bool:
     return any(_base(w) in _INTERPRETERS for w in ctx.words)
 
 
+def _looks_like_assignment(token: str) -> bool:
+    """Report whether ``token`` is ``NAME=VALUE`` (an ``env`` inline assign)."""
+    return bool(_ASSIGNMENT_RE.match(token))
+
+
+def _peel_wrapper(ctx: _CommandContext) -> Optional[_CommandContext]:
+    """If ``ctx``'s head is a wrapper, return the command it actually runs.
+
+    Skips the wrapper's own option flags (and their values), ``env`` inline
+    assignments, and any leading positional (a ``timeout`` duration / ``chrt``
+    priority), leaving the wrapped command. Returns ``None`` if the head is not
+    a wrapper or nothing runnable remains.
+    """
+    if ctx.word is None:
+        return None
+    wrapper = _base(ctx.word)
+    if wrapper not in _WRAPPERS:
+        return None
+    value_flags: FrozenSet[str] = _WRAPPER_VALUE_FLAGS.get(wrapper, frozenset())
+    positionals = _WRAPPER_POSITIONALS.get(wrapper, 0)
+    args = ctx.args
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token == "--":  # explicit end of options
+            i += 1
+            break
+        if token.startswith("-"):
+            i += 1
+            if token in value_flags and i < len(args):
+                i += 1  # this flag consumes the next token as its value
+            continue
+        if wrapper == "env" and _looks_like_assignment(token):
+            i += 1
+            continue
+        if positionals > 0:
+            positionals -= 1
+            i += 1
+            continue
+        break
+    inner = args[i:]
+    if not inner:
+        return None
+    return _CommandContext(
+        word=inner[0], args=inner[1:], words=inner, assignments=[]
+    )
+
+
+def _resolve_chain(ctx: _CommandContext) -> List[_CommandContext]:
+    """Return ``ctx`` and each command it runs by peeling wrappers, outer first.
+
+    The depth bound is a guard against a pathological self-referential peel; a
+    real wrapper chain is only a few deep.
+    """
+    chain = [ctx]
+    current = ctx
+    for _ in range(10):
+        inner = _peel_wrapper(current)
+        if inner is None:
+            break
+        chain.append(inner)
+        current = inner
+    return chain
+
+
+def _base_deny_reason(base: str, policy: Policy) -> Optional[str]:
+    """Return the deny reason for a bare command basename (mkfs / deny-set)."""
+    if base == "mkfs" or base.startswith("mkfs."):
+        return f"{base} is denied (destroys filesystems)"
+    if base in DEFAULT_DENY or base in policy.deny:
+        return f"{base} is denied"
+    return None
+
+
+def _find_exec_reason(ctx: _CommandContext, policy: Policy) -> Optional[str]:
+    """Return the deny reason for a ``find … -exec <denied>`` primary, if any."""
+    if ctx.word is None or _base(ctx.word) != "find":
+        return None
+    args = ctx.args
+    for index, token in enumerate(args):
+        if token in _FIND_EXEC_PRIMARIES and index + 1 < len(args):
+            reason = _base_deny_reason(_base(args[index + 1]), policy)
+            if reason is not None:
+                return f"{reason} (via find -exec)"
+    return None
+
+
 # --- evaluation ---
 
 
@@ -371,6 +507,7 @@ def evaluate(command: str, policy: Policy) -> Decision:
             )
 
     for ctx in commands:
+        # Shell assignments prefix the outer command, so check them on ``ctx``.
         for assignment in ctx.assignments:
             name = assignment.split("=", 1)[0]
             if name in DANGEROUS_ASSIGNMENTS:
@@ -378,13 +515,20 @@ def evaluate(command: str, policy: Policy) -> Decision:
                     policy, f"dangerous environment assignment: {name}"
                 )
 
+        # Peel wrappers so the rest of the rules see the command actually run.
+        chain = _resolve_chain(ctx)
+        effective = chain[-1]
+
         if not policy.allow_shell_features:
-            if ctx.word is not None and _base(ctx.word) in _SHELL_ESCAPE_WORDS:
+            if (
+                effective.word is not None
+                and _base(effective.word) in _SHELL_ESCAPE_WORDS
+            ):
                 return _violation(
                     policy,
-                    f"'{ctx.word}' is disabled in strict mode",
+                    f"'{effective.word}' is disabled in strict mode",
                 )
-            if _has_interpreter_dash_c(ctx):
+            if _has_interpreter_dash_c(effective):
                 return _violation(
                     policy,
                     "running an interpreter with -c/-e is disabled in "
@@ -392,12 +536,19 @@ def evaluate(command: str, policy: Policy) -> Decision:
                 )
 
         if policy.mode == "allowlist":
-            if ctx.word is not None and _base(ctx.word) not in policy.allow:
-                return _violation(
-                    policy, f"command not in allowlist: {ctx.word}"
-                )
+            # Both the wrapper(s) and the wrapped command must be allowlisted.
+            for node in chain:
+                if (
+                    node.word is not None
+                    and _base(node.word) not in policy.allow
+                ):
+                    return _violation(
+                        policy, f"command not in allowlist: {node.word}"
+                    )
         else:  # denylist
-            reason = _denylist_reason(ctx, policy)
+            reason = _denylist_reason(effective, policy)
+            if reason is None:
+                reason = _find_exec_reason(effective, policy)
             if reason is not None:
                 return _violation(policy, reason)
 
@@ -408,10 +559,9 @@ def _denylist_reason(ctx: _CommandContext, policy: Policy) -> Optional[str]:
     if ctx.word is None:
         return None
     base = _base(ctx.word)
-    if base == "mkfs" or base.startswith("mkfs."):
-        return f"{base} is denied (destroys filesystems)"
-    if base in DEFAULT_DENY or base in policy.deny:
-        return f"{base} is denied"
+    reason = _base_deny_reason(base, policy)
+    if reason is not None:
+        return reason
     if base == "rm" and _is_dangerous_rm(ctx.args):
         return "rm with a recursive force on a top-level target is denied"
     if base == "git" and _is_force_push(ctx.args):

--- a/src/gimle/hugin/sandbox/policy.py
+++ b/src/gimle/hugin/sandbox/policy.py
@@ -1,0 +1,385 @@
+"""Pure command policy engine for the bash tool.
+
+``evaluate(command, policy)`` parses a shell command with ``bashlex`` and
+returns an :class:`Allow`, :class:`Deny`, or :class:`Escalate` decision. It has
+no I/O and no dependency on any execution backend, so it is trivially testable.
+
+The engine is a **guardrail against accidents, not a security boundary.** The
+runtime you run commands in — a container, a disposable remote machine, or
+(on the local backend) nothing — is the boundary. In the default ``denylist``
+mode the engine is deliberately permissive: it blocks a blunt set of
+catastrophic commands and dangerous environment assignments, but it does *not*
+stop interpreter-based execution (``python3 -c ...``, ``awk 'BEGIN{system()}'``,
+``git -c core.pager='!sh'``). Pretending a wordlist stops those would be
+security theatre — the container does.
+
+What the engine guarantees:
+
+- **Fails closed:** a command ``bashlex`` cannot parse is denied, never allowed.
+- **Walks the whole AST:** a denied binary hidden behind ``&&``/``|`` or inside
+  ``$(...)`` is still found.
+- **Rejects execution-hijacking assignments** (``LD_PRELOAD`` and friends) on
+  every backend.
+- **Opt-in strict mode** (``allow_shell_features=False``) additionally blocks
+  the shell escape hatches (command/process substitution, ``eval``/``source``,
+  interpreter ``-c``, and wrappers like ``timeout`` that run their argument).
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Iterator, List, Literal, Optional, Tuple, Union
+
+import bashlex
+
+logger = logging.getLogger(__name__)
+
+
+# --- decisions ---
+
+
+@dataclass(frozen=True)
+class Allow:
+    """The command may run."""
+
+
+@dataclass(frozen=True)
+class Deny:
+    """The command is refused; ``reason`` explains why (shown to the agent)."""
+
+    reason: str
+
+
+@dataclass(frozen=True)
+class Escalate:
+    """The command needs human approval; ``reason`` explains why."""
+
+    reason: str
+
+
+Decision = Union[Allow, Deny, Escalate]
+
+
+# --- rule sets ---
+
+# Binaries denied outright: destroying disks/filesystems or halting the host is
+# never a legitimate agent action. Matched on the basename, so an absolute path
+# like ``/sbin/reboot`` is caught too. ``mkfs*`` is handled separately.
+DEFAULT_DENY: Tuple[str, ...] = (
+    "dd",
+    "shutdown",
+    "reboot",
+    "halt",
+    "poweroff",
+    "init",
+    "telinit",
+    "fdisk",
+    "parted",
+    "mkswap",
+)
+
+# Recursive-remove targets treated as catastrophic. A relative target such as
+# ``./build`` is intentionally NOT here — that's an ordinary (if regrettable)
+# action, and over-blocking pushes users toward disabling the policy.
+_DANGEROUS_RM_TARGETS = frozenset(
+    {"/", "~", "~/", "/*", "*", "/.", "$HOME", "${HOME}"}
+)
+
+# Environment assignments that redirect execution into attacker-controlled code
+# regardless of the (allowlisted) binary being run.
+DANGEROUS_ASSIGNMENTS = frozenset(
+    {
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "LD_AUDIT",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH",
+        "BASH_ENV",
+        "ENV",
+        "IFS",
+        "PROMPT_COMMAND",
+        "PATH",
+        "PYTHONSTARTUP",
+        "PERL5OPT",
+        "GIT_SSH",
+        "GIT_SSH_COMMAND",
+        "GIT_EXTERNAL_DIFF",
+        "GIT_PAGER",
+    }
+)
+
+# Shell builtins that evaluate an arbitrary string as code.
+_SHELL_ESCAPE_WORDS = frozenset({"eval", "source", "."})
+
+# Interpreters whose ``-c``/``-e`` flag runs an arbitrary program.
+_INTERPRETERS = frozenset(
+    {
+        "sh",
+        "bash",
+        "zsh",
+        "dash",
+        "ksh",
+        "python",
+        "python2",
+        "python3",
+        "node",
+        "ruby",
+        "perl",
+        "php",
+    }
+)
+
+# Binaries that run their argument as a command, so a nested interpreter must be
+# looked through in strict mode.
+_WRAPPERS = frozenset(
+    {
+        "timeout",
+        "env",
+        "xargs",
+        "nice",
+        "ionice",
+        "nohup",
+        "setsid",
+        "stdbuf",
+        "command",
+        "time",
+        "chrt",
+        "watch",
+    }
+)
+
+
+# --- policy ---
+
+
+@dataclass(frozen=True)
+class Policy:
+    """How a command is judged before it runs.
+
+    Attributes:
+        mode: ``denylist`` (default, permissive — block only the accident set),
+            ``allowlist`` (only ``allow`` command words permitted), or
+            ``unrestricted`` (no checks; still fails closed on a parse error).
+        deny: Extra denied binary basenames, added to :data:`DEFAULT_DENY`.
+        allow: Permitted command basenames, used only in ``allowlist`` mode.
+        allow_shell_features: When ``False`` (opt-in strict mode) the shell
+            escape hatches are refused. Default ``True`` — the runtime is the
+            boundary, so the engine need not fight the shell.
+        workspace_only: Confine filesystem access to the workspace. Enforced by
+            the sandbox layer (realpath confinement), not this pure function.
+        network: Whether the command may reach the network (advisory here;
+            enforced by the backend).
+        timeout_s: Interactive per-command timeout.
+        max_timeout_s: Ceiling for an explicit longer timeout.
+        max_output_bytes: Cap on captured output.
+        on_violation: ``deny`` to refuse, or ``ask_human`` to escalate.
+    """
+
+    mode: Literal["denylist", "allowlist", "unrestricted"] = "denylist"
+    deny: Tuple[str, ...] = DEFAULT_DENY
+    allow: Tuple[str, ...] = field(default_factory=tuple)
+    allow_shell_features: bool = True
+    workspace_only: bool = True
+    network: bool = False
+    timeout_s: int = 15
+    max_timeout_s: int = 600
+    max_output_bytes: int = 16_000
+    on_violation: Literal["deny", "ask_human"] = "deny"
+
+
+# --- AST helpers ---
+
+
+@dataclass
+class _CommandContext:
+    """One ``command`` node reduced to the fields the rules care about."""
+
+    word: Optional[str]  # command basename-bearing first word (raw)
+    args: List[str]
+    words: List[str]
+    assignments: List[str]
+
+
+def _is_node(value: Any) -> bool:
+    return hasattr(value, "kind")
+
+
+def _children(node: Any) -> Iterator[Any]:
+    """Yield every child bashlex node, regardless of the attribute holding it."""
+    for value in vars(node).values():
+        if _is_node(value):
+            yield value
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                if _is_node(item):
+                    yield item
+
+
+def _command_context(node: Any) -> _CommandContext:
+    words: List[str] = []
+    assignments: List[str] = []
+    for part in getattr(node, "parts", []):
+        kind = getattr(part, "kind", None)
+        if kind == "word":
+            words.append(part.word)
+        elif kind == "assignment":
+            assignments.append(part.word)
+    return _CommandContext(
+        word=words[0] if words else None,
+        args=words[1:],
+        words=words,
+        assignments=assignments,
+    )
+
+
+def _collect(node: Any, commands: List[_CommandContext], flags: dict) -> None:
+    """Walk the tree, gathering command contexts and shell-feature flags."""
+    kind = getattr(node, "kind", None)
+    if kind == "command":
+        commands.append(_command_context(node))
+    elif kind == "commandsubstitution":
+        flags["cmdsub"] = True
+    elif kind == "processsubstitution":
+        flags["procsub"] = True
+    for child in _children(node):
+        _collect(child, commands, flags)
+
+
+def _base(word: str) -> str:
+    """Return the basename of a command word (``/sbin/reboot`` -> ``reboot``)."""
+    return word.rsplit("/", 1)[-1]
+
+
+def _short_flag_letters(args: List[str]) -> str:
+    """All letters from clustered short flags, e.g. ``-rf`` -> ``rf``."""
+    letters = ""
+    for arg in args:
+        if arg.startswith("-") and not arg.startswith("--"):
+            letters += arg[1:]
+    return letters.lower()
+
+
+def _is_dangerous_rm(args: List[str]) -> bool:
+    letters = _short_flag_letters(args)
+    long_flags = {a for a in args if a.startswith("--")}
+    recursive = "r" in letters or "--recursive" in long_flags
+    force = "f" in letters or "--force" in long_flags
+    if not (recursive and force):
+        return False
+    targets = [a for a in args if not a.startswith("-")]
+    return any(t in _DANGEROUS_RM_TARGETS for t in targets)
+
+
+def _is_force_push(args: List[str]) -> bool:
+    if "push" not in args:
+        return False
+    return any(a in ("--force", "-f", "--force-with-lease") for a in args)
+
+
+def _is_recursive_chmod_777(args: List[str]) -> bool:
+    letters = _short_flag_letters(args)
+    recursive = "r" in letters or "--recursive" in args
+    return recursive and any("777" in a for a in args)
+
+
+def _has_interpreter_dash_c(ctx: _CommandContext) -> bool:
+    if "-c" not in ctx.args and "-e" not in ctx.args:
+        return False
+    return any(_base(w) in _INTERPRETERS for w in ctx.words)
+
+
+# --- evaluation ---
+
+
+def _violation(policy: Policy, reason: str) -> Decision:
+    if policy.on_violation == "ask_human":
+        return Escalate(reason)
+    return Deny(reason)
+
+
+def _parse(command: str) -> Optional[List[Any]]:
+    """Parse ``command``; return ``None`` if bashlex cannot (fail closed)."""
+    try:
+        return list(bashlex.parse(command))
+    except Exception as error:  # bashlex raises several ParsingError subtypes
+        logger.debug("bashlex could not parse %r: %s", command, error)
+        return None
+
+
+def evaluate(command: str, policy: Policy) -> Decision:
+    """Judge ``command`` against ``policy``.
+
+    Returns :class:`Allow`, :class:`Deny`, or :class:`Escalate`. A command that
+    cannot be parsed is always denied (never escalated) — you cannot ask a
+    human to approve something you could not read.
+    """
+    trees = _parse(command)
+    if trees is None:
+        return Deny("could not parse command; failing closed")
+
+    if policy.mode == "unrestricted":
+        return Allow()
+
+    commands: List[_CommandContext] = []
+    flags = {"cmdsub": False, "procsub": False}
+    for tree in trees:
+        _collect(tree, commands, flags)
+
+    if not policy.allow_shell_features:
+        if flags["cmdsub"]:
+            return _violation(
+                policy, "command substitution is disabled in strict mode"
+            )
+        if flags["procsub"]:
+            return _violation(
+                policy, "process substitution is disabled in strict mode"
+            )
+
+    for ctx in commands:
+        for assignment in ctx.assignments:
+            name = assignment.split("=", 1)[0]
+            if name in DANGEROUS_ASSIGNMENTS:
+                return _violation(
+                    policy, f"dangerous environment assignment: {name}"
+                )
+
+        if not policy.allow_shell_features:
+            if ctx.word is not None and _base(ctx.word) in _SHELL_ESCAPE_WORDS:
+                return _violation(
+                    policy,
+                    f"'{ctx.word}' is disabled in strict mode",
+                )
+            if _has_interpreter_dash_c(ctx):
+                return _violation(
+                    policy,
+                    "running an interpreter with -c/-e is disabled in "
+                    "strict mode",
+                )
+
+        if policy.mode == "allowlist":
+            if ctx.word is not None and _base(ctx.word) not in policy.allow:
+                return _violation(
+                    policy, f"command not in allowlist: {ctx.word}"
+                )
+        else:  # denylist
+            reason = _denylist_reason(ctx, policy)
+            if reason is not None:
+                return _violation(policy, reason)
+
+    return Allow()
+
+
+def _denylist_reason(ctx: _CommandContext, policy: Policy) -> Optional[str]:
+    if ctx.word is None:
+        return None
+    base = _base(ctx.word)
+    if base == "mkfs" or base.startswith("mkfs."):
+        return f"{base} is denied (destroys filesystems)"
+    if base in DEFAULT_DENY or base in policy.deny:
+        return f"{base} is denied"
+    if base == "rm" and _is_dangerous_rm(ctx.args):
+        return "rm with a recursive force on a top-level target is denied"
+    if base == "git" and _is_force_push(ctx.args):
+        return "git push --force is denied"
+    if base == "chmod" and _is_recursive_chmod_777(ctx.args):
+        return "recursive chmod 777 is denied"
+    return None

--- a/src/gimle/hugin/sandbox/policy.py
+++ b/src/gimle/hugin/sandbox/policy.py
@@ -26,8 +26,8 @@ What the engine guarantees:
 """
 
 import logging
-from dataclasses import dataclass, field
-from typing import Any, Iterator, List, Literal, Optional, Tuple, Union
+from dataclasses import dataclass, field, fields
+from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple, Union
 
 import bashlex
 
@@ -184,6 +184,42 @@ class Policy:
     max_timeout_s: int = 600
     max_output_bytes: int = 16_000
     on_violation: Literal["deny", "ask_human"] = "deny"
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "Policy":
+        """Build a Policy from a config dict, failing loud on anything wrong.
+
+        A security object must never silently fall back to a default because a
+        key was misspelled, so unknown keys and invalid literals raise
+        ``ValueError`` rather than being dropped. An empty/absent mapping yields
+        the conservative defaults.
+        """
+        if data is None:
+            return cls()
+        if not isinstance(data, dict):
+            raise ValueError("policy must be a mapping")
+        known = {f.name for f in fields(cls)}
+        unknown = set(data) - known
+        if unknown:
+            raise ValueError(f"unknown policy keys: {sorted(unknown)}")
+        kwargs = dict(data)
+        mode = kwargs.get("mode")
+        if mode is not None and mode not in (
+            "denylist",
+            "allowlist",
+            "unrestricted",
+        ):
+            raise ValueError(f"invalid policy mode: {mode!r}")
+        on_violation = kwargs.get("on_violation")
+        if on_violation is not None and on_violation not in (
+            "deny",
+            "ask_human",
+        ):
+            raise ValueError(f"invalid on_violation: {on_violation!r}")
+        for key in ("deny", "allow"):
+            if key in kwargs:
+                kwargs[key] = tuple(kwargs[key])
+        return cls(**kwargs)
 
 
 # --- AST helpers ---

--- a/src/gimle/hugin/sandbox/policy.py
+++ b/src/gimle/hugin/sandbox/policy.py
@@ -75,6 +75,11 @@ class Escalate:
 
 Decision = Union[Allow, Deny, Escalate]
 
+# Reason attached to the Deny for a command bashlex cannot parse. Exposed so the
+# tool can tell "the guard's parser choked" (rephrase) from "policy refused this"
+# (try something else) — they are very different signals to an agent.
+UNPARSEABLE_REASON = "could not parse command; failing closed"
+
 
 # --- rule sets ---
 
@@ -486,7 +491,7 @@ def evaluate(command: str, policy: Policy) -> Decision:
     """
     trees = _parse(command)
     if trees is None:
-        return Deny("could not parse command; failing closed")
+        return Deny(UNPARSEABLE_REASON)
 
     if policy.mode == "unrestricted":
         return Allow()

--- a/src/gimle/hugin/sandbox/policy.py
+++ b/src/gimle/hugin/sandbox/policy.py
@@ -218,10 +218,13 @@ class Policy:
         allow_shell_features: When ``False`` (opt-in strict mode) the shell
             escape hatches are refused. Default ``True`` — the runtime is the
             boundary, so the engine need not fight the shell.
-        workspace_only: Confine filesystem access to the workspace. Enforced by
-            the sandbox layer (realpath confinement), not this pure function.
-        network: Whether the command may reach the network (advisory here;
-            enforced by the backend).
+        workspace_only: Request that filesystem access stay in the workspace.
+            Advisory: honored only by an isolating backend (docker/ssh). The
+            local backend does NOT enforce it (it cannot confine ``exec``) —
+            the runtime is the boundary, so do not rely on this flag on local.
+        network: Request that the command not reach the network. Advisory in the
+            same way — honored by an isolating backend, ignored by the local
+            backend.
         timeout_s: Interactive per-command timeout.
         max_timeout_s: Ceiling for an explicit longer timeout.
         max_output_bytes: Cap on captured output.

--- a/src/gimle/hugin/sandbox/reaper.py
+++ b/src/gimle/hugin/sandbox/reaper.py
@@ -19,11 +19,22 @@ import json
 import logging
 import os
 import shutil
-from typing import Callable, List
+from dataclasses import dataclass
+from typing import Callable, List, Optional
 
 from gimle.hugin.sandbox.local import OWNER_FILE
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WorkspaceInfo:
+    """A local sandbox workspace as seen by the reaper/CLI."""
+
+    name: str
+    pid: Optional[int]
+    alive: bool
+    age_s: float
 
 
 def _pid_alive(pid: int) -> bool:
@@ -96,3 +107,29 @@ def reap_local_workspaces(
     if reaped:
         logger.info("reaped %d abandoned sandbox workspace(s)", len(reaped))
     return reaped
+
+
+def list_local_workspaces(
+    workspace_root: str,
+    *,
+    now: float,
+    pid_alive: Callable[[int], bool] = _pid_alive,
+) -> List[WorkspaceInfo]:
+    """Describe each session workspace under ``workspace_root`` (for the CLI)."""
+    if not os.path.isdir(workspace_root):
+        return []
+    infos: List[WorkspaceInfo] = []
+    for name in sorted(os.listdir(workspace_root)):
+        session_dir = os.path.join(workspace_root, name)
+        if not os.path.isdir(session_dir):
+            continue
+        pid = _owner_pid(session_dir)
+        infos.append(
+            WorkspaceInfo(
+                name=name,
+                pid=pid,
+                alive=pid_alive(pid) if pid is not None else False,
+                age_s=now - os.path.getmtime(session_dir),
+            )
+        )
+    return infos

--- a/src/gimle/hugin/sandbox/reaper.py
+++ b/src/gimle/hugin/sandbox/reaper.py
@@ -6,13 +6,18 @@
 invocation and removes only workspaces whose owning process is gone, never a
 live peer's.
 
-A local sandbox stamps its session directory with the owning PID
-(``LocalSandbox`` writes ``OWNER_FILE`` on start). The reaper reaps a directory
-when that owner is no longer alive; a directory with no stamp is reaped only
-once it is older than ``min_age_s`` (so a sandbox mid-startup, before it has
-written its stamp, is never swept out from under itself). PID reuse can only
-make the reaper *keep* a dead workspace a while longer, never delete a live
-one — the safe direction to err.
+A local sandbox stamps its session directory with the owning PID and that
+process's start time (``LocalSandbox`` writes ``OWNER_FILE`` on every start).
+The reaper reaps a directory when that owner is no longer alive; a directory
+with no stamp is reaped only once it is older than ``min_age_s`` (so a sandbox
+mid-startup, before it has written its stamp, is never swept out from under
+itself).
+
+The start-time token guards against PID reuse: a live process that merely
+recycled the dead owner's PID has a different start time, so it is not mistaken
+for the owner (which would leak the dead workspace forever). Whenever the reaper
+cannot positively confirm a PID belongs to a *different* incarnation, it errs
+toward keeping the workspace — never deleting a possibly-live one.
 """
 
 import json
@@ -20,9 +25,9 @@ import logging
 import os
 import shutil
 from dataclasses import dataclass
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
-from gimle.hugin.sandbox.local import OWNER_FILE
+from gimle.hugin.sandbox.local import OWNER_FILE, process_start_time
 
 logger = logging.getLogger(__name__)
 
@@ -50,15 +55,47 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
-def _owner_pid(session_dir: str) -> "int | None":
-    """Read the owning PID from a session directory's stamp, or None."""
+def _read_owner(session_dir: str) -> Optional[Tuple[int, Optional[str]]]:
+    """Read ``(pid, start_time)`` from a session directory's stamp, or None.
+
+    Tolerates a corrupt/partial stamp (truncated JSON, a null or non-integer
+    ``pid``) by returning None rather than raising — one bad stamp must never
+    abort the whole sweep.
+    """
     try:
         with open(
             os.path.join(session_dir, OWNER_FILE), encoding="utf-8"
         ) as handle:
-            return int(json.load(handle)["pid"])
-    except (OSError, ValueError, KeyError):
+            data = json.load(handle)
+        pid = int(data["pid"])
+    except (OSError, ValueError, KeyError, TypeError):
         return None
+    start_time = data.get("start_time")
+    if not isinstance(start_time, str):
+        start_time = None
+    return pid, start_time
+
+
+def _owner_is_alive(
+    pid: int,
+    start_time: Optional[str],
+    pid_alive: Callable[[int], bool],
+    start_time_of: Callable[[int], Optional[str]],
+) -> bool:
+    """Report whether the stamped owner is still the live process it names.
+
+    Reaps only when we can *positively* tell the PID now belongs to a different
+    incarnation (start time differs); an unknowable start time keeps the
+    workspace, so the reaper never deletes a possibly-live one.
+    """
+    if not pid_alive(pid):
+        return False
+    if start_time is None:
+        return True  # nothing to disambiguate with — trust liveness
+    current = start_time_of(pid)
+    if current is None:
+        return True  # can't read it now — err toward keeping
+    return current == start_time
 
 
 def reap_local_workspaces(
@@ -67,6 +104,7 @@ def reap_local_workspaces(
     now: float,
     min_age_s: float = 30.0,
     pid_alive: Callable[[int], bool] = _pid_alive,
+    start_time_of: Callable[[int], Optional[str]] = process_start_time,
 ) -> List[str]:
     """Remove abandoned session workspaces under ``workspace_root``.
 
@@ -75,6 +113,7 @@ def reap_local_workspaces(
         now: Current time (passed in for testability).
         min_age_s: An unstamped directory younger than this is left alone.
         pid_alive: Liveness check (injectable for tests).
+        start_time_of: Process-incarnation token lookup (injectable for tests).
 
     Returns:
         The names of the session directories that were removed.
@@ -85,20 +124,20 @@ def reap_local_workspaces(
     reaped: List[str] = []
     for name in os.listdir(workspace_root):
         session_dir = os.path.join(workspace_root, name)
-        if not os.path.isdir(session_dir):
-            continue
-
-        pid = _owner_pid(session_dir)
-        if pid is not None:
-            if pid_alive(pid):
-                continue  # a live owner — never reap
-        else:
-            # No stamp: only reap if it's clearly not a sandbox mid-startup.
-            age = now - os.path.getmtime(session_dir)
-            if age < min_age_s:
-                continue
-
+        # A concurrent reaper (parallel `hugin` processes) can remove an entry
+        # between listing and acting on it; guard the whole per-entry body so
+        # one vanished/unreadable dir never aborts the sweep.
         try:
+            if not os.path.isdir(session_dir):
+                continue
+            owner = _read_owner(session_dir)
+            if owner is not None:
+                if _owner_is_alive(*owner, pid_alive, start_time_of):
+                    continue  # a live owner — never reap
+            else:
+                # Unstamped: reap only if clearly not a sandbox mid-startup.
+                if now - os.path.getmtime(session_dir) < min_age_s:
+                    continue
             shutil.rmtree(session_dir)
             reaped.append(name)
         except OSError as error:  # best-effort; a busy dir is tried next time
@@ -114,6 +153,7 @@ def list_local_workspaces(
     *,
     now: float,
     pid_alive: Callable[[int], bool] = _pid_alive,
+    start_time_of: Callable[[int], Optional[str]] = process_start_time,
 ) -> List[WorkspaceInfo]:
     """Describe each session workspace under ``workspace_root`` (for the CLI)."""
     if not os.path.isdir(workspace_root):
@@ -121,15 +161,19 @@ def list_local_workspaces(
     infos: List[WorkspaceInfo] = []
     for name in sorted(os.listdir(workspace_root)):
         session_dir = os.path.join(workspace_root, name)
-        if not os.path.isdir(session_dir):
+        try:
+            if not os.path.isdir(session_dir):
+                continue
+            owner = _read_owner(session_dir)
+            if owner is not None:
+                pid: Optional[int] = owner[0]
+                alive = _owner_is_alive(*owner, pid_alive, start_time_of)
+            else:
+                pid, alive = None, False
+            age_s = now - os.path.getmtime(session_dir)
+        except OSError:  # vanished mid-scan — skip it, don't crash the listing
             continue
-        pid = _owner_pid(session_dir)
         infos.append(
-            WorkspaceInfo(
-                name=name,
-                pid=pid,
-                alive=pid_alive(pid) if pid is not None else False,
-                age_s=now - os.path.getmtime(session_dir),
-            )
+            WorkspaceInfo(name=name, pid=pid, alive=alive, age_s=age_s)
         )
     return infos

--- a/src/gimle/hugin/sandbox/reaper.py
+++ b/src/gimle/hugin/sandbox/reaper.py
@@ -1,0 +1,98 @@
+"""Out-of-band reaping of abandoned local sandbox workspaces.
+
+``Session.close`` cleans up on a clean exit, but it is skipped on an abrupt one
+— SIGKILL, an OOM-kill, a closed laptop lid — which is the common case. So the
+*primary* cleanup is this reaper: it runs at the start of every ``hugin``
+invocation and removes only workspaces whose owning process is gone, never a
+live peer's.
+
+A local sandbox stamps its session directory with the owning PID
+(``LocalSandbox`` writes ``OWNER_FILE`` on start). The reaper reaps a directory
+when that owner is no longer alive; a directory with no stamp is reaped only
+once it is older than ``min_age_s`` (so a sandbox mid-startup, before it has
+written its stamp, is never swept out from under itself). PID reuse can only
+make the reaper *keep* a dead workspace a while longer, never delete a live
+one — the safe direction to err.
+"""
+
+import json
+import logging
+import os
+import shutil
+from typing import Callable, List
+
+from gimle.hugin.sandbox.local import OWNER_FILE
+
+logger = logging.getLogger(__name__)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return whether a process with ``pid`` currently exists."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user
+    return True
+
+
+def _owner_pid(session_dir: str) -> "int | None":
+    """Read the owning PID from a session directory's stamp, or None."""
+    try:
+        with open(
+            os.path.join(session_dir, OWNER_FILE), encoding="utf-8"
+        ) as handle:
+            return int(json.load(handle)["pid"])
+    except (OSError, ValueError, KeyError):
+        return None
+
+
+def reap_local_workspaces(
+    workspace_root: str,
+    *,
+    now: float,
+    min_age_s: float = 30.0,
+    pid_alive: Callable[[int], bool] = _pid_alive,
+) -> List[str]:
+    """Remove abandoned session workspaces under ``workspace_root``.
+
+    Args:
+        workspace_root: Directory holding one subdirectory per session.
+        now: Current time (passed in for testability).
+        min_age_s: An unstamped directory younger than this is left alone.
+        pid_alive: Liveness check (injectable for tests).
+
+    Returns:
+        The names of the session directories that were removed.
+    """
+    if not os.path.isdir(workspace_root):
+        return []
+
+    reaped: List[str] = []
+    for name in os.listdir(workspace_root):
+        session_dir = os.path.join(workspace_root, name)
+        if not os.path.isdir(session_dir):
+            continue
+
+        pid = _owner_pid(session_dir)
+        if pid is not None:
+            if pid_alive(pid):
+                continue  # a live owner — never reap
+        else:
+            # No stamp: only reap if it's clearly not a sandbox mid-startup.
+            age = now - os.path.getmtime(session_dir)
+            if age < min_age_s:
+                continue
+
+        try:
+            shutil.rmtree(session_dir)
+            reaped.append(name)
+        except OSError as error:  # best-effort; a busy dir is tried next time
+            logger.debug("could not reap %s: %s", session_dir, error)
+
+    if reaped:
+        logger.info("reaped %d abandoned sandbox workspace(s)", len(reaped))
+    return reaped

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -1,0 +1,115 @@
+"""The ``Sandbox`` execution-backend protocol.
+
+A :class:`Sandbox` is *somewhere a command can run* — the host, a local
+container, or a remote machine. The protocol is deliberately narrow and mirrors
+the ``Storage`` ABC: a small surface, concrete backends beside it, no knowledge
+of agents or tools. Everything above this layer is backend-agnostic.
+
+Concrete backends (``LocalSandbox``, ``DockerSandbox``, ``SSHSandbox``) and the
+``create_sandbox`` factory land in later phases. This module defines only the
+shared types so the tool and the policy engine can be built and tested against
+a fake backend first.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from gimle.hugin.sandbox.policy import Policy
+
+
+class PolicyDenied(Exception):
+    """Raised inside ``Sandbox.exec`` when policy refuses a command.
+
+    Enforcement lives in the backend (not only in the tool) so that *every*
+    route to ``exec`` is checked by construction — a future tool or the harvest
+    layer cannot reach execution unchecked. The tool additionally calls
+    ``evaluate`` itself only to render a friendly result.
+    """
+
+    def __init__(self, reason: str) -> None:
+        """Record the human-readable ``reason`` the command was refused."""
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    """The outcome of running one command.
+
+    ``exit_code`` is the process's own status; a non-zero exit is data about
+    the process (``grep`` finding nothing exits 1), not necessarily an error.
+    The distinct failure surfaces the tool must tell apart are carried
+    explicitly: ``timed_out`` and ``oom_killed`` (policy denial and infra
+    failure are represented by ``PolicyDenied`` / raised exceptions, not here).
+    """
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_s: float
+    truncated: bool = False
+    timed_out: bool = False
+    oom_killed: bool = False
+
+
+@dataclass(frozen=True)
+class SandboxSpec:
+    """Which backend to run in, and its resource shape.
+
+    ``backend`` has no default — a config must name where its agent's shell
+    runs. The three backends are peers with no Docker dependency: ``local``
+    (no isolation, honest about it), ``docker`` (container boundary), ``ssh``
+    (the remote machine is the boundary). ``image`` applies to ``docker`` only;
+    ``host`` to ``ssh`` only; the resource knobs to the container backends only.
+    """
+
+    backend: Literal["local", "docker", "ssh"]
+    image: Optional[str] = None
+    host: Optional[str] = None
+    network: bool = False
+    cpu: float = 2.0
+    memory: str = "2g"
+    pids: int = 512
+
+
+class Sandbox(ABC):
+    """Somewhere a command can run. Backends implement this."""
+
+    @abstractmethod
+    def start(self) -> None:
+        """Create/pull/connect. Idempotent; called lazily on first ``exec``."""
+
+    @abstractmethod
+    def exec(
+        self,
+        command: str,
+        *,
+        policy: Policy,
+        cwd: str,
+        timeout_s: int,
+        max_output_bytes: int = 16_000,
+    ) -> ExecResult:
+        """Run ``command``.
+
+        The backend enforces ``policy`` before running and raises
+        :class:`PolicyDenied` on a violation (fail closed). It executes through
+        the same dialect the policy parsed (``bash -c``). It never raises for a
+        non-zero exit — that is reported in :class:`ExecResult`.
+        """
+
+    @abstractmethod
+    def workspace_for(self, agent_id: str, branch: Optional[str]) -> str:
+        """Absolute working directory for this ``(agent, branch)``; created."""
+
+    @abstractmethod
+    def put_file(self, path: str, content: bytes) -> None:
+        """Write ``content`` to ``path`` inside the workspace."""
+
+    @abstractmethod
+    def get_file(self, path: str) -> bytes:
+        """Read ``path`` from the workspace (realpath-confined, no symlink escape)."""
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Tear down. Idempotent; safe on an unstarted sandbox."""

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -13,9 +13,29 @@ a fake backend first.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Literal, Optional, Tuple
 
 from gimle.hugin.sandbox.policy import Policy
+
+
+def truncate_output(text: str, max_bytes: int) -> Tuple[str, bool]:
+    """Cap ``text`` at ``max_bytes``, tail-biased, with an elision marker.
+
+    Returns ``(text, truncated)``. The truncation keeps a small head (so the
+    reader sees where output began) and a larger tail — the actionable error
+    (a test failure, a traceback summary) is usually last. Shared by every
+    backend so the cap behaves identically regardless of where the command ran.
+    """
+    raw = text.encode("utf-8", "replace")
+    if len(raw) <= max_bytes:
+        return text, False
+    head_n = max_bytes // 5
+    tail_n = max_bytes - head_n
+    elided = len(raw) - head_n - tail_n
+    marker = f"\n[... {elided} bytes elided ...]\n"
+    head = raw[:head_n].decode("utf-8", "ignore")
+    tail = raw[len(raw) - tail_n :].decode("utf-8", "ignore")
+    return head + marker + tail, True
 
 
 class PolicyDenied(Exception):

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -12,8 +12,8 @@ a fake backend first.
 """
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Literal, Optional, Tuple
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Literal, Optional, Tuple
 
 from gimle.hugin.sandbox.policy import Policy
 
@@ -91,6 +91,51 @@ class SandboxSpec:
     cpu: float = 2.0
     memory: str = "2g"
     pids: int = 512
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SandboxSpec":
+        """Build a SandboxSpec from the ``options.bash`` block, failing loud.
+
+        The ``policy`` sub-block belongs to :class:`Policy`, so it is ignored
+        here; every other unknown key raises. ``backend`` is required — a config
+        must name where its agent's shell runs; there is no silent default.
+        """
+        if not isinstance(data, dict):
+            raise ValueError("options.bash must be a mapping")
+        known = {f.name for f in fields(cls)}
+        provided = {k: v for k, v in data.items() if k != "policy"}
+        unknown = set(provided) - known
+        if unknown:
+            raise ValueError(f"unknown sandbox keys: {sorted(unknown)}")
+        if "backend" not in provided:
+            raise ValueError(
+                "options.bash.backend is required (local | docker | ssh)"
+            )
+        if provided["backend"] not in ("local", "docker", "ssh"):
+            raise ValueError(f"invalid backend: {provided['backend']!r}")
+        return cls(**provided)
+
+
+def create_sandbox(
+    spec: SandboxSpec,
+    session_id: str,
+    workspace_root: str = "./storage/sandboxes",
+) -> "Sandbox":
+    """Construct the backend named by ``spec``.
+
+    The concrete backend is imported lazily so selecting ``local`` never pulls
+    in the ``docker`` SDK, and vice versa — the three backends are peers with
+    no shared dependency.
+    """
+    if spec.backend == "local":
+        from gimle.hugin.sandbox.local import LocalSandbox
+
+        return LocalSandbox(spec, session_id, workspace_root)
+    if spec.backend in ("docker", "ssh"):
+        raise NotImplementedError(
+            f"the {spec.backend} backend lands in phase 2"
+        )
+    raise ValueError(f"unknown backend: {spec.backend!r}")
 
 
 class Sandbox(ABC):

--- a/src/gimle/hugin/tools/__init__.py
+++ b/src/gimle/hugin/tools/__init__.py
@@ -2,6 +2,7 @@
 
 # Import tools to register them
 from gimle.hugin.tools.builtins.ask_user import ask_user  # noqa: F401
+from gimle.hugin.tools.builtins.bash import bash  # noqa: F401
 from gimle.hugin.tools.builtins.finish import finish_tool  # noqa: F401
 from gimle.hugin.tools.builtins.launch_agent import launch_agent  # noqa: F401
 from gimle.hugin.tools.builtins.list_agents import list_agents  # noqa: F401

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -38,11 +38,17 @@ files there — each call is a FRESH shell, so `cd`, `export`, `source`, and \
 background jobs do NOT carry over between calls. Use the `cwd` argument to run \
 in a subdirectory for a single call.
 
-Large output is truncated (tail-biased); the full output is written to \
-`.hugin/last_output.txt` in your workspace — inspect it with `rg` or `sed -n`. \
-A non-zero exit code is normal information (e.g. `grep` finding no matches), \
-not a tool failure. A command refused by policy comes back with a `denied` \
-reason — that is information, so try a permitted alternative."""
+Commands are killed after ~15s by default; pass a larger `timeout_s` for a \
+slow command (a build, a test run). Only the last few command outputs stay \
+visible to you — write anything you need to keep into a file.
+
+Large output is truncated (tail-biased); when that happens the response \
+carries a `full_output` path (`.hugin/last_output.txt`) holding the complete \
+output — inspect it with `rg` or `sed -n`. A non-zero exit code is normal \
+information (e.g. `grep` finding no matches), not a tool failure. A command \
+refused by policy comes back with a `denied` reason — try a permitted \
+alternative; an `unparseable` reason means the guard's parser choked, so \
+rephrase the command (avoid `[[ ]]`, `$(( ))`, arrays)."""
 
 
 @Tool.register(
@@ -59,6 +65,12 @@ reason — that is information, so try a permitted alternative."""
             "description": "Optional subdirectory of the workspace to run in.",
             "required": False,
         },
+        "timeout_s": {
+            "type": "integer",
+            "description": "Optional per-command timeout in seconds for a slow "
+            "command (default ~15s, capped by policy).",
+            "required": False,
+        },
     },
     is_interactive=False,
     options={
@@ -72,6 +84,7 @@ def bash(
     command: str,
     stack: Optional["Stack"] = None,
     cwd: Optional[str] = None,
+    timeout_s: Optional[int] = None,
     branch: Optional[str] = None,
 ) -> ToolResponse:
     """Run ``command`` in the agent's sandbox and map the outcome for the model.
@@ -80,11 +93,13 @@ def bash(
         command: The shell command to run.
         stack: Injected agent stack (gives config, session, env_vars, agent id).
         cwd: Optional workspace-relative subdirectory to run in.
+        timeout_s: Optional per-command timeout; clamped to the policy ceiling.
         branch: Injected branch, so branches get isolated working directories.
 
     Returns:
         A ToolResponse. ``is_error`` is set only for a policy denial, a timeout,
-        or an infrastructure failure — never for a plain non-zero exit.
+        an out-of-memory kill, or an infrastructure failure — never for a plain
+        non-zero exit.
     """
     if stack is None:
         return ToolResponse(
@@ -171,12 +186,17 @@ def bash(
             content={"error": f"cwd escapes the workspace: {cwd}"},
         )
 
+    requested_timeout = (
+        timeout_s
+        if timeout_s is not None and timeout_s > 0
+        else policy.timeout_s
+    )
     try:
         result = sandbox.exec(
             command,
             policy=policy,
             cwd=effective_cwd,
-            timeout_s=policy.timeout_s,
+            timeout_s=requested_timeout,  # sandbox clamps to policy.max_timeout_s
             max_output_bytes=policy.max_output_bytes,
         )
     except PolicyDenied as denied:  # backstop; pre-check should have caught it
@@ -277,16 +297,22 @@ def _resolve_cwd(workspace: str, cwd: Optional[str]) -> Optional[str]:
 
 def _to_response(command: str, result: ExecResult) -> ToolResponse:
     """Map an ExecResult to a ToolResponse (see the module docstring on errors)."""
+    content: Dict[str, Any] = {
+        "command": command,
+        "exit_code": result.exit_code,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "duration_s": round(result.duration_s, 3),
+        "truncated": result.truncated,
+        "timed_out": result.timed_out,
+        "oom_killed": result.oom_killed,
+    }
+    if result.truncated:
+        # Point the model at the spill so it can read past the cap instead of
+        # re-running with a guessed filter. Path is relative to the command cwd.
+        content["full_output"] = ".hugin/last_output.txt"
+    # An OOM kill returns partial output for a process that did not finish — it
+    # is an error the model must react to, like a timeout (not a plain exit).
     return ToolResponse(
-        is_error=result.timed_out,
-        content={
-            "command": command,
-            "exit_code": result.exit_code,
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-            "duration_s": round(result.duration_s, 3),
-            "truncated": result.truncated,
-            "timed_out": result.timed_out,
-            "oom_killed": result.oom_killed,
-        },
+        is_error=result.timed_out or result.oom_killed, content=content
     )

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -14,7 +14,14 @@ import os
 from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
 from gimle.hugin.sandbox.manager import SandboxManager
-from gimle.hugin.sandbox.policy import Allow, Deny, Escalate, Policy, evaluate
+from gimle.hugin.sandbox.policy import (
+    UNPARSEABLE_REASON,
+    Allow,
+    Deny,
+    Escalate,
+    Policy,
+    evaluate,
+)
 from gimle.hugin.sandbox.sandbox import ExecResult, PolicyDenied, SandboxSpec
 from gimle.hugin.tools.tool import Tool, ToolResponse
 
@@ -95,8 +102,32 @@ def bash(
             content={"error": f"invalid bash policy config: {error}"},
         )
 
+    # Resolve the manager up front so its audit exists even for a denial — the
+    # first (or only) command in a session may be denied, and a denied command
+    # is exactly the security event worth recording. A bad/missing backend is
+    # tolerated here and only reported when a command is actually allowed.
+    try:
+        manager: Optional[SandboxManager] = _resolve_manager(stack, bash_opts)
+        manager_error: Optional[str] = None
+    except (ValueError, NotImplementedError) as error:
+        manager, manager_error = None, str(error)
+
     decision = evaluate(command, policy)
     if isinstance(decision, Deny):
+        if decision.reason == UNPARSEABLE_REASON:
+            # A parser limitation, NOT a policy refusal — tell the model to
+            # rephrase rather than to try a different (permitted) command.
+            _record(stack, command, "unparseable", reason=decision.reason)
+            return ToolResponse(
+                is_error=True,
+                content={
+                    "unparseable": decision.reason,
+                    "command": command,
+                    "hint": "the policy guard uses a limited bash parser; "
+                    "rephrase without [[ ]], $(( )), or arrays "
+                    "(use [ ], test, or expr)",
+                },
+            )
         _record(stack, command, "denied", reason=decision.reason)
         return ToolResponse(
             is_error=True,
@@ -111,15 +142,22 @@ def bash(
             content={
                 "needs_approval": decision.reason,
                 "command": command,
-                "note": "human approval is not available in this session",
+                "note": "human approval is unavailable in this session and "
+                "will not become available; do not retry — choose a "
+                "different approach",
             },
         )
     assert isinstance(decision, Allow)
 
+    if manager is None:
+        return ToolResponse(
+            is_error=True,
+            content={"error": f"sandbox unavailable: {manager_error}"},
+        )
     try:
-        manager = _resolve_manager(stack, bash_opts)
         sandbox = manager.get()
     except (ValueError, NotImplementedError) as error:
+        _record(stack, command, "infra_error", reason=str(error))
         return ToolResponse(
             is_error=True,
             content={"error": f"sandbox unavailable: {error}"},

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -97,6 +97,7 @@ def bash(
 
     decision = evaluate(command, policy)
     if isinstance(decision, Deny):
+        _record(stack, command, "denied", reason=decision.reason)
         return ToolResponse(
             is_error=True,
             content={"denied": decision.reason, "command": command},
@@ -104,6 +105,7 @@ def bash(
     if isinstance(decision, Escalate):
         # Human-approval routing lands in phase 3; until then, refuse cleanly
         # rather than run an out-of-policy command.
+        _record(stack, command, "escalated", reason=decision.reason)
         return ToolResponse(
             is_error=True,
             content={
@@ -140,17 +142,29 @@ def bash(
             max_output_bytes=policy.max_output_bytes,
         )
     except PolicyDenied as denied:  # backstop; pre-check should have caught it
+        _record(stack, command, "denied", reason=denied.reason)
         return ToolResponse(
             is_error=True,
             content={"denied": denied.reason, "command": command},
         )
     except Exception as error:  # infrastructure failure (daemon down, etc.)
         logger.warning("bash infra failure: %s", error)
+        _record(stack, command, "infra_error", reason=str(error))
         return ToolResponse(
             is_error=True,
             content={"infra_error": str(error), "command": command},
         )
 
+    _record(
+        stack,
+        command,
+        "timed_out" if result.timed_out else "run",
+        exit_code=result.exit_code,
+        duration_s=round(result.duration_s, 3),
+        truncated=result.truncated,
+        timed_out=result.timed_out,
+        oom_killed=result.oom_killed,
+    )
     return _to_response(command, result)
 
 
@@ -169,9 +183,48 @@ def _resolve_manager(
     if manager is not None:
         return cast(SandboxManager, manager)
     spec = SandboxSpec.from_dict(bash_opts)
-    manager = SandboxManager(spec, session.id)
+    manager = SandboxManager(spec, session.id, record_audit_to_file=True)
     session.sandbox = manager
     return manager
+
+
+def _record(
+    stack: "Stack",
+    command: str,
+    outcome: str,
+    *,
+    exit_code: Optional[int] = None,
+    duration_s: Optional[float] = None,
+    truncated: bool = False,
+    timed_out: bool = False,
+    oom_killed: bool = False,
+    reason: Optional[str] = None,
+) -> None:
+    """Record an outcome in the session's audit, if a sandbox manager exists.
+
+    Denials can happen before the manager is built (no command has run yet); in
+    that rare case there is nothing to record to, so this is a no-op. Recording
+    is best-effort and must never disrupt the command result.
+    """
+    session = stack.agent.session
+    manager = getattr(session, "sandbox", None)
+    if manager is None:
+        return
+    try:
+        manager.audit.record(
+            session_id=session.id,
+            agent_id=stack.agent.id,
+            command=command,
+            outcome=outcome,
+            exit_code=exit_code,
+            duration_s=duration_s,
+            truncated=truncated,
+            timed_out=timed_out,
+            oom_killed=oom_killed,
+            reason=reason,
+        )
+    except Exception as error:  # audit must never break the tool
+        logger.debug("audit record failed: %s", error)
 
 
 def _resolve_cwd(workspace: str, cwd: Optional[str]) -> Optional[str]:

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -159,16 +159,18 @@ def _resolve_manager(
 ) -> SandboxManager:
     """Return the session's SandboxManager, creating and caching it if absent.
 
-    A pre-seeded ``env_vars['sandbox']`` (an app, or a test) wins; otherwise the
-    manager is built from ``options.bash`` and cached for the session.
+    The session owns the sandbox (``session.sandbox``) so there is a single,
+    typed owner that ``Session.close`` can tear down — a pre-created one (an
+    app, or a test) wins; otherwise it is built from ``options.bash`` and
+    cached on the session.
     """
-    env_vars = stack.agent.environment.env_vars
-    manager = env_vars.get("sandbox")
+    session = stack.agent.session
+    manager = getattr(session, "sandbox", None)
     if manager is not None:
         return cast(SandboxManager, manager)
     spec = SandboxSpec.from_dict(bash_opts)
-    manager = SandboxManager(spec, stack.agent.session.id)
-    env_vars["sandbox"] = manager
+    manager = SandboxManager(spec, session.id)
+    session.sandbox = manager
     return manager
 
 

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -1,0 +1,199 @@
+"""The ``bash`` builtin: run a shell command in the agent's sandbox.
+
+The tool resolves the policy and backend from ``config.options["bash"]``,
+pre-checks the command with the policy engine (to render a friendly refusal),
+then runs it through the session's sandbox. The mapping to ``ToolResponse`` is
+deliberate about *what an error is to the model*: only a policy denial, a
+timeout, or an infrastructure failure set ``is_error``. A process that ran to
+completion is not an error even if it exited non-zero — ``grep`` finding
+nothing exits 1, and flagging that as a failure just makes the model thrash.
+"""
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+
+from gimle.hugin.sandbox.manager import SandboxManager
+from gimle.hugin.sandbox.policy import Allow, Deny, Escalate, Policy, evaluate
+from gimle.hugin.sandbox.sandbox import ExecResult, PolicyDenied, SandboxSpec
+from gimle.hugin.tools.tool import Tool, ToolResponse
+
+if TYPE_CHECKING:
+    from gimle.hugin.interaction.stack import Stack
+
+logger = logging.getLogger(__name__)
+
+_DESCRIPTION = """Run a shell command and return its stdout, stderr, and exit \
+code.
+
+Working directory: your private per-agent workspace. Persist state by writing \
+files there — each call is a FRESH shell, so `cd`, `export`, `source`, and \
+background jobs do NOT carry over between calls. Use the `cwd` argument to run \
+in a subdirectory for a single call.
+
+Large output is truncated (tail-biased); the full output is written to \
+`.hugin/last_output.txt` in your workspace — inspect it with `rg` or `sed -n`. \
+A non-zero exit code is normal information (e.g. `grep` finding no matches), \
+not a tool failure. A command refused by policy comes back with a `denied` \
+reason — that is information, so try a permitted alternative."""
+
+
+@Tool.register(
+    name="builtins.bash",
+    description=_DESCRIPTION,
+    parameters={
+        "command": {
+            "type": "string",
+            "description": "The shell command to run.",
+            "required": True,
+        },
+        "cwd": {
+            "type": "string",
+            "description": "Optional subdirectory of the workspace to run in.",
+            "required": False,
+        },
+    },
+    is_interactive=False,
+    options={
+        # Old bash output falls out of context (this knob actually drops it,
+        # unlike reduced_context_window which only reformats DataFrames).
+        "include_only_in_context_window": True,
+        "context_window": 5,
+    },
+)
+def bash(
+    command: str,
+    stack: Optional["Stack"] = None,
+    cwd: Optional[str] = None,
+    branch: Optional[str] = None,
+) -> ToolResponse:
+    """Run ``command`` in the agent's sandbox and map the outcome for the model.
+
+    Args:
+        command: The shell command to run.
+        stack: Injected agent stack (gives config, session, env_vars, agent id).
+        cwd: Optional workspace-relative subdirectory to run in.
+        branch: Injected branch, so branches get isolated working directories.
+
+    Returns:
+        A ToolResponse. ``is_error`` is set only for a policy denial, a timeout,
+        or an infrastructure failure — never for a plain non-zero exit.
+    """
+    if stack is None:
+        return ToolResponse(
+            is_error=True, content={"error": "bash requires an agent stack"}
+        )
+
+    config = stack.agent.config
+    bash_opts = dict(getattr(config, "options", {}) or {}).get("bash") or {}
+
+    try:
+        policy = Policy.from_dict(bash_opts.get("policy"))
+    except ValueError as error:
+        return ToolResponse(
+            is_error=True,
+            content={"error": f"invalid bash policy config: {error}"},
+        )
+
+    decision = evaluate(command, policy)
+    if isinstance(decision, Deny):
+        return ToolResponse(
+            is_error=True,
+            content={"denied": decision.reason, "command": command},
+        )
+    if isinstance(decision, Escalate):
+        # Human-approval routing lands in phase 3; until then, refuse cleanly
+        # rather than run an out-of-policy command.
+        return ToolResponse(
+            is_error=True,
+            content={
+                "needs_approval": decision.reason,
+                "command": command,
+                "note": "human approval is not available in this session",
+            },
+        )
+    assert isinstance(decision, Allow)
+
+    try:
+        manager = _resolve_manager(stack, bash_opts)
+        sandbox = manager.get()
+    except (ValueError, NotImplementedError) as error:
+        return ToolResponse(
+            is_error=True,
+            content={"error": f"sandbox unavailable: {error}"},
+        )
+
+    workspace = sandbox.workspace_for(stack.agent.id, branch)
+    effective_cwd = _resolve_cwd(workspace, cwd)
+    if effective_cwd is None:
+        return ToolResponse(
+            is_error=True,
+            content={"error": f"cwd escapes the workspace: {cwd}"},
+        )
+
+    try:
+        result = sandbox.exec(
+            command,
+            policy=policy,
+            cwd=effective_cwd,
+            timeout_s=policy.timeout_s,
+            max_output_bytes=policy.max_output_bytes,
+        )
+    except PolicyDenied as denied:  # backstop; pre-check should have caught it
+        return ToolResponse(
+            is_error=True,
+            content={"denied": denied.reason, "command": command},
+        )
+    except Exception as error:  # infrastructure failure (daemon down, etc.)
+        logger.warning("bash infra failure: %s", error)
+        return ToolResponse(
+            is_error=True,
+            content={"infra_error": str(error), "command": command},
+        )
+
+    return _to_response(command, result)
+
+
+def _resolve_manager(
+    stack: "Stack", bash_opts: Dict[str, Any]
+) -> SandboxManager:
+    """Return the session's SandboxManager, creating and caching it if absent.
+
+    A pre-seeded ``env_vars['sandbox']`` (an app, or a test) wins; otherwise the
+    manager is built from ``options.bash`` and cached for the session.
+    """
+    env_vars = stack.agent.environment.env_vars
+    manager = env_vars.get("sandbox")
+    if manager is not None:
+        return cast(SandboxManager, manager)
+    spec = SandboxSpec.from_dict(bash_opts)
+    manager = SandboxManager(spec, stack.agent.session.id)
+    env_vars["sandbox"] = manager
+    return manager
+
+
+def _resolve_cwd(workspace: str, cwd: Optional[str]) -> Optional[str]:
+    """Resolve ``cwd`` inside ``workspace``; None if it escapes."""
+    if not cwd:
+        return workspace
+    candidate = os.path.normpath(os.path.join(workspace, cwd))
+    if candidate == workspace or candidate.startswith(workspace + os.sep):
+        return candidate
+    return None
+
+
+def _to_response(command: str, result: ExecResult) -> ToolResponse:
+    """Map an ExecResult to a ToolResponse (see the module docstring on errors)."""
+    return ToolResponse(
+        is_error=result.timed_out,
+        content={
+            "command": command,
+            "exit_code": result.exit_code,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "duration_s": round(result.duration_s, 3),
+            "truncated": result.truncated,
+            "timed_out": result.timed_out,
+            "oom_killed": result.oom_killed,
+        },
+    )

--- a/tasks/open/023-bash-tool/description.md
+++ b/tasks/open/023-bash-tool/description.md
@@ -1,0 +1,172 @@
+---
+title: Bash tool with pluggable execution sandbox
+state: OPEN
+labels: [enhancement, tools, security]
+priority: high
+created: 2026-07-13
+---
+
+# Bash tool with pluggable execution sandbox
+
+Give Hugin agents the ability to run shell commands, with the execution
+backend pluggable: directly on the host, in a local container, or on a
+remote machine. Nothing in `src/gimle/hugin` currently shells out — no
+`subprocess`, no docker, no ssh — so this is greenfield.
+
+## Why
+
+A shell is the universal escape hatch. Today every capability an agent needs
+must be anticipated and hand-built as a tool (`read_file`, `list_files`,
+`search_files`, ...). With `bash`, capable models can explore, inspect,
+transform and build without the tool registry having to predict what they
+will want. It also unlocks the whole class of agents Hugin currently cannot
+express: anything that touches a repo, a build, a data file, or a CLI.
+
+The cost is that a shell is also the universal footgun, so the isolation and
+policy story has to be part of the design from the first commit rather than
+bolted on later.
+
+## The core framing: bash is three features, not one
+
+Keeping these orthogonal is the single most important design decision.
+Conflating them is what turns this into a mess.
+
+1. **Execution backend — *where* the process runs.** A narrow `Sandbox`
+   protocol (`exec` / `put_file` / `get_file` / `start` / `stop`), mirroring
+   the existing `Storage` ABC, with `LocalSandbox`, `DockerSandbox` and
+   `SSHSandbox` as implementations. Nothing above this layer knows which
+   backend it got.
+
+2. **Policy — *what* is allowed.** Allow/deny lists, path scoping, network
+   on/off, timeouts, output caps, and escalation-to-human. A pure function
+   over a parsed command: `evaluate(command, policy) -> Allow | Deny | Escalate`.
+
+3. **Workspace — *what is on the filesystem* when the command runs.** Image
+   contents, directory layout, what (if anything) Hugin projects into it.
+   This is the only genuinely novel piece; see `notes.md`.
+
+## Decisions taken
+
+> These were revised after a four-role panel review. See `review.md` for the
+> findings and why each decision landed where it did.
+
+- **The isolation boundary is whichever backend you choose — not the allowlist.**
+  A command-word allowlist stops meaning anything the moment an interpreter is on
+  it (`python3 -c '...'`, `awk 'BEGIN{system()}'`, `git -c core.pager='!sh'`),
+  and the command is composed by the LLM from untrusted input, so injection walks
+  straight through it. The allowlist is therefore never *sold* as isolation on
+  any backend. What actually contains a confused-or-injected agent is the runtime
+  you picked: a container, a disposable remote machine, or — if you chose
+  `local` — nothing, stated plainly.
+
+- **The three backends are peers; none is privileged and there is no Docker
+  dependency.** The package installs and `bash` works with `bashlex` alone. The
+  `docker` SDK is an optional extra pulled only when you select that backend;
+  `ssh` shells out to the `ssh` binary and needs no library. A config must name
+  its backend — there is no silent default that decides *where your agent's shell
+  runs* for you.
+  - `local` — runs on the host. **No isolation boundary.** The policy is an
+    accident-guard only, and the knobs a bare subprocess can't enforce
+    (`network`, `cpu`, `memory`) *raise* rather than silently no-op — a control
+    that lies is worse than an absent one. Legitimate for iterating and trusted
+    tasks; `examples/bash_agent` uses it so the example needs zero infra.
+  - `docker` — a local container boundary (`--network=none`, `--cap-drop=ALL`,
+    `no-new-privileges`, read-only root, `noexec` tmpfs, userns-remap, caps).
+  - `ssh` — the **remote machine itself is the boundary**; the design steers you
+    to a disposable VPS you don't mind the agent breaking, ideally a container on
+    it. First-class, not an afterthought to Docker.
+
+- Inside a real boundary (container or disposable remote) the policy can be
+  *permissive* — a blunt denylist for accidents — because the runtime, not the
+  wordlist, is what contains the agent.
+
+- **Sandbox scope: worktree hybrid.** One sandbox per `Session`; one working
+  directory per `(agent, branch)` inside it, plus a shared `/workspace/common/`
+  for deliberate hand-offs. (Keying by agent alone collides concurrent branches
+  and starves delegated sub-agents — see `review.md`.) This is the worktree
+  pattern `CLAUDE.md` already prescribes for parallel Claude agents, applied one
+  level down. Note the honest limit: all agents in a session share one container
+  uid and filesystem, so they share a trust level.
+
+- **`Session` owns the sandbox, and teardown is Phase 1.** A typed, lazily-created
+  `session.sandbox` (not an `env_vars` convention a builtin can't satisfy),
+  with `Session.close()` and out-of-band reaping landing in Phase 1 — the local
+  backend already leaks process groups and workspace dirs, and a remote box
+  leaks orphaned jobs, so cleanup can't wait for a later backend.
+
+- **v1 is bash-only against a plain workspace — but the tool description carries
+  the environment.** The task, memory and results reach the agent as they do
+  today. The Pi-style projection/harvest layer is deferred (parked in
+  `notes.md`). But the ~10-line "what's on this box, what's allowed, the shell is
+  stateless" text goes in the tool description from day one — it's the cheapest,
+  highest-value thing in the whole design and needs none of the phase-5 machinery.
+
+## Threat model (be honest about it)
+
+A deny-list matched against a bash *string* is not a security boundary. Neither
+is an *allowlist* once an interpreter is on it: `python3 -c`, `uv run`,
+`awk 'BEGIN{system()}'`, `find -exec`, `git -c core.pager='!sh'`,
+`sed` with the `e` flag, `curl file://` all reach arbitrary execution or file
+access without ever using `eval`/`$()`/`bash -c`. And because the command is
+composed by the LLM from untrusted content (repo files, `curl` output), a
+prompt-injected instruction reaches execution *entirely within policy*. So:
+
+- **The runtime you choose is the boundary — a container or a disposable remote,
+  or none.** The `docker` backend hardens the container (`--network=none`,
+  `--cap-drop=ALL`, `--security-opt=no-new-privileges`, read-only root, `noexec`
+  tmpfs, non-root + userns-remap, cpu/mem/pid caps, no docker socket, no host
+  mounts beyond the workspace, `HOME`=workspace, no secrets in the env). The
+  `ssh` backend leans on the remote machine being disposable. Injection is
+  contained by *whichever* of these you picked — or, on `local`, not at all.
+- **The policy engine is a guardrail against accidents, not a boundary.** It's
+  permissive-by-default (blunt denylist: `rm -rf`, `git push --force`, raw writes
+  to `/dev`) and is never sold as isolation on any backend.
+- **The `local` backend has no boundary at all** and says so — no Docker required
+  to run it, and no pretence that it isolates anything.
+
+Consequences for the design: policy is enforced against a *parsed* command (AST
+walk), fails closed on parse failure, is enforced *inside* `Sandbox.exec` (not
+only in the tool) so every caller is checked by construction, and the command is
+run through the same dialect it was parsed as (`bash -c`, not `/bin/sh`).
+
+## Success criteria
+
+- [ ] The package installs and `bash` runs with **no Docker present** (local
+      backend, `bashlex` only); selecting `backend: docker` or `ssh` is an
+      additive choice, not a prerequisite
+- [ ] A config must name its backend; there is no silent default deciding where
+      the agent's shell runs
+- [ ] With `backend: docker`, an agent runs `bash` with no network and no host
+      filesystem access beyond the workspace; a denied command is a clean
+      `ToolResponse` it can recover from
+- [ ] `python3 -c 'os.system("id")'`, `awk 'BEGIN{system(...)}'` and
+      `git -c core.pager='!sh'` are contained by the chosen runtime (container or
+      disposable remote), *not* by the allowlist, and the design nowhere claims
+      the allowlist stopped them
+- [ ] The `local` backend's unenforceable knobs (`network`/`cpu`/`memory`) raise
+      rather than silently no-op, and it is documented as offering no isolation
+- [ ] Two agents in one session get isolated `(agent, branch)` working
+      directories and can hand off through `/workspace/common/`; two branches of
+      one agent do not collide
+- [ ] Policy engine is a pure function with table-driven tests, including the
+      interpreter bypasses (`python3 -c`, `find -exec`, `awk system()`,
+      `git -c`), wrapper binaries (`timeout`/`env`/`xargs`), assignment prefixes
+      (`LD_PRELOAD`), path escape, and parse failure
+- [ ] Command output cannot blow up the context window — verified against the
+      *actual* knob (`include_only_in_context_window`, not `reduced_context_window`,
+      which does not drop stdout)
+- [ ] The tool description tells the agent the workspace layout, installed tools,
+      "no network", the stateless-shell contract, and the policy-derived
+      allow/deny line — generated from the `Policy` so it cannot drift
+- [ ] Sandboxes self-heal: every non-clean exit (SIGTERM, SIGKILL, sleep) is
+      reaped within one TTL by a dead-owner-scoped reaper, and `Session.close()`
+      lands with the local backend in Phase 1
+- [ ] A structured command audit log + counters exist from Phase 1
+
+## Relationship to other tasks
+
+- **005-builtin-tools** — `bash` subsumes several of the candidates there. Once
+  this lands, revisit which file-oriented builtins are still worth having.
+  (Current position: keep structured tools where the framework needs to
+  *observe, validate or persist* a result; use bash for exploration and
+  mechanical work.)

--- a/tasks/open/023-bash-tool/notes.md
+++ b/tasks/open/023-bash-tool/notes.md
@@ -1,0 +1,76 @@
+# Notes: the harness blend (parked for phase 5)
+
+The open question behind this task is bigger than the tool: **are we moving
+toward a blend of a Pi-like harness — markdown files and bash commands — and
+the traditional tool-calling setup?** v1 deliberately does not answer it. This
+file keeps the thinking so it isn't lost.
+
+## What "the blend" actually means
+
+Treat the filesystem as a shared, inspectable medium between the framework and
+the agent, in two directions:
+
+- **Down (framework → files, read-only projection).** The task, prior
+  artifacts, insights and sub-agent results get rendered into the workspace as
+  markdown. The agent can `grep memory/` instead of calling `query_artifacts`
+  — often cheaper, always more expressive.
+- **Up (files → framework, harvest at explicit boundaries).** Whatever the
+  agent leaves in `outbox/` becomes an `Artifact` at the end of the tool call
+  or the end of the agent.
+
+Sketch:
+
+```
+/workspace/
+  TASK.md              # projected (ro) — the task definition
+  ENVIRONMENT.md       # projected (ro) — what's installed, what's allowed
+  memory/*.md          # projected (ro) — artifacts, insights
+  outbox/              # harvested → Artifacts
+  common/              # cross-agent hand-offs
+  agents/<id>/         # per-agent cwd
+```
+
+## The one rule that keeps it coherent
+
+**One direction of authority per object.** Storage is authoritative for
+projected things and the files are a *render*, regenerated per turn. The
+filesystem is authoritative for harvested things and nothing else writes them.
+
+If both sides can write the same object, artifacts will drift between storage
+and disk and we will spend a month on reconciliation. Enforce it structurally:
+the projection mount is genuinely read-only, not read-only by convention.
+
+## Why it's worth doing at all
+
+`bash` is a universal escape hatch, so the tool registry stops needing to
+anticipate everything — `read_file`, `list_files` and `search_files` largely
+collapse into it for capable models.
+
+But structured tools keep two advantages bash never gets:
+
+1. **Typed arguments** the model can't fumble.
+2. **Results that land in the stack as inspectable interactions**, rather than
+   as an opaque stdout blob that `hugin monitor` cannot visualise.
+
+So the end state isn't "replace tools with bash". It's:
+
+> **bash for exploration and mechanical work; structured tools wherever the
+> framework needs to observe, validate or persist the result.**
+
+That line is what should drive the follow-up to task 005 (which builtins are
+still worth having).
+
+## Open questions for phase 5
+
+- Does the projection regenerate every turn, or only when storage changes?
+  (Every turn is simpler and probably fast enough; measure before optimising.)
+- Is `ENVIRONMENT.md` generated from the `Policy` object, so the agent's map of
+  what it may run can never drift from what it actually may run? (Strongly
+  suspect yes — a hand-written description of the allowlist *will* rot.)
+- Does the harvest run at the tool-call boundary or the agent boundary? The
+  tool-call boundary gives faster feedback; the agent boundary gives cleaner
+  semantics.
+- What does the *system prompt* say? Giving an agent bash without telling it
+  what is on the box is a recipe for a dozen wasted turns of `which`. This is
+  the same problem `ENVIRONMENT.md` solves — the projection and the prompt
+  should share a source.

--- a/tasks/open/023-bash-tool/plan.md
+++ b/tasks/open/023-bash-tool/plan.md
@@ -1,0 +1,139 @@
+# Plan
+
+Re-sliced after panel review (`review.md`), then adjusted per direction:
+**no Docker dependency — the three backends (`local`, `docker`, `ssh`) are
+peers and none is privileged.** So Phase 1 ships the whole vertical on the
+zero-dependency `local` backend (installs and runs with `bashlex` alone), and
+the isolation backends (`docker`, `ssh`) follow in Phase 2 as additive choices.
+The moves that survived the review unchanged: **lifecycle, reaping and
+observability are in Phase 1** (the local backend leaks process groups and
+workspace dirs from the first commit), and **background exec moves up to
+Phase 2** (the synchronous freeze is the worst operational property, not a
+phase-6 nicety). Work each phase in its own worktree per `CLAUDE.md`.
+
+> **Residual risk to weigh:** the first shippable backend (`local`) has no
+> isolation. That's acceptable only while bash is used for examples and trusted
+> tasks. If bash needs to run untrusted work before Phase 2 lands, pull the
+> `docker` backend forward into Phase 1. Flagged for a call.
+
+## Phase 0 — Prerequisite check: one tool call per turn
+
+`anthropic.py:125` keeps only the last `tool_use` block. Bash agents batch, so
+this silently drops calls.
+
+- [ ] Land the >1-`tool_use` detection + explicit error for dropped calls (a
+      small, safe change) OR confirm task 006 lands first
+- [ ] Decide whether full multi-tool-call support (006) blocks bash GA — it
+      strongly shapes bash UX
+
+**Rationale:** without this, every bash exploration step is a silent-data-loss
+risk. It's cheap; do it first.
+
+## Phase 1 — Core vertical on the zero-dependency `local` backend
+
+The whole feature end-to-end with no Docker and no daemon — the package installs
+and `bash` runs with `bashlex` alone. Honest labeling throughout: no allowlist
+theatre, the `local` backend documented as offering no isolation.
+
+- [ ] `sandbox/sandbox.py` — `Sandbox` ABC, `ExecResult`, `SandboxSpec`
+      (backend has **no default — must be named**), `create_sandbox()` with
+      up-front backend validation and a remediation error
+- [ ] `sandbox/policy.py` — `Policy` (denylist default, permissive because the
+      boundary is the runtime), `evaluate()`, `Policy.from_dict` (reject unknown
+      keys, fail loud); bashlex AST walk that descends into wrapper binaries and
+      rejects dangerous assignment prefixes; fail closed on parse failure;
+      enforcement raises `PolicyDenied`
+- [ ] `sandbox/local.py` — `LocalSandbox`; boundary-only knobs
+      (`network`/`cpu`/`memory`/`pids`) raise; `HOME`=workspace; env scrubbed;
+      process-group kill on timeout; documented as no-isolation
+- [ ] `sandbox/manager.py` — `SandboxManager`; `workspace_for(agent, branch)`;
+      config→Policy/Spec resolution with key-level-merge precedence
+- [ ] `sandbox/reaper.py` — dead-owner/stale reaping at every `hugin`
+      invocation; workspace-dir GC; never kills a live peer
+- [ ] `sandbox/audit.py` — append-only command log + counters
+- [ ] **`Session.close()` + `Session.__enter__/__exit__`** — the teardown seam
+      that doesn't exist today; SIGTERM/SIGINT handler; wired into CLI, TUI, and
+      app `finally`s
+- [ ] `sandbox/fake.py` — `FakeSandbox`
+- [ ] `tools/builtins/bash.py` — the tool; policy-derived description carrying
+      the environment; tail-biased truncation + spill file; `is_error` only for
+      denial/timeout/infra; `include_only_in_context_window`; no `include_reason`,
+      no `timeout` param; deferral via `response_interaction`
+- [ ] `hugin sandbox list|prune` CLI (dead-owner-scoped)
+- [ ] Tests: policy bypasses (interpreter/wrapper/assignment/path/parse);
+      tool against `FakeSandbox`; reaper; local process-group kill; env scrub;
+      multi-agent/multi-branch workspaces
+- [ ] `bashlex` → core deps; CLAUDE.md bash section
+- [ ] `examples/bash_agent/` — smallest working agent, `backend: local`, with a
+      comment stating the example accepts no isolation
+
+**Done when:** the package installs with no Docker, an agent runs bash on the
+local backend, a denial is a recoverable `ToolResponse`, nothing claims the
+allowlist is a boundary, and any non-clean exit self-heals within one TTL.
+
+## Phase 2 — Isolation backends + the freeze fix
+
+The additive isolation choices, plus the concurrency fix. Any of these can be
+pulled into Phase 1 if bash must run untrusted work sooner (see residual risk).
+
+- [ ] `sandbox/docker.py` — `docker` backend, **lazy `docker`-SDK import** so it's
+      never needed unless selected; **all** hardening flags (`--cap-drop=ALL`,
+      `--security-opt=no-new-privileges`, `noexec` tmpfs, `--init`, userns-remap,
+      caps, session-keyed volume, `HOME`=workspace, empty env, labels + heartbeat)
+- [ ] `docker/sandbox.Dockerfile` — pinned-by-digest thick image; scanned;
+      built once; no credentials, no Hugin source; `docker` → `sandbox` extra
+- [ ] `sandbox/ssh.py` — `ssh` backend (shell-out, no `paramiko`); throwaway key;
+      `ForwardAgent=no`/`BatchMode=yes`/`ConnectTimeout`/`ServerAliveInterval`;
+      remote command under `systemd-run`/`timeout`/tmux so Hugin kills the remote
+      job; ControlMaster socket owned + cleaned in `stop()`. (Secrets /
+      provisioning / cost story written first.)
+- [ ] Background exec: `bash` returns `ToolResponse(response_interaction=Waiting)`
+      for long commands; `bash_output` poll tool; subprocess runs off the step
+      thread so a 120s build stops freezing siblings
+- [ ] `AgentCall` `inherit_workspace` option so delegated children start
+      populated
+- [ ] `network: true` egress control (block link-local/metadata/RFC1918; proxy
+      allowlist)
+- [ ] Persistent shell per agent (pexpect) so `cd`/`export`/`source` persist —
+      or, if deferred, remove `cd` from allowlist and bold the stateless contract
+- [ ] Tests: docker hardening asserted + containment of
+      `python3 -c 'os.system(...)'` (`slow`, skipped without a daemon)
+
+**Done when:** the same config runs unchanged with `backend: docker` (contained,
+no network) or `backend: ssh` (disposable remote), and `financial_newspaper`
+runs a real build without freezing the edition.
+
+## Phase 3 — Human escalation
+
+- [ ] `on_violation: ask_human` → `ToolResponse(response_interaction=AskHuman)`
+      (the correct pattern; a bare `AskHuman` raises)
+- [ ] Degrade to `deny` when the session is non-interactive (else the agent
+      parks forever)
+- [ ] Escalation shows *capabilities/effects*, not a raw base64 string;
+      approve-once is scoped to an exact command hash, never "allow this binary"
+- [ ] Surface pending command in `hugin interactive` / `monitor`
+
+**Done when:** an out-of-policy command asks rather than fails, and a
+non-interactive run degrades cleanly.
+
+> The `ssh`/remote backend lives in Phase 2 alongside `docker` (both are
+> additive isolation choices). Its harder sub-problems — idempotency across a
+> mid-command partition, and the secrets/provisioning/ownership/cost story —
+> must be written up before that code is built, not during.
+
+## Phase 4 — The harness blend (spin out as its own task)
+
+Projection down (`TASK.md`, `ENVIRONMENT.md` — generated from `Policy` —,
+`memory/*.md`, read-only) and harvest up (`outbox/` → `Artifact`s, with
+`realpath`/`O_NOFOLLOW` confinement). Design task, written *after* watching
+real agents use phases 1–2. Parked in `notes.md`.
+
+## Review
+
+Per `CLAUDE.md`, re-run `/panel-review` on the Phase 1 *implementation* before
+merge — this is security-sensitive and the policy engine is exactly the kind of
+thing that looks right and isn't. For Phase 2, the security judge's containment
+test is the acceptance gate for each isolation backend: `python3 -c
+'os.system("id")'` must be *contained by the runtime* (the container, or the
+disposable remote) — provably, not merely denied — while the docs never claim
+the allowlist stopped it.

--- a/tasks/open/023-bash-tool/review.md
+++ b/tasks/open/023-bash-tool/review.md
@@ -1,0 +1,221 @@
+# Panel review — verdict and resolutions
+
+A four-role panel (security engineer, framework architect, agent/harness
+designer, SRE/ops) reviewed the v1 design. The architecture survived; five
+load-bearing claims did not. This file records what they found and how the
+design changed in response. `description.md`, `spec.md` and `plan.md` have been
+revised to match; this file is the "why".
+
+## What survived
+
+Backend / policy / workspace as three orthogonal features; the `Sandbox` ABC
+mirroring `Storage`; fail-closed command parsing; deferring the harness blend
+until an agent has been observed using bash.
+
+## The keystone reframe: the container is the boundary, not the allowlist
+
+Three of four judges independently found that `DEFAULT_ALLOW` was security
+theatre. It contained `python3 uv git awk sed find curl` — each a general
+code-execution or network hatch the AST walk never looks inside — so
+`python3 -c 'os.system(...)'` passed cleanly while `mkdir` was denied. The
+allowlist was *inverted safety*: maximal friction on harmless commands, zero
+protection on harmful ones. And nothing modelled that the command is composed
+by the LLM from untrusted input (files, `curl` output), so an allowlisted
+interpreter is a direct pipe from an injected instruction to execution.
+
+Resolution, which collapses the security *and* usability critiques together:
+
+- **The isolation boundary is the runtime you choose, not the allowlist.** The
+  allowlist is never sold as isolation on any backend. What contains a
+  confused-or-injected agent is a container, a disposable remote machine, or —
+  on `local` — nothing, stated plainly.
+- **Inside a real boundary, policy is permissive by default** (a blunt denylist
+  for accidents + resource caps), because the runtime contains it. This also
+  ends the allowlist thrash the harness judge documented.
+- **Prompt injection is contained by the runtime invariants** — `network=none`,
+  no secrets in env or on disk, `HOME`=workspace, disposable filesystem — and
+  the design says so explicitly. The allowlist and the human-escalation flow
+  are *not* claimed as injection defenses.
+
+> **Correction (post-review, per direction).** The panel's resolution was
+> originally written as "Docker is the *default* backend and the local backend
+> is a demoted `unsafe_host` opt-in." That over-rotated: it conflated two
+> separable things — *don't claim isolation you don't have* (the real finding)
+> with *you must use Docker* (not a finding). Docker is only one way to get a
+> boundary; a disposable VPS over SSH is another, equally first-class, and
+> running `local` with no isolation is a legitimate choice for trusted/iterative
+> work. So the three backends are **peers with no privileged default and no
+> Docker dependency** (the package installs and `bash` runs on `bashlex`
+> alone). The honesty requirement is backend-*neutral*: every backend declares
+> exactly what boundary it does and doesn't provide. The allowlist-isn't-a-
+> boundary finding stands unchanged — it was always about not lying, not about
+> mandating containers.
+
+## Structural findings (design claims that were false)
+
+- **"Return type stays open for phase 6" — false.** `ToolCall.step`
+  (`interaction/tool_call.py:54-60`) special-cases only `AgentCall`; any other
+  bare `Interaction` raises `ValueError`. And `include_reason: true` makes
+  `execute_tool` (`tools/tool.py:391-395`) raise unless the result is a
+  `ToolResponse`. → Drop `include_reason` for bash; route every deferral
+  (long-running `Waiting`, escalation `AskHuman`) through
+  `ToolResponse.response_interaction`, which `ToolResult.step`
+  (`tool_result.py:107-108`) already honors.
+
+- **A builtin has no owner for `env_vars["sandbox"]`.** The `worlds` analogy
+  fails: an app (`the_hugins/run.py`) builds and drives `worlds`, but a generic
+  `hugin run` has no session-creation hook that instantiates a framework
+  service. → Give `Session` a typed, lazily-created `session.sandbox`
+  (`SandboxManager`), read by the tool via `stack.agent.session.sandbox`, torn
+  down by `Session.close()`. "No framework change needed" was the root error.
+
+- **Teardown must be Phase 1, not Phase 2.** The *local* backend already leaks
+  process groups (on timeout) and never-GC'd `storage/sandboxes/<id>/` dirs.
+  And `atexit`/`finally` do not run on SIGTERM (CPython's default disposition
+  terminates without raising), SIGKILL, OOM-kill, or laptop-sleep — i.e. every
+  non-clean exit, which is the common case. → Out-of-band reaping is the
+  **primary** lifecycle mechanism: stamp each sandbox with
+  `hugin.session` / `hugin.owner_pid` / `hugin.ttl` / heartbeat; a reaper runs
+  at the start of every `hugin` invocation and kills only dead-owner or stale
+  sandboxes (never by session label alone — that races live peers). `close()`
+  + a `SIGTERM`/`SIGINT` handler + `atexit` are the second/third lines.
+
+- **Synchronous `execute_tool` freezes every sibling agent and branch.**
+  `Session.run` (`session.py:170-195`) is single-threaded round-robin;
+  `execute_tool` (`tool.py:381`) calls the tool synchronously. One 120s
+  `uv sync` stalls the whole `financial_newspaper` edition — session time
+  becomes `sum` of command durations, not `max`, and the monitor looks hung
+  because `save_session` is after the step loop. → Pull background exec forward
+  to phase 2/3 (`Waiting` via `response_interaction` + a `bash_output` poll
+  tool); until then ship a *short* interactive default timeout (10–20s), a
+  separate policy `max_timeout_s`, and a loud doc note.
+
+## Framework facts that broke stated safeguards (grounded in code)
+
+- **The framework executes exactly ONE tool call per turn.**
+  `anthropic.py:125` has a `# TODO support multiple tool calls` and keeps only
+  the *last* `tool_use` block. Bash agents are the heaviest batchers
+  (`ls` + `cat a` + `cat b` in one turn) → the earlier calls silently never
+  run and the model believes it saw their output. This is close to a
+  prerequisite. → At minimum, detect >1 `tool_use` and return an explicit error
+  for the dropped ones so the model doesn't proceed on phantom results. Flag
+  multi-tool-call support (task 006) as a hard dependency.
+
+- **`reduced_context_window` does not drop stdout.** In reduced mode the
+  renderer only reformats DataFrames (`renderer.py:82-89`); string stdout is
+  kept verbatim, and the `ignore_list` blanking applies to the assistant's
+  `tool_use` args, never the tool_result. So 30 commands accumulate ~½ MB of
+  stdout permanently — exactly the blow-up the design claimed to prevent. →
+  Use `include_only_in_context_window: true` with a small `context_window`
+  (`stack.py:254-261` actually drops older ones).
+
+- **The host-filesystem builtins see a different world than bash.**
+  `read_file`/`search_files` call `Path(path).resolve()` on the *host*
+  (`read_file.py:58`); bash runs in the sandbox workspace (a different
+  filesystem under Docker). A model that reads `config.yaml` with `read_file`
+  then edits it with bash edits two different files. → Drop
+  `read_file`/`list_files`/`search_files` from any bash-enabled non-local
+  config; keep only structured tools the framework must observe/persist
+  (`save_insight`, `save_file`→Artifact, `finish`). Enforce per-config, not by
+  trusting the model to choose.
+
+## Agent-usability findings (cheap wins wrongly deferred)
+
+- **The agent is told nothing about the box.** The fix is not the phase-5
+  projection machinery — it's ~10 lines in the tool *description* (the one
+  thing the model always sees, `anthropic.py:56`): workspace layout, installed
+  toolchain, "no network", the stateless-shell warning, and the exact
+  allow/deny line **generated from the `Policy` object** so it can't drift from
+  enforcement. In v1.
+
+- **Stateless-per-call breaks the model's mental model, and `cd` on the
+  allowlist actively lies** — it returns exit 0 and silently no-ops next call,
+  reinforcing the wrong model. → Persistent shell per agent (pexpect/coprocess,
+  one per `workspace_for(agent.id)`) *inside* the disposable container. This
+  also resolves the only real tension between judges: security wants ephemeral,
+  harness wants stateful → a persistent shell inside a disposable container is
+  both.
+
+- **`is_error = exit_code != 0` mislabels normal exits.** `grep`/`rg` no-match
+  and `diff`-with-differences exit 1; flagged as errors, the model retries or
+  apologizes. → Reserve `is_error=True` for denial / timeout / infra failure;
+  a process that ran to completion is `is_error=False` with `exit_code` +
+  explicit `timed_out` / `denied` fields in content.
+
+- **head+tail truncation corrupts the important outputs** — it hands the model
+  syntactically invalid JSON and elides the pytest traceback that lives in the
+  middle. → Tail-biased truncation (the actionable error is usually last),
+  spill full output to `/workspace/.hugin/last_output.txt`, and tell the model
+  how to read more; never claim structured output survived truncation.
+
+- **`include_reason: true` is a token tax** on a tool called dozens of times,
+  producing restated intent ("I am listing the directory"). Also forbidden by
+  finding above. → `include_reason: false`; reserve a justification for the
+  escalation path where a human actually reads it.
+
+- **Don't expose `timeout` to the model** while the cap is hidden and execution
+  is synchronous — it sets 600, gets clamped to 120, is confused. Hide it until
+  background exec exists.
+
+## Docker defense-in-depth (was under-specified)
+
+Required, not optional: `--cap-drop=ALL`,
+`--security-opt=no-new-privileges:true`, `--tmpfs /tmp:rw,noexec,nosuid,size=`,
+`--ulimit nproc/nofile`, `--init`, keep (never disable) the default
+seccomp+apparmor profiles, userns-remap. `HOME`=workspace on every backend
+(else `cat ~/.aws/credentials` defeats env-scrubbing entirely). `network:true`
+must block link-local / metadata (`169.254.0.0/16`) and RFC1918 by default,
+ideally via an egress-allowlist proxy — otherwise it's SSRF to cloud IAM
+credentials. Execute via `bash -c` so the validated dialect matches the run
+dialect (`subprocess(shell=True)` uses `/bin/sh`=dash, not the bash bashlex
+parses). The AST walk must also reject dangerous assignment prefixes
+(`LD_PRELOAD`, `BASH_ENV`, `IFS`, `GIT_*`) and descend into wrapper binaries
+that run their argument (`timeout env xargs nice nohup setsid`). Image pinned
+by digest (not a mutable tag), scanned, signed. Symlink TOCTOU defeats static
+path scoping, so harvest/`get_file` must `realpath`-confine and open
+`O_NOFOLLOW`.
+
+## Config validation
+
+`Policy.from_dict` / `SandboxSpec.from_dict` must reject unknown keys, validate
+every `Literal`, and fail **loud** if `options.bash` exists but is malformed —
+never silently fall back to the permissive-inside-container default when a
+typo'd key (`mode: allowlst`, a mis-indented `policy:` block) drops the policy.
+Precedence between config / session / default is explicit key-level merge.
+
+## Enforcement location
+
+Enforce policy inside `Sandbox.exec` (fail-closed, raises), not only in the
+tool — so any future caller (a `git` tool, the phase-5 harvest layer, a test)
+is checked by construction. The tool additionally calls `evaluate()` only to
+render a friendly `ToolResponse` / escalation.
+
+## Observability (into Phase 1)
+
+A structured, append-only command audit log (session, agent, command, decision,
+exit code, duration, `truncated`/`timed_out`/`oom` flags) plus counters
+(run / denied / timed-out / container-starts / start-failures). `hugin monitor`
+and `hugin interactive` get a per-session "commands" view rendering denials and
+timeouts distinctly. This is table stakes for debugging a security-sensitive
+feature, not polish.
+
+## Per-agent isolation
+
+cwd must be keyed by `(agent.id, branch)`, not `agent.id` alone — branches
+share one `agent.id` and would collide (two branches running `git checkout` in
+one dir). `AgentCall` needs an explicit workspace-inheritance option so a
+delegated child can start in a populated dir instead of an empty one. One
+container per session means all agents share a uid and filesystem — document
+that agents in a session share a trust level, or offer per-agent containers.
+
+## SSH / VPS (phase 4, story rewritten before build)
+
+Dedicated throwaway key per session, `ForwardAgent no`, `BatchMode yes`,
+`ConnectTimeout` + `ServerAliveInterval` (else a network partition hangs the
+client while the remote command runs on). Run the remote command under
+`systemd-run --scope` / `timeout` / a named tmux so Hugin can kill the *remote*
+job, not just the local client — remote commands are not idempotent to retry.
+Own the `ControlMaster` socket path and clean it in `stop()`. Better: target a
+hardened container on the remote (`ssh host docker run …`) rather than the bare
+host. Provisioning / ownership / cost / secrets must be written before phase 4,
+not during it.

--- a/tasks/open/023-bash-tool/review.md
+++ b/tasks/open/023-bash-tool/review.md
@@ -219,3 +219,51 @@ Own the `ControlMaster` socket path and clean it in `stop()`. Better: target a
 hardened container on the remote (`ssh host docker run …`) rather than the bare
 host. Provisioning / ownership / cost / secrets must be written before phase 4,
 not during it.
+
+---
+
+# Implementation panel review (Phase 1, post-build)
+
+A second four-judge panel (security / framework architecture / agent-usability /
+SRE) reviewed the **implemented** Phase 1 code before the PR. Findings that were
+real on the local backend today, plus the cheap honesty/robustness set, were
+fixed in the branch; genuine phase-2 design items were deferred to
+`tasks/open/024-bash-sandbox-phase2-followups.md`.
+
+## Fixed before the Phase 1 PR
+
+- **Wrapper-prefix bypass** — `env dd`, `timeout 60 dd`, `nice -n 19 dd`,
+  `xargs … reboot`, `sudo reboot`, `command reboot`, `find -exec shutdown` all
+  passed the denylist/allowlist/strict mode (the AST walk saw only the first
+  word; `_WRAPPERS` was dead code). Now peels wrappers to the command they run,
+  in every mode, without false-denying data-position names.
+- **Unbounded output → orchestrator OOM** — `communicate()` buffered the whole
+  child output in parent memory before truncation. Now streamed with a 2MB
+  ceiling; past it the group is killed and the model sees an "output exceeded"
+  note.
+- **Timeout escape hang** — a `setsid`-escaped child holding the stdout pipe made
+  the post-kill `communicate()` block until it exited (defeating the timeout).
+  Now a bounded drain + kill by saved pgid.
+- **Reaper deleted a live session's workspace** — the owner stamp was written
+  once, so a resumed session kept the dead PID and a concurrent reaper deleted
+  the running workspace. Now re-stamped on every start with a process start-time
+  token (PID-reuse safe), plus per-entry crash guards (vanished dir / null pid).
+- **Audit dropped pre-backend denials** — the audit was built with the manager on
+  the allow path, so a denied first command recorded nothing. Manager (hence
+  audit) now resolved before the policy check.
+- **Model UX** — parse failures surfaced as `unparseable` (rephrase) vs `denied`;
+  `timeout_s` lever added (max_timeout_s was dead config); `oom_killed` → is_error;
+  spill path returned on truncation; clearer escalation note.
+- **Honesty** — `workspace_only`/`network` docstrings corrected (no code enforces
+  them); one-shot runtime warning that the local backend has no isolation.
+- **Lifecycle** — `Session.close()` wired into both `hugin run` paths (had no
+  production caller).
+
+## Deferred (tracked in task 024)
+
+Per-spec/per-agent sandbox ownership; backend registry; `put_file`/`get_file`
+agent context; remote lifecycle + secrets seam; `_resolve_cwd` realpath (latent,
+phase-2 path model); counter emission/alerting + monitor commands view; audit &
+workspace growth bounds; sandbox root from storage config; thread-safety;
+environment-probe affordance; elided-output marker; spill-file uniqueness;
+minor policy/error polish.

--- a/tasks/open/023-bash-tool/spec.md
+++ b/tasks/open/023-bash-tool/spec.md
@@ -1,0 +1,444 @@
+# Spec: bash tool + sandbox
+
+> Revised after panel review, then adjusted per direction. `review.md` records
+> what changed and why. The headline: **the isolation boundary is whichever
+> backend you choose** (`local` = none, `docker` = container, `ssh` = the remote
+> machine), the three backends are peers with **no Docker dependency**, and the
+> policy engine is a guardrail against accidents — never sold as isolation.
+
+## Module layout
+
+```
+src/gimle/hugin/sandbox/
+├── __init__.py
+├── sandbox.py       # Sandbox ABC + ExecResult + SandboxSpec + enforcement
+├── policy.py        # Policy + evaluate() -> Decision   (pure, no I/O)
+├── manager.py       # SandboxManager: lifecycle, per-(agent,branch) workspaces
+├── reaper.py        # out-of-band, dead-owner-scoped container/dir reaping
+├── audit.py         # structured append-only command log + counters
+├── local.py         # LocalSandbox (local backend; subprocess; no isolation)
+├── docker.py        # DockerSandbox  (opt-in container boundary)
+├── ssh.py           # SSHSandbox     (remote/VPS boundary; phase 2)
+└── fake.py          # FakeSandbox    (tests)
+
+src/gimle/hugin/tools/builtins/bash.py         # the tool
+src/gimle/hugin/tools/builtins/bash_output.py  # poll a backgrounded command (phase 2/3)
+```
+
+`sandbox.py` deliberately mirrors `storage/storage.py`: a small ABC, concrete
+backends beside it, no knowledge of agents or tools.
+
+## 1. Execution backend
+
+```python
+@dataclass(frozen=True)
+class ExecResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_s: float
+    truncated: bool      # output exceeded max_output_bytes
+    timed_out: bool
+    oom_killed: bool     # container hit its memory cap (exit 137)
+
+
+class Sandbox(ABC):
+    @abstractmethod
+    def start(self) -> None:
+        """Create/pull/connect. Idempotent. Lazy on first exec."""
+
+    @abstractmethod
+    def exec(
+        self,
+        command: str,
+        *,
+        policy: "Policy",              # enforcement lives HERE, fail-closed
+        cwd: str,
+        timeout_s: int,
+        max_output_bytes: int = 16_000,
+    ) -> ExecResult:
+        """Run `command`. Enforce `policy` before running (raise PolicyDenied
+        on violation — every caller is checked by construction). Execute via
+        `bash -c` so the run dialect matches the parsed dialect. Never raise
+        for a non-zero exit."""
+
+    @abstractmethod
+    def workspace_for(self, agent_id: str, branch: Optional[str]) -> str:
+        """Absolute cwd for this (agent, branch); created if absent."""
+
+    @abstractmethod
+    def put_file(self, path: str, content: bytes) -> None: ...
+
+    @abstractmethod
+    def get_file(self, path: str) -> bytes:
+        """realpath-confine + O_NOFOLLOW — a container-planted symlink must not
+        read the host out of the workspace mount."""
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Tear down. Idempotent. Safe on an unstarted sandbox."""
+```
+
+Note: `evaluate()` is called in two places — inside `exec` for **hard
+enforcement** (fail-closed, raises), and in the tool for **friendly rendering**
+(turn a denial into a readable `ToolResponse`/escalation). Enforcement is not
+the tool's job alone; a future `git` tool or the phase-5 harvest layer must not
+be able to reach `exec` unchecked.
+
+```python
+@dataclass(frozen=True)
+class SandboxSpec:
+    backend: Literal["local", "docker", "ssh"]                    # no default — must be named
+    image: str = "gimle/hugin-sandbox@sha256:<pinned-digest>"     # docker only; digest, not tag
+    host: Optional[str] = None                                    # ssh only
+    network: bool = False
+    cpu: float = 2.0                                              # container backends only
+    memory: str = "2g"                                            # container backends only
+    pids: int = 512                                              # container backends only
+
+def create_sandbox(spec: SandboxSpec, session_id: str, owner_pid: int) -> Sandbox:
+    """Validate the chosen backend up front and fail with a remediation message
+    — e.g. docker selected but daemon unreachable, or ssh host unreachable —
+    never surface a raw DockerException 30 steps into a run. On `local`, raise if
+    any boundary-only knob (network/cpu/memory/pids) was set to a non-default
+    value: the local backend cannot enforce them and must not pretend to."""
+```
+
+### DockerSandbox (opt-in container boundary)
+
+Selected by `backend: docker`; not required for the package to install or for
+`bash` to run. The `docker` SDK is a **lazy import inside `docker.py`**, so a
+user who never selects it needs neither the library nor a daemon. One long-lived
+container per session, `docker exec` per command (or a persistent shell — see
+§Statefulness). When chosen, all of these flags are mandatory:
+
+- `--network=none` unless `network: true`
+- `--cap-drop=ALL`, `--security-opt=no-new-privileges:true`
+- `--read-only` root, `--tmpfs /tmp:rw,noexec,nosuid,size=256m`
+- `--cpus`, `--memory`, `--pids-limit` from spec; `--ulimit nproc/nofile`
+- `--init` so PID 1 reaps double-forked children
+- default seccomp + apparmor profiles kept (never `--privileged`, never
+  `--security-opt seccomp=unconfined`)
+- userns-remap so container-root is not host-root
+- `HOME=/workspace/...`, empty env by default (no inherited secrets)
+- workspace = a **named/bind volume keyed by session-id** so a resumed session
+  reattaches its filesystem instead of getting an empty new one
+- labels `hugin.session`, `hugin.owner_pid`, `hugin.created`, `hugin.ttl`;
+  a heartbeat file touched each step
+- no docker socket mount, ever
+
+`network: true` must not be an open egress cliff: block link-local / metadata
+(`169.254.0.0/16`) and RFC1918 by default, ideally via an egress-allowlist
+proxy — otherwise an injected `curl http://169.254.169.254/...` exfiltrates
+cloud IAM credentials.
+
+Image is **thick and boring** (a thin image is a false economy — every missing
+binary is a wasted turn): Debian slim + `bash coreutils findutils git curl
+ca-certificates ripgrep jq less` + `python3` + `uv` + `node`. Pinned by digest,
+scanned (Trivy/Grype), signed (cosign), verified on pull. **No Hugin source,
+no credentials** — the sandbox is dumb; stack/interactions/artifacts stay
+host-side.
+
+### LocalSandbox (`local` backend)
+
+`subprocess` on the host — the zero-dependency backend, and a legitimate choice
+for iterating or trusted tasks (it's what `examples/bash_agent` uses). **No
+isolation boundary**, and the design says so rather than dressing it up.
+`create_sandbox` raises if any boundary-only knob (`network`/`cpu`/`memory`/
+`pids`) was set — a `network:false` a bare subprocess can't enforce is a lie, so
+asking for it here is an error, not a silent no-op. `HOME` is set to the
+workspace and the env scrubbed, but the docs state plainly that
+`cat ~/.aws/credentials` and `/dev/tcp` egress remain reachable. Process group
+started with `start_new_session=True`; timeout kills the group — with the
+documented caveat that `setsid`/daemonized children escape it.
+
+### SSHSandbox (`ssh` backend — the remote machine is the boundary; phase 2)
+
+A peer to Docker, not a footnote to it: for many users a disposable VPS is the
+most natural isolation story (a throwaway box you don't mind the agent
+breaking). Shell out to `ssh`/`scp` (no `paramiko` dep). Dedicated throwaway key
+per session, `-o ForwardAgent=no -o BatchMode=yes -o ConnectTimeout=... -o
+ServerAliveInterval=...`. Run the remote command under `systemd-run --scope` /
+`timeout` / a named tmux so Hugin can kill the *remote* job, not just the local
+client (remote commands are not idempotent to retry). Own the ControlMaster
+socket path; clean it in `stop()`. Preferably target a hardened container on the
+remote (`ssh host docker run …`) rather than the bare host. Provisioning /
+ownership / cost / secrets written before build, not during.
+
+Shell out to `ssh`/`scp` (no `paramiko` dep). Dedicated throwaway key per
+session, `-o ForwardAgent=no -o BatchMode=yes -o ConnectTimeout=... -o
+ServerAliveInterval=...`. Run the remote command under `systemd-run --scope` /
+`timeout` / a named tmux so Hugin can kill the *remote* job, not just the local
+client (remote commands are not idempotent to retry). Own the ControlMaster
+socket path; clean it in `stop()`. Preferably target a hardened container on
+the remote (`ssh host docker run …`) rather than the bare host. Provisioning /
+ownership / cost / secrets written before build, not during.
+
+## 2. Workspace layout (worktree hybrid)
+
+```
+/workspace/                         # the only writable location
+├── common/                         # shared across agents; deliberate hand-offs
+├── .hugin/last_output.txt          # full output of the last command (spill target)
+└── agents/
+    ├── <agent-id-a>/<branch>/      # keyed by (agent, branch) — branches don't collide
+    └── <agent-id-b>/<branch>/
+```
+
+- Default `cwd` for a `bash` call is `workspace_for(agent.id, branch)`.
+- `AgentCall` gets an `inherit_workspace` option so a delegated child can start
+  in a populated dir (or a pointer to `common/`) instead of an empty one.
+- `workspace_only: true` (default) denies resolved paths outside `/workspace`.
+  On Docker the mount enforces it; on `local` it is best-effort only and
+  documented as such.
+
+## 3. Policy engine
+
+Pure function, no I/O, trivially testable. **Permissive-by-default inside the
+container**, because the container is the boundary:
+
+```python
+@dataclass(frozen=True)
+class Policy:
+    mode: Literal["denylist", "allowlist", "unrestricted"] = "denylist"
+    deny: List[str] = field(default_factory=lambda: DEFAULT_DENY)
+    allow: List[str] = field(default_factory=list)   # only used in allowlist mode
+    allow_shell_features: bool = True                # container contains it
+    workspace_only: bool = True
+    network: bool = False
+    timeout_s: int = 15                              # interactive default (short!)
+    max_timeout_s: int = 600                         # policy cap for explicit long cmds
+    max_output_bytes: int = 16_000
+    on_violation: Literal["deny", "ask_human"] = "deny"
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "Policy":
+        """Reject unknown keys, validate every Literal, raise LOUDLY on a
+        malformed options.bash block — never silently fall back to default."""
+
+
+Decision = Union[Allow, Deny, Escalate]   # Deny/Escalate carry reason: str
+
+def evaluate(command: str, policy: Policy) -> Decision: ...
+```
+
+`evaluate()`:
+
+1. Parse with `bashlex` into an AST. **Parse failure → `Deny`** (fail closed).
+2. Walk the AST through pipes, `&&`, `;`, subshells, process substitution.
+3. **Descend into wrapper binaries that run their argument** — `timeout`,
+   `env`, `xargs`, `nice`, `nohup`, `setsid`, `command`, `stdbuf` — don't treat
+   the nested command as an opaque arg.
+4. **Reject dangerous assignment prefixes** — `LD_PRELOAD`, `LD_LIBRARY_PATH`,
+   `BASH_ENV`, `ENV`, `IFS`, `GIT_*`, `PATH=` overrides.
+5. Apply `deny` (or `allow` in allowlist mode) to each command word.
+6. Check path-looking args / redirection targets against `workspace_only`.
+7. Violation → `Deny` or `Escalate` per `on_violation`.
+
+`DEFAULT_DENY` is blunt and about *accidents*, not capability control:
+`rm -rf` at `/` or `~`, `dd`, `mkfs`, `shutdown`, `reboot`, fork bombs,
+`git push --force`, raw writes to `/dev/*`, `chmod -R 777 /`. The design
+**does not** pretend this stops a determined or injected agent — the chosen
+runtime (container or disposable remote) does, or on `local`, nothing does.
+
+`allowlist` mode still exists for the paranoid / `local` case, but the
+docs state explicitly: **once any interpreter (`python3`, `uv`, `node`) or
+code-exec-capable tool (`git`, `awk`, `sed`, `find`, `curl`) is on the allow
+list, the allowlist is not a capability boundary.** No allowlist is ever
+described as isolation.
+
+Tests (the bypasses are the *first* cases written): `python3 -c`, `uv run`,
+`awk 'BEGIN{system()}'`, `find -exec`, `git -c core.pager='!sh'`, `sed` `e`
+flag, `curl file://`, `timeout bash -c`, `env bash`, `xargs sh`,
+`LD_PRELOAD=./x ls`, `$'\x72\x6d'` ANSI-C quoting, symlink escape, `> /dev/tcp`,
+parse failure.
+
+## 4. The tool
+
+`builtins.bash`, referenced as `builtins.bash:bash`.
+
+```yaml
+parameters:
+  command: {type: string, description: "Shell command to run", required: true}
+  cwd:     {type: string, description: "Dir relative to your workspace", required: false}
+  # NOTE: no `timeout` param and no `include_reason` — see below.
+options:
+  include_only_in_context_window: true   # actually drops old outputs (reduced_context_window does NOT)
+  context_window: 5
+```
+
+- **No `include_reason`.** It forbids returning an Interaction
+  (`tool.py:391-395`), taxes a high-frequency tool, and produces restated
+  intent. A justification is required only on the escalation path (phase 3),
+  where a human reads it.
+- **No `timeout` param** while execution is synchronous and the cap is hidden.
+  Policy owns the timeout; `max_timeout_s` bounds an explicit long command once
+  background exec exists.
+
+### Tool description carries the environment (v1)
+
+The description is the one thing the model always sees. Generate the allow/deny
+line and the network flag **from the `Policy` object** so they cannot drift:
+
+> Run a shell command in your sandboxed workspace; returns stdout, stderr, exit
+> code. **Working dir:** `/workspace/agents/<you>/<branch>` (private).
+> `/workspace/common/` is shared with sibling agents. Nothing outside
+> `/workspace` is readable/writable. **Installed:** bash, coreutils, git,
+> ripgrep (`rg`), jq, python3, uv, node. **No network** (when
+> `network:false`) — `curl`/`uv` cannot reach the internet. **Each call is a
+> fresh shell:** `cd`/`export`/`source`/background jobs do NOT persist across
+> calls unless a persistent shell is enabled; persist state by writing files
+> under your workspace. **Output is truncated to ~16 KB (tail-biased);** full
+> output is in `/workspace/.hugin/last_output.txt` — inspect with `rg`/`sed -n`.
+> **Refused commands** (e.g. `rm -rf /`, `git push --force`) come back with a
+> reason — that's information, not a failure.
+
+### Flow
+
+1. Resolve `Policy` + `SandboxSpec` from `config.options["bash"]`
+   (`Policy.from_dict` — fail loud on malformed), falling back to session
+   defaults, then the built-in default.
+2. `sandbox.exec(command, policy=..., cwd=workspace_for(agent.id, branch), ...)`
+   — enforcement happens inside `exec`; a `PolicyDenied` is caught here and
+   rendered.
+3. Map to `ToolResponse`:
+   - **Denial / timeout / infra failure → `is_error=True`** with a distinct
+     `denied` / `timed_out` / `infra_error` field.
+   - **A process that ran to completion → `is_error=False`**, `exit_code` in
+     content. (`grep`-no-match and `diff`-differences exit 1 and are *not*
+     errors — reserving `is_error` for them mis-signals the model.)
+   - `content = {command, exit_code, stdout, stderr, truncated, timed_out,
+     oom_killed, duration_s}`.
+   - Output is **tail-biased** truncated to `max_output_bytes` (the actionable
+     error is usually last; head+tail hands the model invalid JSON and elides
+     pytest tracebacks), full copy spilled to `/workspace/.hugin/last_output.txt`,
+     with a marker telling the model how to read more. Never claim structured
+     output survived truncation.
+
+### Return type / deferral — the real contract
+
+`ToolCall.step` (`interaction/tool_call.py:54-60`) accepts only `ToolResponse`
+and `AgentCall`; a bare `Waiting`/`AskHuman` raises. So **all deferral routes
+through `ToolResponse.response_interaction`**, which `ToolResult.step`
+(`tool_result.py:107-108`) already honors — never a bare Interaction. Phase 3
+escalation and phase-6 background exec both use this path. This is the concrete
+mechanism the earlier "return type stays open" hand-wave lacked.
+
+### Hard dependency: one-tool-call-per-turn
+
+`anthropic.py:125` keeps only the *last* `tool_use` block in a response
+(`# TODO support multiple tool calls`). Bash agents batch heavily, so batched
+calls are silently dropped and the model proceeds on phantom results. Until
+task 006 lands: **detect >1 `tool_use` and return an explicit error for the
+dropped ones.** Note 006 as a blocking dependency for good bash UX.
+
+## 5. Config surface
+
+`Config.options` is already free-form, so no `Config` schema change — but the
+policy dict is validated strictly (`Policy.from_dict`), because a typo'd key
+(`mode: allowlst`) or a mis-indented `policy:` block silently dropping the
+policy is a security bug.
+
+```yaml
+name: coder
+system_template: coder_system
+tools:
+  - builtins.bash:bash
+  - builtins.finish:finish
+  # NOTE: read_file/list_files/search_files deliberately absent — they read the
+  # HOST filesystem while bash runs in the sandbox; shipping both = two
+  # filesystems the model can't reconcile.
+options:
+  bash:
+    backend: docker
+    network: false
+    policy:
+      mode: denylist
+      timeout_s: 15
+      max_timeout_s: 600
+      workspace_only: true
+      on_violation: ask_human
+```
+
+Precedence: config `options.bash` > session default > built-in default, as an
+explicit **key-level merge** (not whole-object replace).
+
+## 6. Lifecycle — Phase 1, out-of-band-primary
+
+`Session` owns a typed, lazily-created `session.sandbox` (`SandboxManager`).
+The tool reads `stack.agent.session.sandbox` — not an `env_vars` convention a
+builtin can't satisfy. Lazy `start()` on first `bash` call, so a session that
+never runs a command never pays.
+
+Teardown is **primarily out-of-band**, because `atexit`/`finally` skip SIGTERM,
+SIGKILL, OOM-kill and laptop-sleep:
+
+- Every sandbox stamped `hugin.session` / `hugin.owner_pid` / `hugin.ttl` +
+  heartbeat.
+- A **reaper runs at the start of every `hugin` invocation** and kills only
+  dead-owner or stale sandboxes (never by session label alone — that races live
+  peers). GCs stale `storage/sandboxes/<id>/` dirs on the same pass.
+- `Session.close()` (new; **Phase 1**) tears down `session.sandbox`
+  idempotently. Called from a context manager (`with Session(...) as s:`), the
+  CLI `finally`, the interactive TUI's agent-thread completion + app exit
+  (daemon threads don't run `finally` reliably), and apps'
+  (`financial_newspaper/run.py`) `finally`.
+- A `SIGTERM`/`SIGINT` handler calls `close()`. `atexit` is the last line.
+- Docker workspace is a session-keyed volume so resume reattaches, not recreates.
+- `hugin sandbox list|prune` — scoped to dead-owner/stale, safe to run beside
+  live peers.
+
+## 7. Concurrency
+
+`Session.run` is single-threaded round-robin (`session.py:170-195`) and
+`execute_tool` is synchronous (`tool.py:381`), so one long `bash` freezes every
+sibling agent and branch. Mitigations, in order:
+
+- v1: short default `timeout_s` (15s), loud doc note that bash blocks siblings.
+- Phase 2/3: background exec — `bash` returns
+  `ToolResponse(response_interaction=Waiting)` for long commands + a
+  `bash_output` poll tool. (Requires running the subprocess off the step
+  thread; scoped as its own work, not a free "return a Waiting".)
+
+## 8. Observability (Phase 1)
+
+`audit.py`: append-only log (session, agent, command, decision, exit_code,
+duration, `truncated`/`timed_out`/`oom` flags) + counters (run / denied /
+timed-out / container-starts / start-failures). `hugin monitor` and
+`hugin interactive` get a per-session commands view rendering denials/timeouts
+distinctly.
+
+## 9. Statefulness
+
+Per-agent **persistent shell** (pexpect/coprocess, one per `workspace_for`)
+*inside* the disposable container, so `cd`/`export`/`source` behave as the model
+expects. This resolves the security-vs-usability tension: persistent shell,
+disposable container. If not shipped in v1, `cd` must be *removed* from any
+allowlist and the stateless contract stated in bold in the description — an
+allowed-but-silently-ineffective `cd` is worse than a denied one.
+
+## 10. Dependencies
+
+`bashlex` is **core** (policy applies everywhere; a policy engine that can
+vanish when an extra is missing is worse than a dependency). `docker` SDK in an
+optional `sandbox` group.
+
+```toml
+dependencies = [ ..., "bashlex>=0.18" ]
+[project.optional-dependencies]
+sandbox = ["docker>=7.1"]
+```
+
+## 11. Testing
+
+- **`FakeSandbox`** — records commands, returns canned `ExecResult`s. Tool,
+  precedence, truncation, workspace routing, deferral (`response_interaction`),
+  the >1-tool-call error path — all tested here. No subprocess, no docker.
+- **Policy engine** — table-driven, pure; the interpreter/wrapper/assignment
+  bypasses are the headline cases.
+- **DockerSandbox** — `slow` marker, skipped without a daemon; asserts the
+  hardening flags are actually set and that `python3 -c 'os.system("id")'` is
+  *contained* (not that it's denied — it isn't, the container is the boundary).
+- **Reaper** — dead-owner detection, TTL, and that it never kills a live peer.
+- **Multi-agent / multi-branch** — distinct `workspace_for` paths; hand-off via
+  `common/`; two branches of one agent don't collide.

--- a/tasks/open/024-bash-sandbox-phase2-followups.md
+++ b/tasks/open/024-bash-sandbox-phase2-followups.md
@@ -1,0 +1,102 @@
+---
+title: Bash sandbox — phase 2 design items and deferred hardening
+state: OPEN
+labels: [enhancement, security, tech-debt]
+priority: medium
+---
+
+# Bash sandbox — phase 2 design items and deferred hardening
+
+Follow-ups deferred from the Phase 1 hardening pass (task 023). A four-judge
+panel review of the Phase 1 implementation (security / framework architecture /
+agent-usability / SRE) surfaced these; the load-bearing "real on local today"
+findings were fixed before the Phase 1 PR, and the items below — genuinely
+phase-2 design decisions or low-severity polish — were deferred here so they are
+tracked rather than lost.
+
+## Phase 2 design (do before docker/ssh backends land)
+
+- [ ] **Per-spec (or per-agent) sandbox ownership.** *(architect, HIGH for
+  phase 2)* Today `session.sandbox` is a single manager built first-writer-wins
+  from whichever agent runs bash first; a second agent's differing spec
+  (`backend: docker`, `network: false`, cpu/memory caps) is silently ignored, so
+  an agent's isolation is decided by call order. Move to
+  `session.sandboxes: Dict[SandboxSpec, SandboxManager]` (or per-agent), all torn
+  down in `Session.close`. Cheap interim guard: reject a second, differing spec
+  with a clear error instead of silently reusing the first.
+- [ ] **Backend selection via a registry, not a hardcoded enum + if/elif.**
+  *(architect, MEDIUM)* `create_sandbox` / `SandboxSpec.backend`
+  `Literal["local","docker","ssh"]` bypass the framework's `Registry` idiom; a
+  third-party backend can't be added without editing core. Register backends
+  (lazy-import thunks) keyed by name.
+- [ ] **`put_file`/`get_file` need agent context.** *(architect, MEDIUM)* They
+  take no agent/branch and `_confine` resolves against the *session* root, while
+  `exec` cwd is agent-scoped — three confinement scopes under one "workspace"
+  word. Docker will need per-agent host↔container path mapping. Give the file
+  methods an explicit workspace/agent argument, or drop them until a caller
+  exists (currently unused speculative API).
+- [ ] **Remote lifecycle + secrets seam.** *(SRE, MEDIUM)* Liveness is a host
+  PID and the workspace is a local dir — neither transfers to a container/VM on
+  another host; the reaper is local-only (can't reap containers/SSH). Phase 2
+  needs backend-owned resource handles + TTL/heartbeat that `close()`/reaper act
+  on generically, and a secret-provisioning hook on `SandboxSpec`/`Policy`
+  (rather than the hardcoded PATH/HOME/LANG/TERM env in `LocalSandbox`).
+- [ ] **`_resolve_cwd` should realpath, not just normpath.** *(security,
+  MEDIUM, latent)* It catches lexical `..` but follows symlinks; on local `exec`
+  is unconfined anyway, but this is the backend-agnostic cwd gate the docker/ssh
+  backends will inherit. Mirror `LocalSandbox._confine`'s realpath check (share
+  a helper) — but realpath is host-relative, so it belongs with the isolating
+  backend's path model.
+- [ ] **Wire `Session.close()` into app entry points and `hugin create`.**
+  *(SRE/architect)* Phase 1 wired the two `hugin run` paths; `apps/*/run.py` and
+  `create_agent.py` still don't call it (they don't use bash yet, so nothing
+  leaks today). Convert to `with Session(...)` / try-finally when phase-2 stop()
+  becomes non-trivial.
+- [ ] **Thread-safety.** *(architect, latent)* `SandboxManager.get()` (check-
+  then-act) and the audit (`counters += 1`, JSONL append) are unguarded; correct
+  only because the step loop is single-threaded and `Tool.execute_tool` is sync.
+  Add a lock, or document the single-threaded-scheduler precondition loudly,
+  before anyone parallelizes stepping.
+
+## Observability / ops
+
+- [ ] **Emit the audit counters somewhere.** *(SRE, HIGH)* `run / denied /
+  timed_out / infra_error / escalated / sandbox_starts / sandbox_start_failures`
+  live only in memory and are discarded at exit — no alerting surface for a
+  misbehaving agent (e.g. a loop of timeouts). Emit them at `Session.close` as a
+  structured log line/metric; consider a "hot" WARN threshold. Add the per-
+  session commands view to `hugin monitor` / `hugin interactive` (spec §8).
+- [ ] **Bound `audit.jsonl` and workspace growth.** *(SRE, MEDIUM)* The audit
+  file is append-only with no rotation; per-`(agent,branch)` workspaces and spill
+  files accumulate for the session lifetime (reaper is session-granularity).
+  Rotate the audit by size; reap idle agent/branch subdirs or at least account
+  their size.
+- [ ] **Derive the sandbox root from session storage.** *(SRE/architect,
+  MEDIUM)* `"./storage/sandboxes"` is duplicated in four places and is cwd-
+  relative, decoupled from `--storage-path`; run from a different dir or with a
+  custom storage path and the self-heal reaper never finds the workspaces. Thread
+  one root from `Environment`/storage config.
+
+## Usability / low severity
+
+- [ ] **"Here is your environment" affordance.** *(harness, MEDIUM)* The agent
+  discovers OS / available binaries / whether network works by trial and error
+  (`sed` GNU-vs-BSD, `rg` may be absent). Inject a short probe (uname, key binary
+  presence, workspace path, network-permitted) on first use or in the system
+  prompt; don't recommend tools in the template the backend may lack.
+- [ ] **"Earlier output elided" marker.** *(harness, LOW)* `context_window: 5`
+  silently drops whole older bash interactions with no trace; the model re-runs
+  or hallucinates. (Description now tells it to persist what it needs — a marker
+  would still help.)
+- [ ] **bash-vs-structured-tools routing guidance** when bash is composed with
+  other tools. *(harness, LOW)*
+- [ ] **`rm` denied-target set is inconsistent** (`/` denied, `/etc` `/usr`
+  allowed). *(security, LOW)* Either match any absolute non-workspace top-level
+  target or rely on confinement once it's real.
+- [ ] **`from_dict` misplaced-key error** — a valid policy key at the top level
+  of `options.bash` (not nested under `policy:`) reports "unknown sandbox keys";
+  a targeted hint would help. *(architect, LOW)*
+- [ ] **Spill file is single/overwritten and follows `cwd`.** *(harness,
+  MEDIUM)* A later truncated command overwrites `.hugin/last_output.txt`, so a
+  deferred read gets the wrong output; and with `cwd: subdir` it lands under the
+  subdir. Consider a unique per-call spill name returned in the response.

--- a/tasks/open/025-bash-sandbox-docker-backend.md
+++ b/tasks/open/025-bash-sandbox-docker-backend.md
@@ -1,0 +1,88 @@
+---
+title: Bash sandbox — Docker backend (Phase 2)
+state: OPEN
+labels: [enhancement, security, sandbox]
+priority: high
+---
+
+# Bash sandbox — Docker backend (Phase 2)
+
+Add the `docker` execution backend for the bash tool: a real container
+isolation boundary, selectable per-config with `backend: docker`. This is one of
+the two isolation backends that make the bash tool safe for untrusted work;
+`local` (shipped in Phase 1) has no boundary and says so. `docker` and `ssh` are
+**peers** — no Docker dependency for the package to install or for `local`/`ssh`
+to run.
+
+**Design source of truth:** task 023 `spec.md` §1 (DockerSandbox), §2 (workspace),
+§6 (lifecycle), §10 (deps); `plan.md` Phase 2; `review.md` (both panels). Phase 1
+built the `Sandbox` ABC, `SandboxSpec` (with `image`/`network`/`cpu`/`memory`/
+`pids` fields already defined), `create_sandbox` factory (raises
+`NotImplementedError("phase 2")` for docker today), `SandboxManager`, reaper, and
+audit — this task fills in `create_sandbox`'s docker branch.
+
+## The acceptance gate (non-negotiable)
+
+The security judge's containment test IS the definition of done: `python3 -c
+'os.system("id")'` must be **contained by the runtime** (the container),
+*provably*, not merely denied — and the docs must never claim the policy
+allowlist stopped it. A denylist by design allows interpreter execution; the
+container is what makes that safe.
+
+## Tasks
+
+- [ ] `sandbox/docker.py` — `DockerSandbox(Sandbox)`. **Lazy `docker`-SDK import
+      inside the module** so a user who never selects docker needs neither the
+      library nor a daemon. One long-lived container per session; `docker exec`
+      per command (or a persistent shell — see task 027 statefulness).
+- [ ] All hardening flags are **mandatory** when this backend is chosen:
+  - `--network=none` unless `network: true`
+  - `--cap-drop=ALL`, `--security-opt=no-new-privileges:true`
+  - `--read-only` root, `--tmpfs /tmp:rw,noexec,nosuid,size=256m`
+  - `--cpus` / `--memory` / `--pids-limit` from spec; `--ulimit nproc/nofile`
+  - `--init` (PID 1 reaps double-forked children — the case the local backend
+    can't handle)
+  - default seccomp + apparmor kept; **never** `--privileged`, never
+    `seccomp=unconfined`
+  - userns-remap so container-root ≠ host-root
+  - `HOME=/workspace/...`, empty env by default (no inherited secrets)
+  - workspace = a **named/bind volume keyed by session-id** so a resumed session
+    reattaches its filesystem instead of getting an empty one
+  - labels `hugin.session` / `hugin.owner_pid` / `hugin.created` / `hugin.ttl` +
+    a heartbeat file touched each step (so the reaper can find/kill it)
+  - **no docker socket mount, ever**
+- [ ] `network: true` egress control — block link-local/metadata
+      (`169.254.0.0/16`) and RFC1918 by default, ideally via an egress-allowlist
+      proxy. Otherwise an injected `curl http://169.254.169.254/...` exfiltrates
+      cloud IAM credentials. (`network:false` — the default — is the safe path;
+      this item is only for when an operator opts into network.)
+- [ ] `docker/sandbox.Dockerfile` — **thick and boring** image (a thin image is a
+      false economy — every missing binary is a wasted agent turn): Debian slim +
+      `bash coreutils findutils git curl ca-certificates ripgrep jq less` +
+      `python3` + `uv` + `node`. Pinned by digest, scanned (Trivy/Grype), signed
+      (cosign), verified on pull. **No Hugin source, no credentials** — the
+      sandbox is dumb; stack/interactions/artifacts stay host-side.
+- [ ] Extend the reaper (`sandbox/reaper.py`) so it reaps abandoned **containers**
+      (by `hugin.owner_pid` label + heartbeat/TTL), not just local dirs — the
+      Phase 1 reaper is local-dir + host-PID only (see task 024). Container
+      liveness is not a host `os.kill`.
+- [ ] `docker` SDK → optional `sandbox` extra in `pyproject.toml`
+      (`docker>=7.1`); `create_sandbox` gives a clear remediation error if
+      `backend: docker` is selected but the extra isn't installed.
+- [ ] Ensure `Session.close()`/`SandboxManager.close()` actually stop+remove the
+      container (Phase 1 `stop()` is a no-op for local; here it releases a real
+      resource — wire it so a clean exit doesn't leak a container, and confirm
+      the reaper is the backstop for abrupt exits).
+- [ ] Tests (`slow` marker, skipped without a daemon): assert every hardening
+      flag is actually set on the created container, and assert the **containment
+      gate** above. Plus: resumed session reattaches its volume; container is
+      removed on `close()`; reaper removes an abandoned container.
+
+## Success criteria
+
+- [ ] The same config runs unchanged with `backend: docker` — contained, no
+      network by default.
+- [ ] `python3 -c 'os.system("id")'` is provably contained by the container.
+- [ ] Package still installs and `local`/`ssh` still run without the `docker` SDK.
+- [ ] No container or volume leaks on clean OR abrupt exit.
+- [ ] `/panel-review` (security judge's containment test is the gate) before merge.

--- a/tasks/open/026-bash-sandbox-ssh-backend.md
+++ b/tasks/open/026-bash-sandbox-ssh-backend.md
@@ -1,0 +1,66 @@
+---
+title: Bash sandbox — SSH / remote (VPS) backend (Phase 2)
+state: OPEN
+labels: [enhancement, security, sandbox]
+priority: medium
+---
+
+# Bash sandbox — SSH / remote (VPS) backend (Phase 2)
+
+Add the `ssh` execution backend: the boundary is a **disposable remote machine**
+(a throwaway VPS the operator doesn't mind the agent breaking). A peer to the
+`docker` backend (task 025), not a footnote — for many users a throwaway box is
+the most natural isolation story. Selectable with `backend: ssh`. No Docker
+dependency; shell out to `ssh`/`scp` (no `paramiko` dependency).
+
+**Design source of truth:** task 023 `spec.md` §1 (SSHSandbox), `plan.md`
+Phase 2/3 note, `review.md` "SSH / VPS" section. Phase 1's `create_sandbox`
+raises `NotImplementedError("phase 2")` for ssh today.
+
+## Prerequisite (write BEFORE building)
+
+The plan is explicit: the **secrets / provisioning / ownership / cost story must
+be written up first, not during the code.** Deliver a short design note
+(`design.md` in this task folder) covering:
+
+- **Provisioning** — who creates the box, when, from what image; is it per-session
+  ephemeral or a reused pool; how is it torn down (and who pays if teardown fails).
+- **Secrets** — the agent will need scoped credentials to do real work; where do
+  they come from, how are they injected, revoked, and rotated (there is no
+  secret-injection seam in Phase 1 — see task 024). Never ship long-lived creds
+  to a box the agent controls.
+- **Cost / ownership** — a leaked VM bills money; the reaper must reap remote
+  resources by ID + TTL/heartbeat, not host PID (Phase 1 reaper is local-only).
+- **Idempotency** — a remote command interrupted by a network partition is NOT
+  safe to blindly retry; how is a mid-command partition handled.
+
+## Tasks
+
+- [ ] Write and get sign-off on the design note above.
+- [ ] `sandbox/ssh.py` — `SSHSandbox(Sandbox)`, shelling out to `ssh`/`scp`.
+  - Dedicated **throwaway key per session**; `-o ForwardAgent=no -o
+    BatchMode=yes -o ConnectTimeout=... -o ServerAliveInterval=...` (a network
+    partition must not hang the client while the remote command runs on).
+  - Run the remote command under `systemd-run --scope` / `timeout` / a named
+    tmux so Hugin can kill the **remote** job, not just the local client.
+  - Own the `ControlMaster` socket path; clean it in `stop()`.
+  - Prefer targeting a **hardened container on the remote** (`ssh host docker
+    run …`) over the bare host.
+  - `put_file`/`get_file` via `scp` with the same workspace confinement contract.
+- [ ] Extend the reaper for remote resources (by session/owner + TTL/heartbeat) —
+      shared with the docker reaper generalization in task 024/025.
+- [ ] `Session.close()`/`SandboxManager.close()` closes the SSH connection,
+      kills the remote job, and (if this backend provisioned the box) tears it
+      down; reaper is the backstop.
+- [ ] Tests: connection/command-kill mocked where a real host isn't available;
+      the containment gate (below) run against a real disposable box in CI or a
+      documented manual gate.
+
+## Success criteria
+
+- [ ] The same config runs unchanged with `backend: ssh` on a disposable remote.
+- [ ] `python3 -c 'os.system("id")'` is contained by the remote machine, provably.
+- [ ] A mid-command network partition does not hang Hugin and does not silently
+      double-execute; the remote job is killable.
+- [ ] No leaked remote VM / connection / key on clean OR abrupt exit.
+- [ ] The secrets/provisioning/cost design note exists and was reviewed.

--- a/tasks/open/027-bash-sandbox-background-exec-and-state.md
+++ b/tasks/open/027-bash-sandbox-background-exec-and-state.md
@@ -1,0 +1,71 @@
+---
+title: Bash sandbox — background exec + per-agent statefulness (Phase 2)
+state: OPEN
+labels: [enhancement, sandbox, concurrency]
+priority: high
+---
+
+# Bash sandbox — background exec + per-agent statefulness (Phase 2)
+
+Fix the bash tool's **worst operational property**: `Session.run` is
+single-threaded round-robin and `execute_tool` is synchronous, so one long
+`bash` command (a 120s build/test) **freezes every sibling agent and branch** in
+the session. Plus the related usability gap: each call is a fresh shell, so
+`cd`/`export`/`source` don't persist. These are grouped because both change the
+execution model.
+
+**Design source of truth:** task 023 `spec.md` §4 (Return type / deferral —
+"the real contract"), §7 (Concurrency), §9 (Statefulness); `plan.md` Phase 2.
+Phase 1 mitigated the freeze only with a short 15s default timeout + a doc note.
+
+## The deferral mechanism (already load-bearing)
+
+`ToolCall.step` accepts **only** `ToolResponse` or `AgentCall`; a bare
+`Waiting`/`AskHuman` raises. So all deferral MUST route through
+`ToolResponse.response_interaction` (which `ToolResult.step` already honors).
+Background exec and Phase 3 human escalation (task 028) both use this one path —
+do not invent a second.
+
+## Tasks
+
+### Background execution (the freeze fix)
+
+- [ ] Run the subprocess **off the step thread** so a long command doesn't block
+      the round-robin scheduler. This is the real work — "return a `Waiting`" is
+      not free; it requires the exec to actually run asynchronously.
+- [ ] For a long/backgrounded command, `bash` returns
+      `ToolResponse(response_interaction=Waiting)` and the parent agent yields so
+      siblings run.
+- [ ] Add a `bash_output` poll tool: the agent checks on / collects the result of
+      a still-running command, and the `Waiting` resolves when it completes.
+- [ ] Decide the trigger: an explicit `background: true` arg, or automatic when a
+      command exceeds a threshold. (Prefer explicit first; measure.)
+- [ ] Ensure the audit + truncation + spill machinery still applies to a
+      background command's eventual result.
+
+### Per-agent statefulness (persistent shell)
+
+- [ ] Per-agent **persistent shell** (pexpect/coprocess, one per
+      `workspace_for(agent, branch)`) *inside* the disposable container/remote, so
+      `cd`/`export`/`source` behave as the model expects. This resolves the
+      security-vs-usability tension: persistent shell, disposable runtime.
+- [ ] If persistent shell is NOT shipped: **remove `cd` from any allowlist** and
+      state the stateless contract in bold in the tool description — an
+      allowed-but-silently-ineffective `cd` is worse than a denied one. (Phase 1's
+      description already says each call is a fresh shell.)
+
+### Related workspace item
+
+- [ ] `AgentCall` gains an `inherit_workspace` option so a delegated child starts
+      in a populated dir (or a pointer to `common/`) instead of an empty one.
+
+## Success criteria
+
+- [ ] A long `bash` command (e.g. a real build in `financial_newspaper`) does
+      **not** freeze sibling agents/branches; the edition still makes progress.
+- [ ] The agent can start a long command, do other work, and collect the result
+      via `bash_output`.
+- [ ] Either `cd`/`export` persist within an agent's session, or the tool makes
+      the stateless contract unmistakable and `cd` is not a silent no-op.
+- [ ] Tests cover the deferral path (`response_interaction=Waiting` +
+      `bash_output` resolution) against `FakeSandbox` — no real subprocess needed.

--- a/tasks/open/028-bash-sandbox-human-escalation.md
+++ b/tasks/open/028-bash-sandbox-human-escalation.md
@@ -1,0 +1,50 @@
+---
+title: Bash sandbox — human escalation (Phase 3)
+state: OPEN
+labels: [enhancement, sandbox, human-in-the-loop]
+priority: medium
+---
+
+# Bash sandbox — human escalation (Phase 3)
+
+Make `on_violation: ask_human` actually ask a human, instead of failing cleanly.
+Phase 1 accepts the config knob but, until this lands, an escalated command
+returns a `needs_approval` error with a note that says approval is unavailable
+(so a model doesn't loop). This task wires the real approval path.
+
+**Design source of truth:** task 023 `spec.md` §4 (deferral contract), `plan.md`
+Phase 3. The `Policy.on_violation` field, `Escalate` decision, and the tool's
+escalation branch already exist from Phase 1.
+
+## The deferral mechanism
+
+Route through `ToolResponse(response_interaction=AskHuman)` — a **bare
+`AskHuman` raises** (`ToolCall.step` only accepts `ToolResponse`/`AgentCall`).
+Same single deferral path as background exec (task 027).
+
+## Tasks
+
+- [ ] `on_violation: ask_human` → `ToolResponse(response_interaction=AskHuman)`
+      carrying the pending command for approval.
+- [ ] **Degrade to `deny` when the session is non-interactive** — otherwise the
+      agent parks forever waiting for an approval that can never come. Detect
+      interactivity from the session/run context.
+- [ ] The escalation prompt shows the command's **capabilities/effects**, not a
+      raw base64/opaque string — a human approving must understand what they're
+      approving.
+- [ ] Approve-once is scoped to an **exact command hash**, never "allow this
+      binary" (which would be a durable capability grant the operator didn't
+      intend).
+- [ ] Surface the pending command in `hugin interactive` / `hugin monitor` so a
+      human can see and act on it.
+- [ ] Reject `on_violation: ask_human` at config-parse time only if we choose NOT
+      to support it; otherwise this task removes the Phase 1 "not available" note.
+- [ ] Tests: escalation defers via `response_interaction=AskHuman` in an
+      interactive session; degrades to `deny` in a non-interactive one; approval
+      is scoped to the exact command.
+
+## Success criteria
+
+- [ ] An out-of-policy command **asks** rather than fails, in an interactive run.
+- [ ] A non-interactive run degrades cleanly to `deny` (no infinite park).
+- [ ] Approval never silently widens to "allow this binary going forward".

--- a/tasks/open/029-bash-sandbox-harness-blend.md
+++ b/tasks/open/029-bash-sandbox-harness-blend.md
@@ -1,0 +1,73 @@
+---
+title: Bash sandbox — the harness blend (Phase 4, design-first)
+state: OPEN
+labels: [design, sandbox, research]
+priority: low
+---
+
+# Bash sandbox — the harness blend (Phase 4, design-first)
+
+The open question behind the whole bash effort: **are we moving toward a blend of
+a Pi-like harness — markdown files + bash — and the traditional tool-calling
+setup?** Phase 1 deliberately did not answer it. This is a **design task, to be
+written *after* watching real agents use Phases 1–2** — do not build it blind.
+
+**Design source of truth:** task 023 `notes.md` (the full thinking is parked
+there — read it first). This task is the pointer so the idea isn't lost when 023
+closes.
+
+## The idea
+
+Treat the filesystem as a shared, inspectable medium between framework and agent,
+in two directions, with **one direction of authority per object**:
+
+```
+/workspace/
+  TASK.md          # projected (read-only) — the task definition
+  ENVIRONMENT.md   # projected (read-only) — generated from Policy: what's
+                   #   installed and what's allowed (so it can't drift)
+  memory/*.md      # projected (read-only) — artifacts, insights (grep instead
+                   #   of query_artifacts)
+  outbox/          # harvested → Artifacts at a boundary (realpath/O_NOFOLLOW)
+  common/          # cross-agent hand-offs
+  agents/<id>/     # per-agent cwd
+```
+
+- **Down (framework → files):** storage is authoritative; files are a *render*,
+  regenerated each turn. The projection mount is genuinely read-only, not
+  read-only by convention.
+- **Up (files → framework):** the filesystem is authoritative for harvested
+  things and nothing else writes them.
+
+The invariant (**one writer per object**) is what prevents a month of
+storage↔disk reconciliation. Enforce it structurally.
+
+## Open questions to resolve in the design (from notes.md)
+
+- [ ] Does the projection regenerate every turn or only on storage change?
+      (Every turn is simpler; measure before optimizing.)
+- [ ] Is `ENVIRONMENT.md` generated from the `Policy` object so the agent's map
+      of what it may run can't drift from what it actually may run? (Likely yes —
+      a hand-written allowlist description will rot.)
+- [ ] Does harvest run at the tool-call boundary (faster feedback) or the agent
+      boundary (cleaner semantics)?
+- [ ] What does the **system prompt** say? The projection and the prompt should
+      share a source, or the agent wastes turns on `which`. (Ties to task 024's
+      "environment affordance" item.)
+
+## The boundary this must preserve
+
+> **bash for exploration and mechanical work; structured tools wherever the
+> framework needs to observe, validate, or persist the result.**
+
+Structured tools keep two advantages bash never gets: typed arguments the model
+can't fumble, and results that land in the stack as inspectable interactions
+(not an opaque stdout blob `hugin monitor` can't visualize). The end state is NOT
+"replace tools with bash". This line should also drive the follow-up to task 005
+(which builtins are still worth having).
+
+## Success criteria
+
+- [ ] A written design (in this task folder) answering the open questions, backed
+      by observations of real Phase 1–2 agent runs.
+- [ ] A decision on scope before any implementation.

--- a/tasks/open/README-bash-sandbox-roadmap.md
+++ b/tasks/open/README-bash-sandbox-roadmap.md
@@ -1,0 +1,49 @@
+# Bash sandbox — roadmap index
+
+The bash tool lets a Hugin agent run shell commands through a pluggable
+execution sandbox. It ships in phases so each is independently reviewable. The
+full design lives in the **task 023 folder** (`spec.md` / `plan.md` / `notes.md`
+/ `review.md`) — read that for rationale; the tasks below are the actionable,
+self-contained pieces.
+
+Guiding thesis: **the runtime you choose is the boundary, not the allowlist.**
+The policy engine is a guardrail against accidents; isolation comes from the
+`docker`/`ssh` runtime. `local`/`docker`/`ssh` are peers — no Docker dependency.
+
+## Status
+
+| Task | What | Status |
+|------|------|--------|
+| 023 | **Phase 0 + 1** — one-tool-call guard; core vertical on the `local` backend (policy engine, LocalSandbox, manager, reaper, audit, `Session.close`, `hugin sandbox`, `bash` tool, example) | **In PR #59** (arnovich/gimle-hugin); hardened after a 4-judge implementation review |
+| 024 | Deferred hardening + phase-2 design items from the Phase 1 implementation review | OPEN |
+| 025 | **Phase 2** — Docker backend (container isolation) | OPEN |
+| 026 | **Phase 2** — SSH / remote (VPS) backend | OPEN (design note first) |
+| 027 | **Phase 2** — background exec (freeze fix) + per-agent statefulness | OPEN |
+| 028 | **Phase 3** — human escalation (`on_violation: ask_human`) | OPEN |
+| 029 | **Phase 4** — the harness blend (markdown projection + outbox harvest) | OPEN (design-first, after watching real agents) |
+
+## Ordering & dependencies
+
+- **023 merges first** (Phase 1 is the foundation everything builds on).
+- **024** items are mostly independent cleanups; several are prerequisites for
+  Phase 2 (per-spec sandbox ownership, backend registry, reaper generalization to
+  non-local resources, sandbox root from storage config). Do those before/with 025.
+- **025 (docker)** and **026 (ssh)** are peers; either can go first. Both share
+  the reaper generalization from 024 and the containment acceptance gate:
+  `python3 -c 'os.system("id")'` must be **provably contained by the runtime**,
+  not merely denied.
+- **027 (background exec)** is independent of the isolation backends but is the
+  worst *operational* property (a long command freezes the whole session), so
+  it's high priority. It and **028 (escalation)** share the one deferral
+  mechanism: `ToolResponse(response_interaction=...)` — never a bare
+  `Waiting`/`AskHuman`.
+- **029 (harness blend)** is design-first and should wait until real agents have
+  used Phases 1–2.
+
+## Cross-cutting notes
+
+- **Blocking dependency for good bash UX:** full multi-tool-call support
+  (task 006). Phase 0 shipped only the >1-`tool_use` *detection*; batched bash
+  calls are otherwise a silent-data-loss risk.
+- **Every isolation backend merges behind `/panel-review`** with the security
+  judge's containment test as the gate (see `plan.md` "Review").

--- a/tests/test_bash_example.py
+++ b/tests/test_bash_example.py
@@ -68,7 +68,7 @@ def test_bash_example_loads_and_runs(tmp_path):
     sandbox = LocalSandbox(
         SPEC, session.id, workspace_root=str(tmp_path / "sb")
     )
-    env.env_vars["sandbox"] = SandboxManager(SPEC, session.id, sandbox=sandbox)
+    session.sandbox = SandboxManager(SPEC, session.id, sandbox=sandbox)
 
     # Scripted model: write a file with bash, then finish.
     registry = get_model_registry()

--- a/tests/test_bash_example.py
+++ b/tests/test_bash_example.py
@@ -1,0 +1,119 @@
+"""End-to-end drive of the examples/bash_agent example through the real loop.
+
+Loads the shipped example directory (validating its YAML, tool references, and
+config), then runs a real Session with a scripted no-API model that calls
+``bash`` and then ``finish``. This proves the whole path works together: the
+example loads, the ``builtins.bash:bash`` alias resolves in a real run, the
+step loop executes the tool against a real LocalSandbox, and a real file lands
+in the agent's workspace.
+"""
+
+import os
+from typing import Any, Dict, List
+
+import pytest
+
+import gimle.hugin.tools  # noqa: F401  (registers builtins.bash)
+from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.session import Session
+from gimle.hugin.llm.models.model import Model, ModelResponse
+from gimle.hugin.llm.models.model_registry import get_model_registry
+from gimle.hugin.sandbox import LocalSandbox, SandboxManager, SandboxSpec
+from gimle.hugin.storage.local import LocalStorage
+
+pytestmark = pytest.mark.integration
+
+EXAMPLE = "examples/bash_agent"
+MODEL_NAME = "scripted-bash-e2e"
+SPEC = SandboxSpec(backend="local")
+
+
+class _ScriptedModel(Model):
+    """A model that replays a fixed sequence of tool calls (no network)."""
+
+    def __init__(self, script: List[Dict[str, Any]]):
+        """Replay ``script`` entries (``{tool, input}``) one call at a time."""
+        super().__init__(
+            {
+                "model": MODEL_NAME,
+                "temperature": 0,
+                "max_tokens": 100,
+                "tool_choice": {"type": "any"},
+            }
+        )
+        self._script = script
+        self._i = 0
+
+    def chat_completion(self, system_prompt, messages, tools=None):
+        """Return the next scripted tool call as a ModelResponse."""
+        entry = self._script[min(self._i, len(self._script) - 1)]
+        self._i += 1
+        return ModelResponse(
+            role="assistant",
+            content=entry["input"],
+            tool_call=entry["tool"],
+            tool_call_id=f"call-{self._i}",
+            input_tokens=1,
+            output_tokens=1,
+        )
+
+
+def test_bash_example_loads_and_runs(tmp_path):
+    """The example loads, runs the loop, and bash creates a real file."""
+    storage = LocalStorage(base_path=str(tmp_path / "storage"))
+    env = Environment.load(EXAMPLE, storage=storage)
+    session = Session(environment=env)
+
+    # Real LocalSandbox rooted under tmp so the run doesn't touch repo storage.
+    sandbox = LocalSandbox(
+        SPEC, session.id, workspace_root=str(tmp_path / "sb")
+    )
+    env.env_vars["sandbox"] = SandboxManager(SPEC, session.id, sandbox=sandbox)
+
+    # Scripted model: write a file with bash, then finish.
+    registry = get_model_registry()
+    registry.register_model(
+        MODEL_NAME,
+        _ScriptedModel(
+            [
+                {
+                    "tool": "bash",
+                    "input": {"command": "echo hello-from-bash > marker.txt"},
+                },
+                {
+                    "tool": "finish",
+                    "input": {
+                        "finish_type": "success",
+                        "result": "wrote marker.txt",
+                        "reason": "task complete",
+                    },
+                },
+            ]
+        ),
+    )
+    try:
+        config = env.config_registry.get("bash_agent")
+        task = env.task_registry.get("explore")
+        session.create_agent_from_task(config, task)
+        agent = session.agents[0]
+        agent.config.llm_model = MODEL_NAME  # avoid a real LLM call
+
+        for _ in range(10):
+            if not agent.step():
+                break
+
+        markers = list((tmp_path / "sb").rglob("marker.txt"))
+        assert markers, "bash did not create the expected file in the workspace"
+        assert markers[0].read_text().strip() == "hello-from-bash"
+    finally:
+        registry.models.pop(MODEL_NAME, None)
+
+
+def test_example_config_wires_the_bash_tool(tmp_path):
+    """Loading the example exposes the bash tool with the sandbox config."""
+    storage = LocalStorage(base_path=str(tmp_path / "storage"))
+    env = Environment.load(EXAMPLE, storage=storage)
+    config = env.config_registry.get("bash_agent")
+    assert "builtins.bash:bash" in config.tools
+    assert config.options["bash"]["backend"] == "local"
+    assert os.path.isdir(EXAMPLE)

--- a/tests/test_bash_integration.py
+++ b/tests/test_bash_integration.py
@@ -1,0 +1,70 @@
+"""End-to-end wiring test: the bash tool through the real framework path.
+
+The unit tests drive ``bash`` with a hand-built stack. This one goes through
+``Tool.execute_tool`` on a *real* Agent/Session/Environment against a real
+``LocalSandbox`` running real subprocesses — so it catches the integration
+seams the fakes can't: that ``execute_tool`` injects ``stack`` and ``branch``,
+that ``config.options`` / ``session.id`` / ``agent.id`` / ``env_vars`` all
+resolve on a real stack, and that a real command runs and comes back mapped.
+"""
+
+import pytest
+
+import gimle.hugin.tools  # noqa: F401  (registers builtins.bash)
+from gimle.hugin.sandbox import LocalSandbox, SandboxManager, SandboxSpec
+from gimle.hugin.tools.tool import Tool
+
+pytestmark = pytest.mark.integration
+
+SPEC = SandboxSpec(backend="local")
+
+
+def _seed_real_sandbox(agent, tmp_path):
+    """Give the agent's session a real LocalSandbox rooted under tmp_path."""
+    sandbox = LocalSandbox(
+        SPEC, session_id=agent.session.id, workspace_root=str(tmp_path)
+    )
+    manager = SandboxManager(SPEC, agent.session.id, sandbox=sandbox)
+    agent.session.environment.env_vars["sandbox"] = manager
+
+
+def test_bash_runs_a_real_command_through_execute_tool(mock_agent, tmp_path):
+    """execute_tool injects the stack; the real backend runs the command."""
+    _seed_real_sandbox(mock_agent, tmp_path)
+    tool = Tool.get_tool("builtins.bash")
+
+    result = Tool.execute_tool(
+        tool, mock_agent.stack, None, command="echo hello-e2e"
+    )
+
+    assert result.is_error is False
+    assert "hello-e2e" in result.content["stdout"]
+    assert result.content["exit_code"] == 0
+
+
+def test_execute_tool_threads_branch_into_the_workspace(mock_agent, tmp_path):
+    """The injected branch reaches workspace_for — branches are isolated."""
+    _seed_real_sandbox(mock_agent, tmp_path)
+    tool = Tool.get_tool("builtins.bash")
+
+    result = Tool.execute_tool(
+        tool, mock_agent.stack, "feature-x", command="pwd"
+    )
+
+    assert result.is_error is False
+    cwd = result.content["stdout"].strip()
+    assert cwd.endswith("/feature-x")
+    assert mock_agent.id in cwd
+
+
+def test_denied_command_is_refused_through_the_real_path(mock_agent, tmp_path):
+    """A policy denial comes back as a recoverable error, not a crash."""
+    _seed_real_sandbox(mock_agent, tmp_path)
+    tool = Tool.get_tool("builtins.bash")
+
+    result = Tool.execute_tool(
+        tool, mock_agent.stack, None, command="dd if=/dev/zero of=/dev/sda"
+    )
+
+    assert result.is_error is True
+    assert "denied" in result.content

--- a/tests/test_bash_integration.py
+++ b/tests/test_bash_integration.py
@@ -24,8 +24,9 @@ def _seed_real_sandbox(agent, tmp_path):
     sandbox = LocalSandbox(
         SPEC, session_id=agent.session.id, workspace_root=str(tmp_path)
     )
-    manager = SandboxManager(SPEC, agent.session.id, sandbox=sandbox)
-    agent.session.environment.env_vars["sandbox"] = manager
+    agent.session.sandbox = SandboxManager(
+        SPEC, agent.session.id, sandbox=sandbox
+    )
 
 
 def test_bash_runs_a_real_command_through_execute_tool(mock_agent, tmp_path):

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -16,12 +16,10 @@ from gimle.hugin.tools.builtins.bash import bash
 LOCAL = SandboxSpec(backend="local")
 
 
-def _stack(config_options=None, env_vars=None):
+def _stack(config_options=None, sandbox_manager=None):
     """Build a minimal stack exposing just what the bash tool reads."""
-    environment = SimpleNamespace(
-        env_vars=env_vars if env_vars is not None else {}
-    )
-    session = SimpleNamespace(id="session-1")
+    environment = SimpleNamespace(env_vars={})
+    session = SimpleNamespace(id="session-1", sandbox=sandbox_manager)
     config = SimpleNamespace(options=config_options or {})
     agent = SimpleNamespace(
         id="agent-a",
@@ -33,9 +31,9 @@ def _stack(config_options=None, env_vars=None):
 
 
 def _stack_with_fake(fake, config_options=None):
-    """Build a stack whose env_vars holds a manager wrapping ``fake``."""
+    """Build a stack whose session owns a manager wrapping ``fake``."""
     manager = SandboxManager(LOCAL, "session-1", sandbox=fake)
-    return _stack(config_options=config_options, env_vars={"sandbox": manager})
+    return _stack(config_options=config_options, sandbox_manager=manager)
 
 
 class TestResultMapping:

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -1,0 +1,171 @@
+"""Tests for the ``builtins.bash`` tool, driven against a FakeSandbox.
+
+These pin the agent-facing behaviour: how a result maps to a ToolResponse
+(only denial/timeout/infra are errors — a non-zero exit is not), that policy is
+read from ``config.options['bash']`` and enforced before the sandbox runs, and
+that the command reaches the backend with the right cwd and policy.
+"""
+
+from types import SimpleNamespace
+
+from gimle.hugin.sandbox.fake import FakeSandbox
+from gimle.hugin.sandbox.manager import SandboxManager
+from gimle.hugin.sandbox.sandbox import ExecResult, SandboxSpec
+from gimle.hugin.tools.builtins.bash import bash
+
+LOCAL = SandboxSpec(backend="local")
+
+
+def _stack(config_options=None, env_vars=None):
+    """Build a minimal stack exposing just what the bash tool reads."""
+    environment = SimpleNamespace(
+        env_vars=env_vars if env_vars is not None else {}
+    )
+    session = SimpleNamespace(id="session-1")
+    config = SimpleNamespace(options=config_options or {})
+    agent = SimpleNamespace(
+        id="agent-a",
+        config=config,
+        session=session,
+        environment=environment,
+    )
+    return SimpleNamespace(agent=agent)
+
+
+def _stack_with_fake(fake, config_options=None):
+    """Build a stack whose env_vars holds a manager wrapping ``fake``."""
+    manager = SandboxManager(LOCAL, "session-1", sandbox=fake)
+    return _stack(config_options=config_options, env_vars={"sandbox": manager})
+
+
+class TestResultMapping:
+    """How an ExecResult becomes a ToolResponse."""
+
+    def test_successful_command_is_not_an_error(self):
+        """Exit 0 maps to a non-error response carrying stdout."""
+        fake = FakeSandbox(
+            ExecResult(exit_code=0, stdout="hi", stderr="", duration_s=0.1)
+        )
+        response = bash("echo hi", stack=_stack_with_fake(fake))
+        assert response.is_error is False
+        assert response.content["exit_code"] == 0
+        assert response.content["stdout"] == "hi"
+        assert fake.last_call.command == "echo hi"
+
+    def test_nonzero_exit_is_not_an_error(self):
+        """A completed process that exits non-zero is data, not an error."""
+        fake = FakeSandbox(
+            ExecResult(exit_code=2, stdout="", stderr="nope", duration_s=0.0)
+        )
+        response = bash("grep x f", stack=_stack_with_fake(fake))
+        assert response.is_error is False
+        assert response.content["exit_code"] == 2
+
+    def test_timeout_is_an_error(self):
+        """A timed-out command is an error the model must react to."""
+        fake = FakeSandbox(
+            ExecResult(
+                exit_code=-1,
+                stdout="",
+                stderr="",
+                duration_s=1.0,
+                timed_out=True,
+            )
+        )
+        response = bash("sleep 99", stack=_stack_with_fake(fake))
+        assert response.is_error is True
+        assert response.content["timed_out"] is True
+
+    def test_infra_failure_is_an_error(self):
+        """A backend that raises maps to an infra_error response."""
+        fake = FakeSandbox(raises=RuntimeError("daemon down"))
+        response = bash("echo hi", stack=_stack_with_fake(fake))
+        assert response.is_error is True
+        assert "daemon down" in response.content["infra_error"]
+
+
+class TestPolicyEnforcement:
+    """Policy is read from config and enforced before the sandbox runs."""
+
+    def test_denied_command_short_circuits_before_exec(self):
+        """A denied command never reaches the sandbox."""
+        fake = FakeSandbox()
+        response = bash(
+            "dd if=/dev/zero of=/dev/sda", stack=_stack_with_fake(fake)
+        )
+        assert response.is_error is True
+        assert "denied" in response.content
+        assert fake.calls == []  # exec never called
+
+    def test_config_policy_is_applied(self):
+        """An allowlist policy from config refuses an unlisted command."""
+        fake = FakeSandbox()
+        options = {"bash": {"policy": {"mode": "allowlist", "allow": ["ls"]}}}
+        response = bash("curl http://x", stack=_stack_with_fake(fake, options))
+        assert response.is_error is True
+        assert "denied" in response.content
+        assert fake.calls == []
+
+    def test_escalate_maps_to_needs_approval(self):
+        """on_violation=ask_human surfaces a needs_approval response."""
+        fake = FakeSandbox()
+        options = {"bash": {"policy": {"on_violation": "ask_human"}}}
+        response = bash("shutdown now", stack=_stack_with_fake(fake, options))
+        assert response.is_error is True
+        assert "needs_approval" in response.content
+        assert fake.calls == []
+
+    def test_malformed_policy_config_is_reported(self):
+        """A bad policy block is a clear config error, not a silent default."""
+        fake = FakeSandbox()
+        options = {"bash": {"policy": {"modee": "allowlist"}}}
+        response = bash("echo hi", stack=_stack_with_fake(fake, options))
+        assert response.is_error is True
+        assert "invalid bash policy config" in response.content["error"]
+
+    def test_policy_is_passed_through_to_exec(self):
+        """The resolved policy (timeout etc.) reaches the sandbox exec."""
+        fake = FakeSandbox()
+        options = {"bash": {"policy": {"timeout_s": 42}}}
+        bash("echo hi", stack=_stack_with_fake(fake, options))
+        assert fake.last_call.policy.timeout_s == 42
+        assert fake.last_call.timeout_s == 42
+
+
+class TestWorkspaceRouting:
+    """cwd handling and workspace confinement."""
+
+    def test_runs_in_workspace_by_default(self):
+        """With no cwd, the command runs in the agent workspace root."""
+        fake = FakeSandbox()
+        bash("pwd", stack=_stack_with_fake(fake))
+        assert fake.last_call.cwd == "/workspace/agents/agent-a/default"
+
+    def test_relative_cwd_is_joined(self):
+        """A relative cwd runs in that subdirectory of the workspace."""
+        fake = FakeSandbox()
+        bash("pwd", cwd="src", stack=_stack_with_fake(fake))
+        assert fake.last_call.cwd == "/workspace/agents/agent-a/default/src"
+
+    def test_escaping_cwd_is_refused(self):
+        """A cwd that climbs out of the workspace is refused."""
+        fake = FakeSandbox()
+        response = bash("pwd", cwd="../../etc", stack=_stack_with_fake(fake))
+        assert response.is_error is True
+        assert "escapes the workspace" in response.content["error"]
+        assert fake.calls == []
+
+
+class TestSandboxResolution:
+    """Building the sandbox from config when none is pre-seeded."""
+
+    def test_missing_backend_is_a_clear_error(self):
+        """An allowed command with no backend named reports it cleanly."""
+        response = bash("echo hi", stack=_stack(config_options={"bash": {}}))
+        assert response.is_error is True
+        assert "sandbox unavailable" in response.content["error"]
+
+    def test_missing_stack_is_handled(self):
+        """Called without a stack, the tool errors instead of crashing."""
+        response = bash("echo hi", stack=None)
+        assert response.is_error is True

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -154,6 +154,45 @@ class TestWorkspaceRouting:
         assert fake.calls == []
 
 
+class TestAudit:
+    """Every command outcome is tallied in the session's audit counters."""
+
+    def test_run_is_counted(self):
+        """A completed command increments the ``run`` counter."""
+        fake = FakeSandbox(
+            ExecResult(exit_code=0, stdout="hi", stderr="", duration_s=0.1)
+        )
+        manager = SandboxManager(LOCAL, "session-1", sandbox=fake)
+        stack = _stack(sandbox_manager=manager)
+        bash("echo hi", stack=stack)
+        assert manager.audit.counters["run"] == 1
+
+    def test_denied_is_counted(self):
+        """A policy denial increments the ``denied`` counter, not ``run``."""
+        fake = FakeSandbox()
+        manager = SandboxManager(LOCAL, "session-1", sandbox=fake)
+        stack = _stack(sandbox_manager=manager)
+        bash("dd if=/dev/zero of=/dev/sda", stack=stack)
+        assert manager.audit.counters["denied"] == 1
+        assert manager.audit.counters["run"] == 0
+
+    def test_timeout_is_counted(self):
+        """A timed-out command increments the ``timed_out`` counter."""
+        fake = FakeSandbox(
+            ExecResult(
+                exit_code=-1,
+                stdout="",
+                stderr="",
+                duration_s=1.0,
+                timed_out=True,
+            )
+        )
+        manager = SandboxManager(LOCAL, "session-1", sandbox=fake)
+        stack = _stack(sandbox_manager=manager)
+        bash("sleep 99", stack=stack)
+        assert manager.audit.counters["timed_out"] == 1
+
+
 class TestSandboxResolution:
     """Building the sandbox from config when none is pre-seeded."""
 

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -6,6 +6,7 @@ read from ``config.options['bash']`` and enforced before the sandbox runs, and
 that the command reaches the backend with the right cwd and policy.
 """
 
+import os
 from types import SimpleNamespace
 
 from gimle.hugin.sandbox.fake import FakeSandbox
@@ -121,6 +122,21 @@ class TestPolicyEnforcement:
         assert response.is_error is True
         assert "invalid bash policy config" in response.content["error"]
 
+    def test_unparseable_command_is_surfaced_distinctly(self):
+        """A parser limitation is reported as 'unparseable', not 'denied'.
+
+        The model must not mistake "the guard's parser choked" for a policy
+        refusal, or it will try other (also-unparseable) syntax instead of
+        rephrasing.
+        """
+        fake = FakeSandbox()
+        response = bash("ls '", stack=_stack_with_fake(fake))  # bad quoting
+        assert response.is_error is True
+        assert "unparseable" in response.content
+        assert "denied" not in response.content
+        assert "hint" in response.content
+        assert fake.calls == []
+
     def test_policy_is_passed_through_to_exec(self):
         """The resolved policy (timeout etc.) reaches the sandbox exec."""
         fake = FakeSandbox()
@@ -191,6 +207,28 @@ class TestAudit:
         stack = _stack(sandbox_manager=manager)
         bash("sleep 99", stack=stack)
         assert manager.audit.counters["timed_out"] == 1
+
+    def test_denied_first_command_is_audited_without_preseeded_manager(self):
+        """A denial is recorded even when no backend has been built yet.
+
+        The audit is resolved before the policy check, so a session whose very
+        first command is denied still counts it (previously dropped, because the
+        manager — and its audit — was only built on the allow path).
+        """
+        import shutil
+
+        stack = _stack(config_options={"bash": {"backend": "local"}})
+        try:
+            response = bash("dd if=/dev/zero of=/dev/sda", stack=stack)
+            assert response.is_error is True
+            assert "denied" in response.content
+            assert stack.agent.session.sandbox is not None
+            assert stack.agent.session.sandbox.audit.counters["denied"] == 1
+        finally:  # the tool builds a real (unstarted) manager under ./storage
+            shutil.rmtree(
+                os.path.join("./storage/sandboxes", "session-1"),
+                ignore_errors=True,
+            )
 
 
 class TestSandboxResolution:

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -82,6 +82,43 @@ class TestResultMapping:
         assert response.is_error is True
         assert "daemon down" in response.content["infra_error"]
 
+    def test_oom_kill_is_an_error(self):
+        """An OOM-killed command is an error, like a timeout — not a plain exit."""
+        fake = FakeSandbox(
+            ExecResult(
+                exit_code=-9,
+                stdout="partial",
+                stderr="",
+                duration_s=0.2,
+                oom_killed=True,
+            )
+        )
+        response = bash("./hog", stack=_stack_with_fake(fake))
+        assert response.is_error is True
+        assert response.content["oom_killed"] is True
+
+    def test_truncated_output_carries_the_spill_path(self):
+        """When output is truncated, the response tells the model where to read."""
+        fake = FakeSandbox(
+            ExecResult(
+                exit_code=0,
+                stdout="tail",
+                stderr="",
+                duration_s=0.1,
+                truncated=True,
+            )
+        )
+        response = bash("cat big", stack=_stack_with_fake(fake))
+        assert response.content["full_output"] == ".hugin/last_output.txt"
+
+    def test_timeout_argument_is_passed_to_exec(self):
+        """A caller-supplied timeout_s reaches the sandbox exec."""
+        fake = FakeSandbox(
+            ExecResult(exit_code=0, stdout="", stderr="", duration_s=0.1)
+        )
+        bash("make", timeout_s=120, stack=_stack_with_fake(fake))
+        assert fake.last_call.timeout_s == 120
+
 
 class TestPolicyEnforcement:
     """Policy is read from config and enforced before the sandbox runs."""

--- a/tests/test_cli_sandbox.py
+++ b/tests/test_cli_sandbox.py
@@ -1,0 +1,49 @@
+"""Tests for the ``hugin sandbox`` CLI command."""
+
+import argparse
+import json
+import os
+
+from gimle.hugin.cli.cli import cmd_sandbox
+from gimle.hugin.sandbox.local import OWNER_FILE
+
+
+def _abandoned(root, name):
+    """Create a workspace whose owner PID is (almost certainly) dead."""
+    path = os.path.join(str(root), name)
+    os.makedirs(path)
+    with open(os.path.join(path, OWNER_FILE), "w") as handle:
+        json.dump({"pid": 2_000_000_000, "created": 0.0}, handle)
+
+
+def test_prune_removes_abandoned_workspace(tmp_path, capsys):
+    """`hugin sandbox prune` reaps a dead-owner workspace and reports it."""
+    _abandoned(tmp_path, "sess-x")
+    args = argparse.Namespace(action="prune", root=str(tmp_path))
+
+    rc = cmd_sandbox(args)
+
+    assert rc == 0
+    assert not os.path.exists(tmp_path / "sess-x")
+    assert "sess-x" in capsys.readouterr().out
+
+
+def test_list_reports_workspaces(tmp_path, capsys):
+    """`hugin sandbox list` prints a row per workspace without removing any."""
+    _abandoned(tmp_path, "sess-y")
+    args = argparse.Namespace(action="list", root=str(tmp_path))
+
+    rc = cmd_sandbox(args)
+
+    assert rc == 0
+    assert os.path.isdir(tmp_path / "sess-y")  # list must not delete
+    out = capsys.readouterr().out
+    assert "sess-y" in out
+    assert "dead" in out
+
+
+def test_list_on_empty_root(tmp_path, capsys):
+    """Listing a root with no workspaces says so cleanly."""
+    args = argparse.Namespace(action="list", root=str(tmp_path))
+    assert cmd_sandbox(args) == 0
+    assert "No sandbox workspaces" in capsys.readouterr().out

--- a/tests/test_sandbox_audit.py
+++ b/tests/test_sandbox_audit.py
@@ -1,0 +1,93 @@
+"""Tests for the ``CommandAudit`` command log and outcome counters.
+
+Two properties matter: outcome counters are always kept (even with no file),
+and when a path is given each command is appended as one JSON line that can be
+grepped after the fact. Best-effort writing must never raise.
+"""
+
+import json
+import os
+
+from gimle.hugin.sandbox.audit import CommandAudit
+
+
+def _entries(path):
+    """Read back the JSONL audit file as a list of dicts."""
+    with open(path, encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+class TestCounters:
+    """Counters partition attempts by outcome, with or without a file."""
+
+    def test_counts_without_a_path(self):
+        """With no path, counters still tally every recorded outcome."""
+        audit = CommandAudit()
+        audit.record(session_id="s", agent_id="a", command="ls", outcome="run")
+        audit.record(
+            session_id="s", agent_id="a", command="dd", outcome="denied"
+        )
+        audit.record(session_id="s", agent_id="a", command="ls", outcome="run")
+        assert audit.counters["run"] == 2
+        assert audit.counters["denied"] == 1
+
+    def test_unrecorded_outcome_is_zero(self):
+        """A never-seen outcome reads back as zero, not a KeyError."""
+        audit = CommandAudit()
+        assert audit.counters["timed_out"] == 0
+
+
+class TestFile:
+    """When a path is set, each command is appended as a JSON line."""
+
+    def test_appends_one_line_per_command(self, tmp_path):
+        """Two commands produce two JSON lines in order."""
+        path = str(tmp_path / "sub" / "audit.jsonl")
+        audit = CommandAudit(path)
+        audit.record(
+            session_id="s", agent_id="a", command="echo hi", outcome="run"
+        )
+        audit.record(
+            session_id="s", agent_id="a", command="rm x", outcome="denied"
+        )
+        entries = _entries(path)
+        assert [e["command"] for e in entries] == ["echo hi", "rm x"]
+        assert [e["outcome"] for e in entries] == ["run", "denied"]
+
+    def test_records_the_full_outcome(self, tmp_path):
+        """Exit code, duration, and the flag fields are all persisted."""
+        path = str(tmp_path / "audit.jsonl")
+        audit = CommandAudit(path)
+        audit.record(
+            session_id="sess",
+            agent_id="agent",
+            command="sleep 99",
+            outcome="timed_out",
+            exit_code=-1,
+            duration_s=1.5,
+            truncated=True,
+            timed_out=True,
+        )
+        (entry,) = _entries(path)
+        assert entry["session_id"] == "sess"
+        assert entry["agent_id"] == "agent"
+        assert entry["exit_code"] == -1
+        assert entry["duration_s"] == 1.5
+        assert entry["truncated"] is True
+        assert entry["timed_out"] is True
+        assert entry["oom_killed"] is False
+
+    def test_creates_parent_directories(self, tmp_path):
+        """The audit file's parent dirs are created on first write."""
+        path = str(tmp_path / "deep" / "nested" / "audit.jsonl")
+        CommandAudit(path).record(
+            session_id="s", agent_id="a", command="ls", outcome="run"
+        )
+        assert os.path.isfile(path)
+
+    def test_write_failure_is_swallowed(self, tmp_path):
+        """A path that cannot be written (a directory) never raises."""
+        path = str(tmp_path)  # a directory: open-for-append will fail
+        audit = CommandAudit(path)
+        audit.record(session_id="s", agent_id="a", command="ls", outcome="run")
+        assert audit.counters["run"] == 1  # counted despite the write failing

--- a/tests/test_sandbox_config.py
+++ b/tests/test_sandbox_config.py
@@ -1,0 +1,77 @@
+"""Tests for strict config parsing (``Policy.from_dict`` / ``SandboxSpec.from_dict``).
+
+A security policy must fail loud, never silently fall back to a default because
+a key was misspelled — these pin that.
+"""
+
+import pytest
+
+from gimle.hugin.sandbox.policy import Policy
+from gimle.hugin.sandbox.sandbox import SandboxSpec
+
+
+class TestPolicyFromDict:
+    """Parsing the options.bash.policy block."""
+
+    def test_empty_yields_conservative_defaults(self):
+        """An absent/empty policy block is the default denylist policy."""
+        assert Policy.from_dict(None) == Policy()
+        assert Policy.from_dict({}) == Policy()
+
+    def test_known_fields_are_applied(self):
+        """Recognised keys are set, and list fields become tuples."""
+        policy = Policy.from_dict(
+            {"mode": "allowlist", "allow": ["ls", "cat"], "timeout_s": 30}
+        )
+        assert policy.mode == "allowlist"
+        assert policy.allow == ("ls", "cat")
+        assert policy.timeout_s == 30
+
+    def test_unknown_key_raises(self):
+        """A misspelled key is an error, not silently dropped."""
+        with pytest.raises(ValueError, match="unknown policy keys"):
+            Policy.from_dict({"modee": "allowlist"})
+
+    def test_invalid_mode_raises(self):
+        """An invalid mode literal is rejected."""
+        with pytest.raises(ValueError, match="invalid policy mode"):
+            Policy.from_dict({"mode": "allowlst"})
+
+    def test_invalid_on_violation_raises(self):
+        """An invalid on_violation literal is rejected."""
+        with pytest.raises(ValueError, match="invalid on_violation"):
+            Policy.from_dict({"on_violation": "maybe"})
+
+
+class TestSandboxSpecFromDict:
+    """Parsing the options.bash block into a SandboxSpec."""
+
+    def test_backend_is_required(self):
+        """A config must name its backend — there is no silent default."""
+        with pytest.raises(ValueError, match="backend is required"):
+            SandboxSpec.from_dict({"network": True})
+
+    def test_policy_subblock_is_ignored(self):
+        """The nested policy block belongs to Policy, not the spec."""
+        spec = SandboxSpec.from_dict(
+            {"backend": "local", "policy": {"mode": "allowlist"}}
+        )
+        assert spec.backend == "local"
+
+    def test_unknown_key_raises(self):
+        """An unknown spec key is an error."""
+        with pytest.raises(ValueError, match="unknown sandbox keys"):
+            SandboxSpec.from_dict({"backend": "local", "gpu": True})
+
+    def test_invalid_backend_raises(self):
+        """An unrecognised backend name is rejected."""
+        with pytest.raises(ValueError, match="invalid backend"):
+            SandboxSpec.from_dict({"backend": "vm"})
+
+    def test_container_knobs_are_carried(self):
+        """Resource knobs pass through for the container backends."""
+        spec = SandboxSpec.from_dict(
+            {"backend": "docker", "network": True, "memory": "4g"}
+        )
+        assert spec.network is True
+        assert spec.memory == "4g"

--- a/tests/test_sandbox_local.py
+++ b/tests/test_sandbox_local.py
@@ -192,3 +192,16 @@ def test_stop_is_idempotent(tmp_path):
     box.start()
     box.stop()
     box.stop()
+
+
+def test_start_writes_owner_stamp(tmp_path):
+    """start() stamps the workspace with the current PID for the reaper."""
+    import json
+
+    from gimle.hugin.sandbox.local import OWNER_FILE
+
+    box = LocalSandbox(SPEC, session_id="s", workspace_root=str(tmp_path))
+    box.start()
+    stamp = tmp_path / "s" / OWNER_FILE
+    assert stamp.exists()
+    assert json.loads(stamp.read_text())["pid"] == os.getpid()

--- a/tests/test_sandbox_local.py
+++ b/tests/test_sandbox_local.py
@@ -251,4 +251,39 @@ def test_start_writes_owner_stamp(tmp_path):
     box.start()
     stamp = tmp_path / "s" / OWNER_FILE
     assert stamp.exists()
-    assert json.loads(stamp.read_text())["pid"] == os.getpid()
+    record = json.loads(stamp.read_text())
+    assert record["pid"] == os.getpid()
+    assert "start_time" in record  # incarnation token for the reaper
+
+
+def test_start_rewrites_stale_owner_stamp(tmp_path):
+    """A resumed session re-stamps its live PID over a stale (dead) one.
+
+    This is the data-loss fix: without rewriting, the stamp would keep the
+    previous process's dead PID and the reaper would delete the running
+    session's workspace.
+    """
+    import json
+
+    from gimle.hugin.sandbox.local import OWNER_FILE
+
+    session_root = tmp_path / "s"
+    session_root.mkdir()
+    stamp = session_root / OWNER_FILE
+    stamp.write_text(json.dumps({"pid": 999_000_001, "created": 1.0}))
+
+    box = LocalSandbox(SPEC, session_id="s", workspace_root=str(tmp_path))
+    box.start()
+
+    record = json.loads(stamp.read_text())
+    assert record["pid"] == os.getpid()  # rewritten to the live owner
+    assert record["created"] == 1.0  # original creation time preserved
+
+
+def test_process_start_time_is_a_stable_token_for_self(tmp_path):
+    """process_start_time returns a stable, non-empty token for a live PID."""
+    from gimle.hugin.sandbox.local import process_start_time
+
+    first = process_start_time(os.getpid())
+    assert isinstance(first, str) and first
+    assert process_start_time(os.getpid()) == first  # stable across calls

--- a/tests/test_sandbox_local.py
+++ b/tests/test_sandbox_local.py
@@ -287,3 +287,13 @@ def test_process_start_time_is_a_stable_token_for_self(tmp_path):
     first = process_start_time(os.getpid())
     assert isinstance(first, str) and first
     assert process_start_time(os.getpid()) == first  # stable across calls
+
+
+def test_local_backend_warns_it_is_not_isolated(tmp_path, caplog):
+    """Selecting the local backend logs that it provides no isolation."""
+    import gimle.hugin.sandbox.local as local_mod
+
+    local_mod._isolation_warned = False  # arm the one-shot warning
+    with caplog.at_level("WARNING", logger="gimle.hugin.sandbox.local"):
+        LocalSandbox(SPEC, session_id="warn", workspace_root=str(tmp_path))
+    assert any("NO isolation" in record.message for record in caplog.records)

--- a/tests/test_sandbox_local.py
+++ b/tests/test_sandbox_local.py
@@ -1,0 +1,194 @@
+"""Integration tests for ``LocalSandbox`` — real subprocesses on the host.
+
+The local backend has **no isolation boundary** (that's the honest design
+position); these tests pin the behaviour it *does* promise: it enforces policy
+fail-closed, runs in the agent's workspace with a scrubbed environment, kills
+the whole process group on timeout, caps output, and confines file access to
+the workspace.
+"""
+
+import os
+
+import pytest
+
+from gimle.hugin.sandbox.local import LocalSandbox
+from gimle.hugin.sandbox.policy import Policy
+from gimle.hugin.sandbox.sandbox import PolicyDenied, SandboxSpec
+
+pytestmark = pytest.mark.integration
+
+SPEC = SandboxSpec(backend="local")
+
+
+@pytest.fixture
+def sandbox(tmp_path):
+    """Yield a started LocalSandbox under a temp dir, stopped on teardown."""
+    box = LocalSandbox(SPEC, session_id="sess1", workspace_root=str(tmp_path))
+    box.start()
+    yield box
+    box.stop()
+
+
+def _cwd(sandbox, agent="agent-a", branch="main"):
+    return sandbox.workspace_for(agent, branch)
+
+
+class TestExec:
+    """Running commands, exit codes, cwd, and env scrubbing."""
+
+    def test_runs_command_and_captures_stdout(self, sandbox):
+        """A successful command returns exit 0 and its stdout."""
+        result = sandbox.exec(
+            "echo hello", policy=Policy(), cwd=_cwd(sandbox), timeout_s=10
+        )
+        assert result.exit_code == 0
+        assert "hello" in result.stdout
+        assert not result.timed_out
+
+    def test_nonzero_exit_is_reported_not_raised(self, sandbox):
+        """A non-zero exit is data on the result, not an exception."""
+        result = sandbox.exec(
+            "exit 3", policy=Policy(), cwd=_cwd(sandbox), timeout_s=10
+        )
+        assert result.exit_code == 3
+        assert not result.timed_out
+
+    def test_denied_command_raises_policy_denied(self, sandbox):
+        """Policy is enforced inside exec (fail closed), raising PolicyDenied."""
+        with pytest.raises(PolicyDenied):
+            sandbox.exec(
+                "dd if=/dev/zero of=/dev/sda",
+                policy=Policy(),
+                cwd=_cwd(sandbox),
+                timeout_s=10,
+            )
+
+    def test_runs_in_the_given_workspace(self, sandbox):
+        """The command's cwd is the agent workspace."""
+        cwd = _cwd(sandbox)
+        result = sandbox.exec("pwd", policy=Policy(), cwd=cwd, timeout_s=10)
+        assert os.path.realpath(result.stdout.strip()) == os.path.realpath(cwd)
+
+    def test_environment_is_scrubbed(self, sandbox, monkeypatch):
+        """Secrets in the parent env do not leak to the command."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "super-secret")
+        result = sandbox.exec(
+            "echo key=$ANTHROPIC_API_KEY",
+            policy=Policy(),
+            cwd=_cwd(sandbox),
+            timeout_s=10,
+        )
+        assert "super-secret" not in result.stdout
+        assert result.stdout.strip() == "key="
+
+    def test_home_is_the_workspace(self, sandbox):
+        """HOME points at the workspace, not the real user home."""
+        cwd = _cwd(sandbox)
+        result = sandbox.exec(
+            "echo $HOME", policy=Policy(), cwd=cwd, timeout_s=10
+        )
+        assert os.path.realpath(result.stdout.strip()) == os.path.realpath(cwd)
+
+
+class TestTimeout:
+    """Timeout handling and process-group kill."""
+
+    def test_timeout_flags_and_returns_promptly(self, sandbox):
+        """A command exceeding the timeout is killed and flagged."""
+        import time
+
+        start = time.monotonic()
+        result = sandbox.exec(
+            "sleep 30", policy=Policy(), cwd=_cwd(sandbox), timeout_s=1
+        )
+        elapsed = time.monotonic() - start
+        assert result.timed_out
+        assert elapsed < 10  # killed near the 1s deadline, not after 30s
+
+    def test_child_process_group_is_killed(self, sandbox):
+        """A backgrounded child started by the command is killed too."""
+        import time
+
+        cwd = _cwd(sandbox)
+        # Write a pid file for a child that would outlive a naive kill.
+        marker = os.path.join(cwd, "child.pid")
+        sandbox.exec(
+            f"(sleep 30 & echo $! > {marker}); sleep 30",
+            policy=Policy(),
+            cwd=cwd,
+            timeout_s=1,
+        )
+        time.sleep(0.5)
+        with open(marker) as handle:
+            child_pid = int(handle.read().strip())
+        with pytest.raises(ProcessLookupError):
+            os.kill(child_pid, 0)  # gone -> group kill worked
+
+
+class TestOutputTruncation:
+    """Output capping behaviour."""
+
+    def test_large_output_is_truncated_tail_biased(self, sandbox):
+        """Output over the cap is truncated, keeping the tail."""
+        policy = Policy(max_output_bytes=300)
+        result = sandbox.exec(
+            "for i in $(seq 1 1000); do echo line-$i; done",
+            policy=policy,
+            cwd=_cwd(sandbox),
+            timeout_s=10,
+            max_output_bytes=300,
+        )
+        assert result.truncated
+        assert len(result.stdout.encode()) <= 600  # cap + marker slack
+        assert "line-1000" in result.stdout  # tail preserved
+
+    def test_small_output_is_not_truncated(self, sandbox):
+        """Output under the cap is returned whole."""
+        result = sandbox.exec(
+            "echo small", policy=Policy(), cwd=_cwd(sandbox), timeout_s=10
+        )
+        assert not result.truncated
+
+
+class TestWorkspaces:
+    """Per-(agent, branch) workspace directories."""
+
+    def test_workspace_is_per_agent_and_branch(self, sandbox):
+        """Each (agent, branch) gets its own existing directory."""
+        a_main = sandbox.workspace_for("agent-a", "main")
+        a_feat = sandbox.workspace_for("agent-a", "feature")
+        b_main = sandbox.workspace_for("agent-b", "main")
+        assert a_main != a_feat != b_main
+        assert a_main != b_main
+        for path in (a_main, a_feat, b_main):
+            assert os.path.isdir(path)
+
+
+class TestFileAccess:
+    """put_file/get_file and workspace confinement."""
+
+    def test_put_and_get_file_round_trip(self, sandbox):
+        """A file written into the workspace reads back byte-for-byte."""
+        sandbox.put_file("notes/todo.txt", b"remember milk")
+        assert sandbox.get_file("notes/todo.txt") == b"remember milk"
+
+    def test_get_file_rejects_symlink_escape(self, sandbox, tmp_path):
+        """A symlink pointing outside the workspace cannot be read."""
+        secret = tmp_path / "outside_secret.txt"
+        secret.write_text("classified")
+        root = sandbox.workspace_for("agent-a", "main")
+        link = os.path.join(root, "escape")
+        os.symlink(str(secret), link)
+        with pytest.raises(PolicyDenied):
+            sandbox.get_file(
+                os.path.join("agents", "agent-a", "main", "escape")
+            )
+
+
+def test_stop_is_idempotent(tmp_path):
+    """stop() is safe to call twice and on an unstarted sandbox."""
+    box = LocalSandbox(SPEC, session_id="s", workspace_root=str(tmp_path))
+    box.stop()  # never started
+    box.start()
+    box.stop()
+    box.stop()

--- a/tests/test_sandbox_local.py
+++ b/tests/test_sandbox_local.py
@@ -124,6 +124,29 @@ class TestTimeout:
         with pytest.raises(ProcessLookupError):
             os.kill(child_pid, 0)  # gone -> group kill worked
 
+    def test_escaped_child_does_not_hang_exec(self, sandbox):
+        """A child that setsid()'s away and holds the pipe cannot hang exec.
+
+        The old code drained with an un-timed communicate() after the kill, so
+        an escaped grandchild holding stdout blocked until it exited (30s here),
+        defeating the timeout. exec must return near the deadline regardless.
+        """
+        import time
+
+        start = time.monotonic()
+        # Trailing `; true` forces bash to fork python (rather than exec it in
+        # place), so python is a group member that can setsid() into its own
+        # session and escape the kill while holding the inherited stdout pipe.
+        result = sandbox.exec(
+            "python3 -c 'import os, time; os.setsid(); time.sleep(30)' ; true",
+            policy=Policy(),
+            cwd=_cwd(sandbox),
+            timeout_s=1,
+        )
+        elapsed = time.monotonic() - start
+        assert result.timed_out
+        assert elapsed < 8  # bounded drain, not blocked on the 30s sleep
+
 
 class TestOutputTruncation:
     """Output capping behaviour."""
@@ -148,6 +171,30 @@ class TestOutputTruncation:
             "echo small", policy=Policy(), cwd=_cwd(sandbox), timeout_s=10
         )
         assert not result.truncated
+
+    def test_runaway_output_is_capped_without_hanging(self, sandbox):
+        """Unbounded output is bounded in memory and the process is killed.
+
+        ``yes`` produces output forever; without a byte ceiling the parent
+        buffers it all and OOMs. The capture must stop it at the ceiling, well
+        before the (10s) timeout, and keep the model-facing output tiny.
+        """
+        import time
+
+        start = time.monotonic()
+        result = sandbox.exec(
+            "yes",
+            policy=Policy(max_output_bytes=300),
+            cwd=_cwd(sandbox),
+            timeout_s=10,
+            max_output_bytes=300,
+        )
+        elapsed = time.monotonic() - start
+        assert result.truncated
+        assert not result.timed_out  # killed for output, not for wall-clock
+        assert elapsed < 8
+        assert len(result.stdout.encode()) <= 600  # cap + marker slack
+        assert "output exceeded" in result.stderr
 
 
 class TestWorkspaces:

--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -55,3 +55,23 @@ class TestSandboxManager:
         """Without an injected backend, get() builds one from the spec."""
         manager = SandboxManager(LOCAL, "s", workspace_root=str(tmp_path))
         assert isinstance(manager.get(), LocalSandbox)
+
+
+class TestLifecycleCounters:
+    """The manager tallies backend starts and start-failures."""
+
+    def test_start_is_counted_once(self, tmp_path):
+        """Creating a backend counts one start; a re-get() does not add more."""
+        manager = SandboxManager(LOCAL, "s", workspace_root=str(tmp_path))
+        manager.get()
+        manager.get()
+        assert manager.audit.counters["sandbox_starts"] == 1
+        assert manager.audit.counters["sandbox_start_failures"] == 0
+
+    def test_start_failure_is_counted_and_reraised(self):
+        """A backend that cannot be created counts a failure and propagates."""
+        manager = SandboxManager(SandboxSpec(backend="docker"), "s")
+        with pytest.raises(NotImplementedError):
+            manager.get()
+        assert manager.audit.counters["sandbox_start_failures"] == 1
+        assert manager.audit.counters["sandbox_starts"] == 0

--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -1,0 +1,57 @@
+"""Tests for ``SandboxManager`` and the ``create_sandbox`` factory."""
+
+import pytest
+
+from gimle.hugin.sandbox.fake import FakeSandbox
+from gimle.hugin.sandbox.local import LocalSandbox
+from gimle.hugin.sandbox.manager import SandboxManager
+from gimle.hugin.sandbox.sandbox import SandboxSpec, create_sandbox
+
+LOCAL = SandboxSpec(backend="local")
+
+
+class TestCreateSandbox:
+    """The backend factory."""
+
+    def test_local_backend_builds_local_sandbox(self, tmp_path):
+        """backend='local' constructs a LocalSandbox."""
+        box = create_sandbox(LOCAL, "s", workspace_root=str(tmp_path))
+        assert isinstance(box, LocalSandbox)
+
+    def test_docker_backend_not_yet_implemented(self):
+        """backend='docker' is a clear NotImplementedError until phase 2."""
+        with pytest.raises(NotImplementedError, match="phase 2"):
+            create_sandbox(SandboxSpec(backend="docker"), "s")
+
+    def test_ssh_backend_not_yet_implemented(self):
+        """backend='ssh' is a clear NotImplementedError until phase 2."""
+        with pytest.raises(NotImplementedError, match="phase 2"):
+            create_sandbox(SandboxSpec(backend="ssh"), "s")
+
+
+class TestSandboxManager:
+    """Lazy lifecycle around a single backend."""
+
+    def test_get_starts_the_injected_sandbox(self):
+        """get() returns and starts the injected backend."""
+        fake = FakeSandbox()
+        manager = SandboxManager(LOCAL, "s", sandbox=fake)
+        assert manager.get() is fake
+        assert fake.started
+
+    def test_close_stops_the_sandbox(self):
+        """close() stops the backend."""
+        fake = FakeSandbox()
+        manager = SandboxManager(LOCAL, "s", sandbox=fake)
+        manager.get()
+        manager.close()
+        assert fake.stopped
+
+    def test_close_is_safe_when_never_started(self):
+        """close() on an unused manager does nothing and does not raise."""
+        SandboxManager(LOCAL, "s").close()
+
+    def test_lazily_creates_a_backend_when_none_injected(self, tmp_path):
+        """Without an injected backend, get() builds one from the spec."""
+        manager = SandboxManager(LOCAL, "s", workspace_root=str(tmp_path))
+        assert isinstance(manager.get(), LocalSandbox)

--- a/tests/test_sandbox_policy.py
+++ b/tests/test_sandbox_policy.py
@@ -1,0 +1,247 @@
+"""Tests for the bash command policy engine (``gimle.hugin.sandbox.policy``).
+
+The policy engine is a **pure** function: ``evaluate(command, policy) ->
+Decision``. It is a guardrail against *accidents*, not a security boundary —
+the runtime (container / disposable remote) is the boundary. These tests pin
+both halves of that contract:
+
+- what the engine **catches** (blunt accidents, dangerous env assignments,
+  parse failures fail closed, and — in opt-in strict mode — the shell escape
+  hatches), walking the whole AST so a denied binary hidden behind ``&&`` or
+  inside ``$(...)`` is still caught; and
+- what it deliberately **does not** catch (``python3 -c '...'`` and other
+  interpreter-based execution) — asserted explicitly, because pretending the
+  wordlist stops those is the exact "security theatre" this design rejects.
+"""
+
+import pytest
+
+from gimle.hugin.sandbox.policy import (
+    Allow,
+    Deny,
+    Escalate,
+    Policy,
+    evaluate,
+)
+
+
+def _decision(command, **policy_kwargs):
+    return evaluate(command, Policy(**policy_kwargs))
+
+
+class TestDenylistDefaultAllowsOrdinaryCommands:
+    """The default (denylist, permissive) mode lets normal work through."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "ls -la",
+            "cat file.txt | grep needle",
+            "rg TODO src/",
+            "git status",
+            "git push origin main",
+            "rm -rf ./build",  # relative target — an accident, but not catastrophic
+            "find . -name '*.py'",
+            "python3 script.py",
+        ],
+    )
+    def test_ordinary_command_is_allowed(self, command):
+        """Everyday shell work is permitted."""
+        assert isinstance(_decision(command), Allow)
+
+
+class TestDenylistIsNotACapabilityBoundary:
+    """By design: interpreter-based execution is ALLOWED in denylist mode.
+
+    The container/remote is the boundary, not the wordlist. These asserts are
+    the honest counterpart to the security review — if any of them start
+    failing as Deny, someone has reintroduced allowlist theatre.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "python3 -c 'import os; os.system(\"id\")'",
+            "uv run python -c 'import os; os.system(\"id\")'",
+            "awk 'BEGIN{system(\"id\")}'",
+            "find . -exec rm {} +",
+            "git -c core.pager='!sh' log",
+        ],
+    )
+    def test_interpreter_execution_is_allowed_by_design(self, command):
+        """Interpreter-based execution passes — the runtime is the boundary."""
+        assert isinstance(_decision(command), Allow)
+
+
+class TestDenylistCatchesAccidents:
+    """The blunt accident set is denied, wherever it appears in the AST."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "dd if=/dev/zero of=/dev/sda",
+            "mkfs.ext4 /dev/sda1",
+            "shutdown now",
+            "reboot",
+            "rm -rf /",
+            "rm -rf ~",
+            "rm -rf /*",
+            "git push --force origin main",
+            "git push -f origin main",
+        ],
+    )
+    def test_dangerous_command_is_denied(self, command):
+        """The blunt catastrophic set is refused."""
+        assert isinstance(_decision(command), Deny)
+
+    def test_denied_binary_after_operator_is_caught(self):
+        """A denied binary behind && is still found (full AST walk)."""
+        assert isinstance(_decision("ls && dd if=/dev/zero of=/dev/sda"), Deny)
+
+    def test_denied_binary_in_command_substitution_is_caught(self):
+        """A denied binary inside $(...) is still found."""
+        assert isinstance(_decision("echo $(shutdown now)"), Deny)
+
+    def test_denied_binary_in_pipeline_is_caught(self):
+        """A denied binary anywhere in a pipeline is still found."""
+        assert isinstance(_decision("cat x | mkfs.ext4 /dev/sda1"), Deny)
+
+
+class TestDangerousAssignmentsRejected:
+    """Env-assignment prefixes that hijack execution are always rejected."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "LD_PRELOAD=./evil.so ls",
+            "LD_LIBRARY_PATH=/tmp/x ls",
+            "BASH_ENV=./x.sh bash script.sh",
+            "IFS=$' ' ls",
+            "GIT_SSH_COMMAND='sh -c id' git fetch",
+        ],
+    )
+    def test_dangerous_assignment_is_denied(self, command):
+        """An execution-hijacking env prefix is refused on any backend."""
+        assert isinstance(_decision(command), Deny)
+
+    def test_ordinary_assignment_is_allowed(self):
+        """A benign inline assignment does not trip the check."""
+        assert isinstance(_decision("FOO=bar env"), Allow)
+
+
+class TestParseFailureFailsClosed:
+    """An unparseable command is denied, never allowed."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "ls '",  # unterminated single quote
+            'cat "',  # unterminated double quote
+            "echo $(",  # unterminated command substitution
+        ],
+    )
+    def test_unparseable_command_is_denied(self, command):
+        """A command bashlex cannot parse is denied, never allowed."""
+        assert isinstance(_decision(command), Deny)
+
+    def test_parse_failure_reason_mentions_parse(self):
+        """The denial reason names the parse failure."""
+        decision = _decision("ls '")
+        assert isinstance(decision, Deny)
+        assert "pars" in decision.reason.lower()
+
+
+class TestOnViolationEscalate:
+    """on_violation='ask_human' turns a Deny into an Escalate."""
+
+    def test_violation_escalates_when_configured(self):
+        """A would-be denial becomes an escalation under ask_human."""
+        decision = _decision(
+            "dd if=/dev/zero of=/dev/sda", on_violation="ask_human"
+        )
+        assert isinstance(decision, Escalate)
+        assert decision.reason
+
+    def test_allowed_command_is_not_escalated(self):
+        """An allowed command is never escalated."""
+        decision = _decision("ls -la", on_violation="ask_human")
+        assert isinstance(decision, Allow)
+
+
+class TestAllowlistMode:
+    """allowlist mode permits only named command words."""
+
+    def test_listed_command_is_allowed(self):
+        """A command word on the allowlist runs."""
+        assert isinstance(
+            _decision("ls -la", mode="allowlist", allow=("ls", "cat")), Allow
+        )
+
+    def test_unlisted_command_is_denied(self):
+        """A command word not on the allowlist is refused."""
+        assert isinstance(
+            _decision("curl http://x", mode="allowlist", allow=("ls", "cat")),
+            Deny,
+        )
+
+    def test_unlisted_command_behind_operator_is_denied(self):
+        """An unlisted command behind && is still caught (full AST walk)."""
+        assert isinstance(
+            _decision("ls && curl http://x", mode="allowlist", allow=("ls",)),
+            Deny,
+        )
+
+    def test_allowlisting_an_interpreter_is_not_a_boundary(self):
+        """Documents WHY allowlisting interpreters is theatre: it passes."""
+        decision = _decision(
+            "python3 -c 'import os; os.system(\"id\")'",
+            mode="allowlist",
+            allow=("python3",),
+        )
+        assert isinstance(decision, Allow)
+
+
+class TestStrictModeRejectsShellFeatures:
+    """allow_shell_features=False (opt-in, paranoid) blocks the escape hatches."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo $(id)",  # command substitution
+            "echo `id`",  # backtick command substitution
+            "cat <(echo hi)",  # process substitution
+            "eval 'ls'",  # eval
+            "source ./x.sh",  # source
+            ". ./x.sh",  # dot-source
+            "bash -c 'id'",  # interpreter -c
+            "timeout 5 bash -c 'id'",  # wrapper -> interpreter -c
+        ],
+    )
+    def test_shell_feature_is_denied_in_strict_mode(self, command):
+        """Each shell escape hatch is refused when strict mode is on."""
+        assert isinstance(_decision(command, allow_shell_features=False), Deny)
+
+    def test_plain_command_still_allowed_in_strict_mode(self):
+        """Strict mode does not block an ordinary command."""
+        assert isinstance(
+            _decision("ls -la", allow_shell_features=False), Allow
+        )
+
+    def test_shell_features_allowed_by_default(self):
+        """Default mode is permissive — the runtime is the boundary."""
+        assert isinstance(_decision("echo $(id)"), Allow)
+
+
+class TestUnrestrictedMode:
+    """unrestricted mode performs no checks (still fails closed on parse)."""
+
+    def test_dangerous_command_is_allowed(self):
+        """Unrestricted mode performs no command checks."""
+        assert isinstance(
+            _decision("dd if=/dev/zero of=/dev/sda", mode="unrestricted"),
+            Allow,
+        )
+
+    def test_still_fails_closed_on_parse_error(self):
+        """Even unrestricted mode denies an unparseable command."""
+        assert isinstance(_decision("ls '", mode="unrestricted"), Deny)

--- a/tests/test_sandbox_policy.py
+++ b/tests/test_sandbox_policy.py
@@ -107,6 +107,77 @@ class TestDenylistCatchesAccidents:
         assert isinstance(_decision("cat x | mkfs.ext4 /dev/sda1"), Deny)
 
 
+class TestWrapperPrefixesDoNotBypass:
+    """A denied binary run *through* a wrapper (env/timeout/…) is still caught.
+
+    bashlex parses ``env dd`` as one command node (``env`` + args), so a naive
+    first-word check misses ``dd``. The engine peels wrappers to the command
+    they actually run, in every mode.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "env dd if=/dev/zero of=/dev/sda",
+            "nohup shutdown -h now",
+            "nice -n 19 dd if=/dev/zero of=/dev/sda",
+            "timeout 60 dd if=/dev/zero of=/dev/sda",
+            "timeout -s KILL 60 dd if=/dev/zero of=/dev/sda",
+            "xargs -a /dev/null reboot",
+            "command reboot",
+            "setsid dd if=/dev/zero of=/dev/sda",
+            "sudo dd if=/dev/zero of=/dev/sda",
+            "sudo -u root reboot",
+            "timeout 5 nohup reboot",  # nested wrappers
+            "find . -exec shutdown -h now ;",  # find -exec
+        ],
+    )
+    def test_wrapped_denied_binary_is_denied(self, command):
+        """The wrapped catastrophic binary is refused, not the wrapper."""
+        assert isinstance(_decision(command), Deny)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "xargs grep reboot file",  # 'reboot' is grep's ARG, not a command
+            "timeout 60 ls -la",
+            "env FOO=bar ls",
+            "nice -n 10 python3 script.py",
+            "find . -name reboot",  # 'reboot' is a filename pattern, not -exec
+        ],
+    )
+    def test_wrapper_does_not_over_block(self, command):
+        """A denied name in data position (arg/filename) is not a false deny."""
+        assert isinstance(_decision(command), Allow)
+
+    def test_wrapped_unlisted_command_is_denied_in_allowlist(self):
+        """Allowlisting a wrapper does not grant its wrapped command."""
+        assert isinstance(
+            _decision(
+                "env curl http://x", mode="allowlist", allow=("env", "ls")
+            ),
+            Deny,
+        )
+
+    def test_wrapper_with_listed_inner_is_allowed_in_allowlist(self):
+        """A wrapper plus an allowlisted inner command runs."""
+        assert isinstance(
+            _decision(
+                "timeout 60 ls -la",
+                mode="allowlist",
+                allow=("timeout", "ls"),
+            ),
+            Allow,
+        )
+
+    def test_wrapped_interpreter_dash_c_is_denied_in_strict_mode(self):
+        """An interpreter -c reached through a wrapper is caught in strict mode."""
+        assert isinstance(
+            _decision("env python3 -c 'import os'", allow_shell_features=False),
+            Deny,
+        )
+
+
 class TestDangerousAssignmentsRejected:
     """Env-assignment prefixes that hijack execution are always rejected."""
 

--- a/tests/test_sandbox_reaper.py
+++ b/tests/test_sandbox_reaper.py
@@ -1,0 +1,89 @@
+"""Tests for out-of-band reaping of abandoned local sandbox workspaces.
+
+The reaper's one invariant: it removes a workspace only when its owner is gone,
+and never a live peer's. These pin exactly that, using an injected liveness
+check so the tests are deterministic (no real dead PIDs).
+"""
+
+import json
+import os
+import time
+
+from gimle.hugin.sandbox.local import OWNER_FILE
+from gimle.hugin.sandbox.reaper import reap_local_workspaces
+
+NOW = 1_000_000.0
+
+
+def _session_dir(root, name, pid=None, mtime=None):
+    """Create a session dir under root, optionally stamped with ``pid``."""
+    path = os.path.join(str(root), name)
+    os.makedirs(path)
+    if pid is not None:
+        with open(os.path.join(path, OWNER_FILE), "w") as handle:
+            json.dump({"pid": pid, "created": NOW}, handle)
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+def _dead(pid):
+    """Report every PID as dead."""
+    return False
+
+
+def _only(alive_pid):
+    """Return a liveness check where only ``alive_pid`` is alive."""
+    return lambda pid: pid == alive_pid
+
+
+def test_dead_owner_workspace_is_reaped(tmp_path):
+    """A workspace whose owner PID is gone is removed."""
+    _session_dir(tmp_path, "sess-dead", pid=4242)
+    reaped = reap_local_workspaces(str(tmp_path), now=NOW, pid_alive=_dead)
+    assert reaped == ["sess-dead"]
+    assert not os.path.exists(tmp_path / "sess-dead")
+
+
+def test_live_owner_workspace_is_kept(tmp_path):
+    """A workspace whose owner is still alive is never removed."""
+    _session_dir(tmp_path, "sess-live", pid=4242)
+    reaped = reap_local_workspaces(
+        str(tmp_path), now=NOW, pid_alive=_only(4242)
+    )
+    assert reaped == []
+    assert os.path.isdir(tmp_path / "sess-live")
+
+
+def test_unstamped_old_workspace_is_reaped(tmp_path):
+    """An unstamped directory older than min_age is treated as an orphan."""
+    _session_dir(tmp_path, "sess-orphan", mtime=NOW - 3600)
+    reaped = reap_local_workspaces(
+        str(tmp_path), now=NOW, min_age_s=30, pid_alive=_dead
+    )
+    assert reaped == ["sess-orphan"]
+
+
+def test_unstamped_young_workspace_is_kept(tmp_path):
+    """An unstamped directory younger than min_age (mid-startup) is left."""
+    _session_dir(tmp_path, "sess-starting", mtime=NOW - 5)
+    reaped = reap_local_workspaces(
+        str(tmp_path), now=NOW, min_age_s=30, pid_alive=_dead
+    )
+    assert reaped == []
+    assert os.path.isdir(tmp_path / "sess-starting")
+
+
+def test_missing_root_is_a_noop(tmp_path):
+    """Reaping a root that does not exist yet returns nothing."""
+    assert reap_local_workspaces(str(tmp_path / "nope"), now=time.time()) == []
+
+
+def test_only_dead_owners_are_reaped_among_several(tmp_path):
+    """A mixed set: dead owners go, the live one stays."""
+    _session_dir(tmp_path, "a-dead", pid=111)
+    _session_dir(tmp_path, "b-live", pid=222)
+    _session_dir(tmp_path, "c-dead", pid=333)
+    reaped = reap_local_workspaces(str(tmp_path), now=NOW, pid_alive=_only(222))
+    assert sorted(reaped) == ["a-dead", "c-dead"]
+    assert os.path.isdir(tmp_path / "b-live")

--- a/tests/test_sandbox_reaper.py
+++ b/tests/test_sandbox_reaper.py
@@ -102,3 +102,80 @@ def test_list_describes_each_workspace(tmp_path):
     assert by_name["live"].pid == 222
     assert by_name["dead"].alive is False
     assert by_name["dead"].age_s == 200
+
+
+def _stamp(root, name, record, mtime=None):
+    """Create a session dir under root stamped with an arbitrary record."""
+    path = os.path.join(str(root), name)
+    os.makedirs(path)
+    with open(os.path.join(path, OWNER_FILE), "w") as handle:
+        json.dump(record, handle)
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+class TestPidReuseDisambiguation:
+    """The start-time token separates the true owner from a recycled PID."""
+
+    def test_reused_pid_is_reaped(self, tmp_path):
+        """A live PID with a DIFFERENT start time is not the owner — reaped."""
+        _stamp(tmp_path, "sess", {"pid": 222, "start_time": "OLD"})
+        reaped = reap_local_workspaces(
+            str(tmp_path),
+            now=NOW,
+            pid_alive=_only(222),
+            start_time_of=lambda pid: "NEW",
+        )
+        assert reaped == ["sess"]
+
+    def test_same_incarnation_is_kept(self, tmp_path):
+        """A live PID whose start time matches the stamp is the owner — kept."""
+        _stamp(tmp_path, "sess", {"pid": 222, "start_time": "SAME"})
+        reaped = reap_local_workspaces(
+            str(tmp_path),
+            now=NOW,
+            pid_alive=_only(222),
+            start_time_of=lambda pid: "SAME",
+        )
+        assert reaped == []
+        assert os.path.isdir(tmp_path / "sess")
+
+    def test_unknowable_start_time_keeps_workspace(self, tmp_path):
+        """When the start time can't be read now, err toward keeping."""
+        _stamp(tmp_path, "sess", {"pid": 222, "start_time": "OLD"})
+        reaped = reap_local_workspaces(
+            str(tmp_path),
+            now=NOW,
+            pid_alive=_only(222),
+            start_time_of=lambda pid: None,
+        )
+        assert reaped == []
+
+
+class TestCorruptStampIsHandled:
+    """A malformed owner stamp is tolerated, never crashing the sweep."""
+
+    def test_null_pid_does_not_crash_sweep(self, tmp_path):
+        """A null pid (int(None) -> TypeError) is treated as unstamped."""
+        _stamp(tmp_path, "bad", {"pid": None}, mtime=NOW - 3600)
+        _session_dir(tmp_path, "dead", pid=333)
+        reaped = reap_local_workspaces(str(tmp_path), now=NOW, pid_alive=_dead)
+        # Both go: the dead-owner one by PID, the null-pid one by age.
+        assert sorted(reaped) == ["bad", "dead"]
+
+    def test_vanished_dir_does_not_abort_listing(self, tmp_path):
+        """A directory removed mid-scan is skipped, not fatal, for the lister."""
+        _session_dir(tmp_path, "gone", pid=333, mtime=NOW - 10)
+
+        def racing_pid_alive(pid):
+            # Simulate a concurrent reaper removing the dir mid-scan.
+            import shutil
+
+            shutil.rmtree(tmp_path / "gone", ignore_errors=True)
+            return False
+
+        infos = list_local_workspaces(
+            str(tmp_path), now=NOW, pid_alive=racing_pid_alive
+        )
+        assert infos == []  # skipped cleanly, no exception

--- a/tests/test_sandbox_reaper.py
+++ b/tests/test_sandbox_reaper.py
@@ -10,7 +10,10 @@ import os
 import time
 
 from gimle.hugin.sandbox.local import OWNER_FILE
-from gimle.hugin.sandbox.reaper import reap_local_workspaces
+from gimle.hugin.sandbox.reaper import (
+    list_local_workspaces,
+    reap_local_workspaces,
+)
 
 NOW = 1_000_000.0
 
@@ -87,3 +90,15 @@ def test_only_dead_owners_are_reaped_among_several(tmp_path):
     reaped = reap_local_workspaces(str(tmp_path), now=NOW, pid_alive=_only(222))
     assert sorted(reaped) == ["a-dead", "c-dead"]
     assert os.path.isdir(tmp_path / "b-live")
+
+
+def test_list_describes_each_workspace(tmp_path):
+    """The lister reports name, owner pid, liveness, and age."""
+    _session_dir(tmp_path, "live", pid=222, mtime=NOW - 100)
+    _session_dir(tmp_path, "dead", pid=333, mtime=NOW - 200)
+    infos = list_local_workspaces(str(tmp_path), now=NOW, pid_alive=_only(222))
+    by_name = {info.name: info for info in infos}
+    assert by_name["live"].alive is True
+    assert by_name["live"].pid == 222
+    assert by_name["dead"].alive is False
+    assert by_name["dead"].age_s == 200

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -15,9 +15,50 @@ from gimle.hugin.interaction.ask_oracle import AskOracle
 from gimle.hugin.interaction.task_definition import TaskDefinition
 from gimle.hugin.interaction.tool_result import ToolResult
 from gimle.hugin.llm.prompt.prompt import Prompt
+from gimle.hugin.sandbox import FakeSandbox, SandboxManager, SandboxSpec
 from gimle.hugin.tools.tool import Tool
 
 from .memory_storage import MemoryStorage
+
+
+class TestSessionClose:
+    """The session-owned sandbox teardown seam."""
+
+    def _session_with_sandbox(self):
+        session = Session(environment=Environment())
+        fake = FakeSandbox()
+        session.sandbox = SandboxManager(
+            SandboxSpec(backend="local"), session.id, sandbox=fake
+        )
+        session.sandbox.get()  # start the backend
+        return session, fake
+
+    def test_close_stops_the_sandbox_and_clears_it(self):
+        """close() tears down the sandbox and drops the reference."""
+        session, fake = self._session_with_sandbox()
+        session.close()
+        assert fake.stopped
+        assert session.sandbox is None
+
+    def test_close_is_idempotent(self):
+        """close() twice, and on a session that never made a sandbox, is safe."""
+        session, _ = self._session_with_sandbox()
+        session.close()
+        session.close()  # no error on the second call
+        Session(environment=Environment()).close()  # never had a sandbox
+
+    def test_context_manager_closes_on_exit(self):
+        """Leaving a `with Session(...)` block tears the sandbox down."""
+        session = Session(environment=Environment())
+        fake = FakeSandbox()
+        session.sandbox = SandboxManager(
+            SandboxSpec(backend="local"), session.id, sandbox=fake
+        )
+        session.sandbox.get()
+        with session:
+            assert session.sandbox is not None
+        assert fake.stopped
+        assert session.sandbox is None
 
 
 class TestSessionBasic:

--- a/uv.lock
+++ b/uv.lock
@@ -45,6 +45,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bashlex"
+version = "0.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/60/aae0bb54f9af5e0128ba90eb83d8d0d506ee8f0475c4fdda3deeda20b1d2/bashlex-0.18.tar.gz", hash = "sha256:5bb03a01c6d5676338c36fd1028009c8ad07e7d61d8a1ce3f513b7fff52796ee", size = 68742, upload-time = "2023-01-18T15:21:26.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/be/6985abb1011fda8a523cfe21ed9629e397d6e06fb5bae99750402b25c95b/bashlex-0.18-py2.py3-none-any.whl", hash = "sha256:91d73a23a3e51711919c1c899083890cdecffc91d8c088942725ac13e9dcfffa", size = 69539, upload-time = "2023-01-18T15:21:24.167Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -517,6 +526,7 @@ name = "gimle-hugin"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "bashlex" },
     { name = "jinja2" },
     { name = "markdown" },
     { name = "ollama" },
@@ -557,6 +567,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.72.0" },
+    { name = "bashlex", specifier = ">=0.18" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "markdown", specifier = ">=3.7.0" },
     { name = "matplotlib", marker = "extra == 'apps'", specifier = ">=3.8.0" },


### PR DESCRIPTION
## Summary

Adds a `bash` builtin that lets a Hugin agent run shell commands through a
**pluggable execution sandbox**, gated by a pure policy engine. Phase 1 ships
the **local** backend (host subprocess) end to end; `docker` and `ssh` are peers
with no Docker dependency and land in phase 2 (they raise a clear
`NotImplementedError` today). The design's thesis is explicit: *the runtime you
choose is the boundary, not the allowlist* — the policy engine is a guardrail
against accidents, and the local backend says plainly it has no isolation.

Before this PR, a four-judge panel (security / framework architecture /
agent-usability / SRE) reviewed the implementation; every finding that was real
on the local backend today was fixed on the branch, and genuine phase-2 design
items were tracked in `tasks/open/024-bash-sandbox-phase2-followups.md`.

## Changes

**Core**
- `sandbox/policy.py` — pure `evaluate(command, policy) -> Allow/Deny/Escalate`
  over a `bashlex` AST; denylist (default), allowlist, unrestricted, and opt-in
  strict mode; fails closed on parse error. **Peels command wrappers**
  (`env`/`timeout`/`nice`/`xargs`/`sudo`/`find -exec`…) so a denied binary run
  through one is still caught, in every mode.
- `sandbox/sandbox.py` — `Sandbox` ABC, `SandboxSpec` (backend has no default),
  `ExecResult`, tail-biased `truncate_output`, `create_sandbox` factory.
- `sandbox/local.py` — `LocalSandbox`: per-agent workspace, scrubbed env, output
  **streamed under a 2MB memory ceiling**, bounded kill/drain on timeout (no hang
  on a `setsid`-escaped child), realpath file confinement, owner stamp (re-written
  each start, with a PID-reuse-safe start-time token), one-shot no-isolation
  warning.
- `sandbox/manager.py` — one lazily-started sandbox per session + lifecycle
  counters; `sandbox/audit.py` — append-only command log + outcome counters;
  `sandbox/reaper.py` — out-of-band cleanup of abandoned workspaces (dead-owner
  scoped, crash-guarded).
- `tools/builtins/bash.py` — the tool: policy pre-check, audit-before-deny,
  `timeout_s` lever, `oom_killed`→error, spill-path pointer, distinct
  `unparseable` surface.
- `agent/session.py` — `Session.close()` / context manager; sandbox owned on the
  session and torn down on both `hugin run` paths.
- `cli/cli.py` — self-heal reaper on each invocation + `hugin sandbox list/prune`.
- `examples/bash_agent/` and `bashlex` dependency.

## Testing

- Full suite green: **868 passed, 41 skipped, 2 xfailed**.
- New coverage: policy (incl. wrapper-bypass and no-over-block cases), local exec
  (runaway-output cap, setsid-escape non-hang, timeout, confinement, stamp
  rewrite, start-time token), reaper (PID-reuse disambiguation, corrupt-stamp and
  concurrent-sweep guards), manager/audit/config/CLI, and the bash tool
  (result mapping, policy enforcement, audit counters, parse-failure surface).
- Verified end to end through the real framework + `LocalSandbox` (real
  subprocess, real audit file written with correct outcomes).
- `pre-commit run --all-files` clean (black/isort/flake8/mypy strict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)