### PR TITLE
Bash sandbox: phase-2 foundation cleanups (registry, storage-derived root, per-spec ownership)

### DIFF
--- a/src/gimle/hugin/agent/session.py
+++ b/src/gimle/hugin/agent/session.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from gimle.hugin.agent.task import Task
     from gimle.hugin.interaction.interaction import Interaction
     from gimle.hugin.sandbox.manager import SandboxManager
+    from gimle.hugin.sandbox.sandbox import SandboxSpec
     from gimle.hugin.storage.storage import Storage
 
 logger = logging.getLogger(__name__)
@@ -45,9 +46,12 @@ class Session:
         # Update state's session reference if it was passed in without one
         if self.state._session is None:
             self.state._session = self
-        # The session owns at most one sandbox (the bash tool creates it lazily
-        # on first use). Not serialized: a resumed session recreates it.
-        self.sandbox: Optional["SandboxManager"] = None
+        # The session owns one sandbox per distinct SandboxSpec (the bash tool
+        # creates them lazily on first use), so agents with different isolation
+        # profiles get the backend their config asks for — not whichever the
+        # first agent to run bash created. Keyed by spec; not serialized (a
+        # resumed session recreates them).
+        self.sandboxes: Dict["SandboxSpec", "SandboxManager"] = {}
 
     @property
     def id(self) -> str:
@@ -199,16 +203,16 @@ class Session:
         return step_count
 
     def close(self) -> None:
-        """Release session-owned resources (currently the sandbox).
+        """Release session-owned resources (the sandboxes).
 
         Idempotent and safe to call on a session that never created a sandbox.
-        This is the in-process teardown seam; because it is skipped on an
-        abrupt exit (SIGKILL, laptop sleep), it is a complement to — not a
-        replacement for — the out-of-band reaper.
+        Every per-spec sandbox is torn down. This is the in-process teardown
+        seam; because it is skipped on an abrupt exit (SIGKILL, laptop sleep),
+        it is a complement to — not a replacement for — the out-of-band reaper.
         """
-        if self.sandbox is not None:
-            self.sandbox.close()
-            self.sandbox = None
+        for manager in self.sandboxes.values():
+            manager.close()
+        self.sandboxes.clear()
 
     def __enter__(self) -> "Session":
         """Enter a context that guarantees ``close`` on exit."""

--- a/src/gimle/hugin/cli/cli.py
+++ b/src/gimle/hugin/cli/cli.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 
 from gimle.hugin import __version__
 from gimle.hugin.cli.ui import HUGIN_LOGO
+from gimle.hugin.sandbox.sandbox import DEFAULT_SANDBOX_ROOT, sandbox_root_for
 
 VERSION = __version__
 
@@ -284,9 +285,6 @@ def cmd_version(args: argparse.Namespace) -> int:
     return 0
 
 
-DEFAULT_SANDBOX_ROOT = "./storage/sandboxes"
-
-
 def reap_sandboxes_quietly(root: str = DEFAULT_SANDBOX_ROOT) -> None:
     """Best-effort reap of abandoned local sandbox workspaces at startup.
 
@@ -313,7 +311,7 @@ def cmd_sandbox(args: argparse.Namespace) -> int:
         reap_local_workspaces,
     )
 
-    root = args.root or DEFAULT_SANDBOX_ROOT
+    root = args.root or sandbox_root_for(getattr(args, "storage_path", None))
     now = time.time()
 
     if args.action == "prune":
@@ -587,8 +585,11 @@ Examples:
     # Parse arguments
     args = parser.parse_args()
 
-    # Self-heal: reap abandoned local sandbox workspaces on every invocation.
-    reap_sandboxes_quietly()
+    # Self-heal: reap abandoned local sandbox workspaces on every invocation,
+    # resolving the root from --storage-path so it matches where the tool wrote.
+    reap_sandboxes_quietly(
+        sandbox_root_for(getattr(args, "storage_path", None))
+    )
 
     # Load .env file if --env flag is set
     if args.env:

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional, Tuple
 
 from gimle.hugin.sandbox.policy import Allow, Policy, evaluate
 from gimle.hugin.sandbox.sandbox import (
+    DEFAULT_SANDBOX_ROOT,
     ExecResult,
     PolicyDenied,
     Sandbox,
@@ -90,7 +91,7 @@ class LocalSandbox(Sandbox):
         self,
         spec: SandboxSpec,
         session_id: str,
-        workspace_root: str = "./storage/sandboxes",
+        workspace_root: str = DEFAULT_SANDBOX_ROOT,
     ) -> None:
         """Bind this sandbox to ``session_id`` under ``workspace_root``."""
         self._spec = spec

--- a/src/gimle/hugin/sandbox/manager.py
+++ b/src/gimle/hugin/sandbox/manager.py
@@ -12,7 +12,12 @@ import os
 from typing import Optional
 
 from gimle.hugin.sandbox.audit import CommandAudit
-from gimle.hugin.sandbox.sandbox import Sandbox, SandboxSpec, create_sandbox
+from gimle.hugin.sandbox.sandbox import (
+    DEFAULT_SANDBOX_ROOT,
+    Sandbox,
+    SandboxSpec,
+    create_sandbox,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +29,7 @@ class SandboxManager:
         self,
         spec: SandboxSpec,
         session_id: str,
-        workspace_root: str = "./storage/sandboxes",
+        workspace_root: str = DEFAULT_SANDBOX_ROOT,
         sandbox: Optional[Sandbox] = None,
         record_audit_to_file: bool = False,
     ) -> None:

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -13,9 +13,47 @@ a fake backend first.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields
-from typing import Any, Dict, Literal, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple, Type, cast
 
 from gimle.hugin.sandbox.policy import Policy
+
+# --- backend registry ---
+# Backend name -> a lazy loader returning its ``Sandbox`` subclass. Lazy so
+# selecting one backend never imports another's dependency (the ``docker`` SDK,
+# a remote client) — the three backends stay true peers. Adding a backend is a
+# ``register_backend`` call, not an edit to a hardcoded enum + factory.
+_BACKENDS: Dict[str, Callable[[], Type["Sandbox"]]] = {}
+
+
+def register_backend(name: str, loader: Callable[[], Type["Sandbox"]]) -> None:
+    """Register ``name`` -> a thunk that imports and returns its Sandbox class."""
+    _BACKENDS[name] = loader
+
+
+def registered_backends() -> Tuple[str, ...]:
+    """Return the registered backend names, sorted."""
+    return tuple(sorted(_BACKENDS))
+
+
+def _load_local() -> Type["Sandbox"]:
+    """Import the local backend on demand."""
+    from gimle.hugin.sandbox.local import LocalSandbox
+
+    return LocalSandbox
+
+
+def _phase2_loader(name: str) -> Callable[[], Type["Sandbox"]]:
+    """Build a loader for a not-yet-implemented backend (clear error on use)."""
+
+    def loader() -> Type["Sandbox"]:
+        raise NotImplementedError(f"the {name} backend lands in phase 2")
+
+    return loader
+
+
+register_backend("local", _load_local)
+register_backend("docker", _phase2_loader("docker"))
+register_backend("ssh", _phase2_loader("ssh"))
 
 
 def truncate_output(text: str, max_bytes: int) -> Tuple[str, bool]:
@@ -84,7 +122,7 @@ class SandboxSpec:
     ``host`` to ``ssh`` only; the resource knobs to the container backends only.
     """
 
-    backend: Literal["local", "docker", "ssh"]
+    backend: str
     image: Optional[str] = None
     host: Optional[str] = None
     network: bool = False
@@ -109,10 +147,14 @@ class SandboxSpec:
             raise ValueError(f"unknown sandbox keys: {sorted(unknown)}")
         if "backend" not in provided:
             raise ValueError(
-                "options.bash.backend is required (local | docker | ssh)"
+                "options.bash.backend is required "
+                f"({' | '.join(registered_backends())})"
             )
-        if provided["backend"] not in ("local", "docker", "ssh"):
-            raise ValueError(f"invalid backend: {provided['backend']!r}")
+        if provided["backend"] not in registered_backends():
+            raise ValueError(
+                f"invalid backend: {provided['backend']!r} "
+                f"(known: {', '.join(registered_backends())})"
+            )
         return cls(**provided)
 
 
@@ -121,21 +163,22 @@ def create_sandbox(
     session_id: str,
     workspace_root: str = "./storage/sandboxes",
 ) -> "Sandbox":
-    """Construct the backend named by ``spec``.
+    """Construct the backend named by ``spec`` via the registry.
 
-    The concrete backend is imported lazily so selecting ``local`` never pulls
-    in the ``docker`` SDK, and vice versa — the three backends are peers with
-    no shared dependency.
+    The backend's class is imported lazily (through its registered loader) so
+    selecting ``local`` never pulls in the ``docker`` SDK, and vice versa — the
+    backends are peers with no shared dependency.
     """
-    if spec.backend == "local":
-        from gimle.hugin.sandbox.local import LocalSandbox
-
-        return LocalSandbox(spec, session_id, workspace_root)
-    if spec.backend in ("docker", "ssh"):
-        raise NotImplementedError(
-            f"the {spec.backend} backend lands in phase 2"
+    loader = _BACKENDS.get(spec.backend)
+    if loader is None:
+        raise ValueError(
+            f"unknown backend: {spec.backend!r} "
+            f"(known: {', '.join(registered_backends())})"
         )
-    raise ValueError(f"unknown backend: {spec.backend!r}")
+    # Every backend is constructed uniformly as (spec, session_id, root); the
+    # Sandbox ABC declares no constructor, so tell the type checker the shape.
+    factory = cast(Callable[[SandboxSpec, str, str], "Sandbox"], loader())
+    return factory(spec, session_id, workspace_root)
 
 
 class Sandbox(ABC):

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -11,11 +11,31 @@ shared types so the tool and the policy engine can be built and tested against
 a fake backend first.
 """
 
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields
 from typing import Any, Callable, Dict, Optional, Tuple, Type, cast
 
 from gimle.hugin.sandbox.policy import Policy
+
+# Default storage base when a session has no explicit path (in-memory storage).
+DEFAULT_STORAGE_BASE = "./storage"
+
+
+def sandbox_root_for(storage_base: Optional[str]) -> str:
+    """Return the sandbox workspace root for a session's storage base path.
+
+    Sandboxes live beside the rest of a session's storage
+    (``<storage_base>/sandboxes``) — one place, derived from one source — so a
+    custom ``--storage-path`` keeps its sandboxes with its sessions and the
+    startup reaper looks where the tool actually wrote. Falls back to the
+    default base when storage is in-memory / has no path.
+    """
+    return os.path.join(storage_base or DEFAULT_STORAGE_BASE, "sandboxes")
+
+
+# The single canonical default root (was duplicated as a literal in four files).
+DEFAULT_SANDBOX_ROOT = sandbox_root_for(None)
 
 # --- backend registry ---
 # Backend name -> a lazy loader returning its ``Sandbox`` subclass. Lazy so
@@ -161,7 +181,7 @@ class SandboxSpec:
 def create_sandbox(
     spec: SandboxSpec,
     session_id: str,
-    workspace_root: str = "./storage/sandboxes",
+    workspace_root: str = DEFAULT_SANDBOX_ROOT,
 ) -> "Sandbox":
     """Construct the backend named by ``spec`` via the registry.
 

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -22,7 +22,12 @@ from gimle.hugin.sandbox.policy import (
     Policy,
     evaluate,
 )
-from gimle.hugin.sandbox.sandbox import ExecResult, PolicyDenied, SandboxSpec
+from gimle.hugin.sandbox.sandbox import (
+    ExecResult,
+    PolicyDenied,
+    SandboxSpec,
+    sandbox_root_for,
+)
 from gimle.hugin.tools.tool import Tool, ToolResponse
 
 if TYPE_CHECKING:
@@ -241,9 +246,27 @@ def _resolve_manager(
     if manager is not None:
         return cast(SandboxManager, manager)
     spec = SandboxSpec.from_dict(bash_opts)
-    manager = SandboxManager(spec, session.id, record_audit_to_file=True)
+    manager = SandboxManager(
+        spec,
+        session.id,
+        workspace_root=_sandbox_root(session),
+        record_audit_to_file=True,
+    )
     session.sandbox = manager
     return manager
+
+
+def _sandbox_root(session: Any) -> str:
+    """Sandbox root for this session — beside its storage, so both agree.
+
+    Derived from the session's storage base path (``<base>/sandboxes``); falls
+    back to the default when storage is in-memory / has no path. This keeps a
+    custom ``--storage-path`` run's sandboxes with its sessions and lets the
+    startup reaper find them.
+    """
+    storage = getattr(getattr(session, "environment", None), "storage", None)
+    base = getattr(storage, "base_path", None)
+    return sandbox_root_for(str(base) if base else None)
 
 
 def _record(

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -11,7 +11,7 @@ nothing exits 1, and flagging that as a failure just makes the model thrash.
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from gimle.hugin.sandbox.manager import SandboxManager
 from gimle.hugin.sandbox.policy import (
@@ -137,7 +137,9 @@ def bash(
         if decision.reason == UNPARSEABLE_REASON:
             # A parser limitation, NOT a policy refusal — tell the model to
             # rephrase rather than to try a different (permitted) command.
-            _record(stack, command, "unparseable", reason=decision.reason)
+            _record(
+                manager, stack, command, "unparseable", reason=decision.reason
+            )
             return ToolResponse(
                 is_error=True,
                 content={
@@ -148,7 +150,7 @@ def bash(
                     "(use [ ], test, or expr)",
                 },
             )
-        _record(stack, command, "denied", reason=decision.reason)
+        _record(manager, stack, command, "denied", reason=decision.reason)
         return ToolResponse(
             is_error=True,
             content={"denied": decision.reason, "command": command},
@@ -156,7 +158,7 @@ def bash(
     if isinstance(decision, Escalate):
         # Human-approval routing lands in phase 3; until then, refuse cleanly
         # rather than run an out-of-policy command.
-        _record(stack, command, "escalated", reason=decision.reason)
+        _record(manager, stack, command, "escalated", reason=decision.reason)
         return ToolResponse(
             is_error=True,
             content={
@@ -177,7 +179,7 @@ def bash(
     try:
         sandbox = manager.get()
     except (ValueError, NotImplementedError) as error:
-        _record(stack, command, "infra_error", reason=str(error))
+        _record(manager, stack, command, "infra_error", reason=str(error))
         return ToolResponse(
             is_error=True,
             content={"error": f"sandbox unavailable: {error}"},
@@ -205,20 +207,21 @@ def bash(
             max_output_bytes=policy.max_output_bytes,
         )
     except PolicyDenied as denied:  # backstop; pre-check should have caught it
-        _record(stack, command, "denied", reason=denied.reason)
+        _record(manager, stack, command, "denied", reason=denied.reason)
         return ToolResponse(
             is_error=True,
             content={"denied": denied.reason, "command": command},
         )
     except Exception as error:  # infrastructure failure (daemon down, etc.)
         logger.warning("bash infra failure: %s", error)
-        _record(stack, command, "infra_error", reason=str(error))
+        _record(manager, stack, command, "infra_error", reason=str(error))
         return ToolResponse(
             is_error=True,
             content={"infra_error": str(error), "command": command},
         )
 
     _record(
+        manager,
         stack,
         command,
         "timed_out" if result.timed_out else "run",
@@ -234,25 +237,26 @@ def bash(
 def _resolve_manager(
     stack: "Stack", bash_opts: Dict[str, Any]
 ) -> SandboxManager:
-    """Return the session's SandboxManager, creating and caching it if absent.
+    """Return the SandboxManager for this agent's spec — one per distinct spec.
 
-    The session owns the sandbox (``session.sandbox``) so there is a single,
-    typed owner that ``Session.close`` can tear down — a pre-created one (an
-    app, or a test) wins; otherwise it is built from ``options.bash`` and
-    cached on the session.
+    The session owns a sandbox per :class:`SandboxSpec` (``session.sandboxes``),
+    so agents that share an isolation profile share a backend (and its per-agent
+    workspaces) while an agent with a different profile gets its own — the
+    agent's own ``options.bash`` decides where its shell runs, not whichever
+    agent happened to run bash first. ``Session.close`` tears them all down.
     """
     session = stack.agent.session
-    manager = getattr(session, "sandbox", None)
-    if manager is not None:
-        return cast(SandboxManager, manager)
     spec = SandboxSpec.from_dict(bash_opts)
+    existing = session.sandboxes.get(spec)
+    if existing is not None:
+        return existing
     manager = SandboxManager(
         spec,
         session.id,
         workspace_root=_sandbox_root(session),
         record_audit_to_file=True,
     )
-    session.sandbox = manager
+    session.sandboxes[spec] = manager
     return manager
 
 
@@ -270,6 +274,7 @@ def _sandbox_root(session: Any) -> str:
 
 
 def _record(
+    manager: Optional[SandboxManager],
     stack: "Stack",
     command: str,
     outcome: str,
@@ -281,19 +286,17 @@ def _record(
     oom_killed: bool = False,
     reason: Optional[str] = None,
 ) -> None:
-    """Record an outcome in the session's audit, if a sandbox manager exists.
+    """Record an outcome in ``manager``'s audit, if a manager was resolved.
 
-    Denials can happen before the manager is built (no command has run yet); in
-    that rare case there is nothing to record to, so this is a no-op. Recording
-    is best-effort and must never disrupt the command result.
+    A denial can happen before any manager is built (a missing/invalid backend),
+    in which case ``manager`` is None and this is a no-op. Recording is
+    best-effort and must never disrupt the command result.
     """
-    session = stack.agent.session
-    manager = getattr(session, "sandbox", None)
     if manager is None:
         return
     try:
         manager.audit.record(
-            session_id=session.id,
+            session_id=stack.agent.session.id,
             agent_id=stack.agent.id,
             command=command,
             outcome=outcome,

--- a/tasks/open/024-bash-sandbox-phase2-followups.md
+++ b/tasks/open/024-bash-sandbox-phase2-followups.md
@@ -16,19 +16,26 @@ tracked rather than lost.
 
 ## Phase 2 design (do before docker/ssh backends land)
 
-- [ ] **Per-spec (or per-agent) sandbox ownership.** *(architect, HIGH for
-  phase 2)* Today `session.sandbox` is a single manager built first-writer-wins
+**Status:** the three de-risking foundation items — per-spec ownership, the
+backend registry, and the storage-derived sandbox root — landed together on
+branch `bash_sandbox_phase2_foundation`. The remaining items below are still
+open.
+
+- [x] **Per-spec (or per-agent) sandbox ownership.** *(architect, HIGH for
+  phase 2)* ~~Today `session.sandbox` is a single manager built first-writer-wins
   from whichever agent runs bash first; a second agent's differing spec
   (`backend: docker`, `network: false`, cpu/memory caps) is silently ignored, so
-  an agent's isolation is decided by call order. Move to
-  `session.sandboxes: Dict[SandboxSpec, SandboxManager]` (or per-agent), all torn
-  down in `Session.close`. Cheap interim guard: reject a second, differing spec
-  with a clear error instead of silently reusing the first.
-- [ ] **Backend selection via a registry, not a hardcoded enum + if/elif.**
-  *(architect, MEDIUM)* `create_sandbox` / `SandboxSpec.backend`
+  an agent's isolation is decided by call order.~~ **Done** (branch
+  `bash_sandbox_phase2_foundation`): `session.sandboxes: Dict[SandboxSpec,
+  SandboxManager]`; the tool resolves the manager for the calling agent's own
+  spec, same-spec agents share a backend, all are torn down in `Session.close`.
+- [x] **Backend selection via a registry, not a hardcoded enum + if/elif.**
+  *(architect, MEDIUM)* ~~`create_sandbox` / `SandboxSpec.backend`
   `Literal["local","docker","ssh"]` bypass the framework's `Registry` idiom; a
-  third-party backend can't be added without editing core. Register backends
-  (lazy-import thunks) keyed by name.
+  third-party backend can't be added without editing core.~~ **Done** (branch
+  `bash_sandbox_phase2_foundation`): backends are registered as lazy-import
+  loader thunks keyed by name (`register_backend` / `registered_backends`);
+  `SandboxSpec.backend` is a free `str` validated against the registry.
 - [ ] **`put_file`/`get_file` need agent context.** *(architect, MEDIUM)* They
   take no agent/branch and `_confine` resolves against the *session* root, while
   `exec` cwd is agent-scoped — three confinement scopes under one "workspace"
@@ -71,11 +78,15 @@ tracked rather than lost.
   files accumulate for the session lifetime (reaper is session-granularity).
   Rotate the audit by size; reap idle agent/branch subdirs or at least account
   their size.
-- [ ] **Derive the sandbox root from session storage.** *(SRE/architect,
-  MEDIUM)* `"./storage/sandboxes"` is duplicated in four places and is cwd-
+- [x] **Derive the sandbox root from session storage.** *(SRE/architect,
+  MEDIUM)* ~~`"./storage/sandboxes"` is duplicated in four places and is cwd-
   relative, decoupled from `--storage-path`; run from a different dir or with a
-  custom storage path and the self-heal reaper never finds the workspaces. Thread
-  one root from `Environment`/storage config.
+  custom storage path and the self-heal reaper never finds the workspaces.~~
+  **Done** (branch `bash_sandbox_phase2_foundation`): a single
+  `sandbox_root_for(storage_base)` derives `<base>/sandboxes` from the session's
+  storage base path; the bash tool and the CLI reaper both call it, so a custom
+  `--storage-path` run keeps its sandboxes with its sessions and the reaper
+  finds them.
 
 ## Usability / low severity
 

--- a/tests/test_bash_example.py
+++ b/tests/test_bash_example.py
@@ -68,7 +68,7 @@ def test_bash_example_loads_and_runs(tmp_path):
     sandbox = LocalSandbox(
         SPEC, session.id, workspace_root=str(tmp_path / "sb")
     )
-    session.sandbox = SandboxManager(SPEC, session.id, sandbox=sandbox)
+    session.sandboxes[SPEC] = SandboxManager(SPEC, session.id, sandbox=sandbox)
 
     # Scripted model: write a file with bash, then finish.
     registry = get_model_registry()

--- a/tests/test_bash_integration.py
+++ b/tests/test_bash_integration.py
@@ -20,11 +20,16 @@ SPEC = SandboxSpec(backend="local")
 
 
 def _seed_real_sandbox(agent, tmp_path):
-    """Give the agent's session a real LocalSandbox rooted under tmp_path."""
+    """Give the agent's session a real LocalSandbox rooted under tmp_path.
+
+    The config names ``backend: local`` so the tool resolves the same spec the
+    manager is keyed by in ``session.sandboxes``.
+    """
+    agent.config.options = {"bash": {"backend": "local"}}
     sandbox = LocalSandbox(
         SPEC, session_id=agent.session.id, workspace_root=str(tmp_path)
     )
-    agent.session.sandbox = SandboxManager(
+    agent.session.sandboxes[SPEC] = SandboxManager(
         SPEC, agent.session.id, sandbox=sandbox
     )
 

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -18,10 +18,22 @@ LOCAL = SandboxSpec(backend="local")
 
 
 def _stack(config_options=None, sandbox_manager=None):
-    """Build a minimal stack exposing just what the bash tool reads."""
+    """Build a minimal stack exposing just what the bash tool reads.
+
+    When a ``sandbox_manager`` is pre-seeded, the config is given
+    ``backend: local`` so the tool resolves the same LOCAL spec the manager is
+    keyed by in ``session.sandboxes``.
+    """
+    opts = dict(config_options or {})
+    sandboxes = {}
+    if sandbox_manager is not None:
+        bash_opts = dict(opts.get("bash", {}))
+        bash_opts.setdefault("backend", "local")
+        opts["bash"] = bash_opts
+        sandboxes[LOCAL] = sandbox_manager
     environment = SimpleNamespace(env_vars={})
-    session = SimpleNamespace(id="session-1", sandbox=sandbox_manager)
-    config = SimpleNamespace(options=config_options or {})
+    session = SimpleNamespace(id="session-1", sandboxes=sandboxes)
+    config = SimpleNamespace(options=opts)
     agent = SimpleNamespace(
         id="agent-a",
         config=config,
@@ -255,7 +267,7 @@ class TestAudit:
         storage = SimpleNamespace(base_path=tmp_path)
         environment = SimpleNamespace(env_vars={}, storage=storage)
         session = SimpleNamespace(
-            id="sess-x", sandbox=None, environment=environment
+            id="sess-x", sandboxes={}, environment=environment
         )
         config = SimpleNamespace(options={"bash": {"backend": "local"}})
         agent = SimpleNamespace(
@@ -285,13 +297,86 @@ class TestAudit:
             response = bash("dd if=/dev/zero of=/dev/sda", stack=stack)
             assert response.is_error is True
             assert "denied" in response.content
-            assert stack.agent.session.sandbox is not None
-            assert stack.agent.session.sandbox.audit.counters["denied"] == 1
+            manager = stack.agent.session.sandboxes[LOCAL]
+            assert manager.audit.counters["denied"] == 1
         finally:  # the tool builds a real (unstarted) manager under ./storage
             shutil.rmtree(
                 os.path.join("./storage/sandboxes", "session-1"),
                 ignore_errors=True,
             )
+
+
+class TestPerSpecOwnership:
+    """A session owns one backend per spec — call order doesn't decide isolation."""
+
+    def test_agents_with_different_specs_use_their_own_backend(self):
+        """Agent B's command runs in B's backend, not whichever agent ran first.
+
+        Under the old single-sandbox model, the first agent to run bash fixed
+        the backend for the whole session, silently downgrading a later agent's
+        isolation. Here each distinct spec gets its own manager.
+        """
+        spec_a = SandboxSpec(backend="local")
+        spec_b = SandboxSpec(backend="local", network=True)  # a different spec
+        fake_a = FakeSandbox(
+            ExecResult(exit_code=0, stdout="A", stderr="", duration_s=0.1)
+        )
+        fake_b = FakeSandbox(
+            ExecResult(exit_code=0, stdout="B", stderr="", duration_s=0.1)
+        )
+        session = SimpleNamespace(
+            id="session-1",
+            sandboxes={
+                spec_a: SandboxManager(spec_a, "session-1", sandbox=fake_a),
+                spec_b: SandboxManager(spec_b, "session-1", sandbox=fake_b),
+            },
+        )
+
+        def _agent_stack(agent_id, bash_opts):
+            config = SimpleNamespace(options={"bash": bash_opts})
+            agent = SimpleNamespace(
+                id=agent_id,
+                config=config,
+                session=session,
+                environment=SimpleNamespace(env_vars={}),
+            )
+            return SimpleNamespace(agent=agent)
+
+        stack_a = _agent_stack("agent-a", {"backend": "local"})
+        stack_b = _agent_stack("agent-b", {"backend": "local", "network": True})
+
+        # Agent A runs first (would have fixed the backend under the old model).
+        result_a = bash("echo hi", stack=stack_a)
+        result_b = bash("echo hi", stack=stack_b)
+
+        assert result_a.content["stdout"] == "A"
+        assert result_b.content["stdout"] == "B"  # B's own backend, not A's
+
+    def test_same_spec_shares_one_backend(self):
+        """Two agents with the same spec share the one manager (and container)."""
+        fake = FakeSandbox(
+            ExecResult(exit_code=0, stdout="", stderr="", duration_s=0.1)
+        )
+        spec = SandboxSpec(backend="local")
+        session = SimpleNamespace(
+            id="session-1",
+            sandboxes={spec: SandboxManager(spec, "session-1", sandbox=fake)},
+        )
+
+        def _agent_stack(agent_id):
+            config = SimpleNamespace(options={"bash": {"backend": "local"}})
+            agent = SimpleNamespace(
+                id=agent_id,
+                config=config,
+                session=session,
+                environment=SimpleNamespace(env_vars={}),
+            )
+            return SimpleNamespace(agent=agent)
+
+        bash("echo hi", stack=_agent_stack("agent-a"))
+        bash("echo hi", stack=_agent_stack("agent-b"))
+
+        assert len(session.sandboxes) == 1  # one shared backend, two agents
 
 
 class TestSandboxResolution:

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -245,6 +245,32 @@ class TestAudit:
         bash("sleep 99", stack=stack)
         assert manager.audit.counters["timed_out"] == 1
 
+    def test_audit_root_follows_session_storage(self, tmp_path):
+        """A built manager writes its audit under <storage-base>/sandboxes.
+
+        The tool derives the sandbox root from the session's storage, so a
+        custom storage path keeps sandboxes (and their audit) beside its
+        sessions rather than in a fixed ./storage/sandboxes.
+        """
+        storage = SimpleNamespace(base_path=tmp_path)
+        environment = SimpleNamespace(env_vars={}, storage=storage)
+        session = SimpleNamespace(
+            id="sess-x", sandbox=None, environment=environment
+        )
+        config = SimpleNamespace(options={"bash": {"backend": "local"}})
+        agent = SimpleNamespace(
+            id="agent-a",
+            config=config,
+            session=session,
+            environment=environment,
+        )
+        stack = SimpleNamespace(agent=agent)
+
+        bash("dd if=/dev/zero of=/dev/sda", stack=stack)  # denied -> audited
+
+        audit = tmp_path / "sandboxes" / "sess-x" / ".hugin" / "audit.jsonl"
+        assert audit.is_file()
+
     def test_denied_first_command_is_audited_without_preseeded_manager(self):
         """A denial is recorded even when no backend has been built yet.
 

--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -68,6 +68,25 @@ class TestBackendRegistry:
             SandboxSpec.from_dict({"backend": "nope"})
 
 
+class TestSandboxRoot:
+    """The sandbox root is derived from the session's storage base path."""
+
+    def test_default_root_when_no_storage_base(self):
+        """No storage path (in-memory) falls back to the default root."""
+        from gimle.hugin.sandbox.sandbox import (
+            DEFAULT_SANDBOX_ROOT,
+            sandbox_root_for,
+        )
+
+        assert sandbox_root_for(None) == DEFAULT_SANDBOX_ROOT
+
+    def test_root_is_beside_a_custom_storage_base(self):
+        """A custom storage base puts sandboxes under <base>/sandboxes."""
+        from gimle.hugin.sandbox.sandbox import sandbox_root_for
+
+        assert sandbox_root_for("/tmp/run7") == "/tmp/run7/sandboxes"
+
+
 class TestSandboxManager:
     """Lazy lifecycle around a single backend."""
 

--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -28,6 +28,45 @@ class TestCreateSandbox:
         with pytest.raises(NotImplementedError, match="phase 2"):
             create_sandbox(SandboxSpec(backend="ssh"), "s")
 
+    def test_unknown_backend_is_a_clear_error(self):
+        """An unregistered backend fails loud, listing what is known."""
+        with pytest.raises(ValueError, match="unknown backend"):
+            create_sandbox(SandboxSpec(backend="nope"), "s")
+
+
+class TestBackendRegistry:
+    """Backends are looked up through a registry, not a hardcoded factory."""
+
+    def test_registered_backends_include_the_three_peers(self):
+        """local, docker, and ssh are registered out of the box."""
+        from gimle.hugin.sandbox.sandbox import registered_backends
+
+        names = registered_backends()
+        assert {"local", "docker", "ssh"} <= set(names)
+
+    def test_a_registered_backend_is_constructed(self):
+        """A newly registered backend is built by create_sandbox (no core edit)."""
+        from gimle.hugin.sandbox import sandbox as sandbox_mod
+        from gimle.hugin.sandbox.sandbox import register_backend
+
+        built = {}
+
+        class _Toy:
+            def __init__(self, spec, session_id, workspace_root):
+                built["ok"] = (spec.backend, session_id)
+
+        register_backend("toytest", lambda: _Toy)
+        try:
+            create_sandbox(SandboxSpec(backend="toytest"), "s", "/tmp/x")
+            assert built["ok"] == ("toytest", "s")
+        finally:
+            sandbox_mod._BACKENDS.pop("toytest", None)
+
+    def test_from_dict_validates_against_the_registry(self):
+        """SandboxSpec.from_dict rejects a backend the registry doesn't know."""
+        with pytest.raises(ValueError, match="invalid backend"):
+            SandboxSpec.from_dict({"backend": "nope"})
+
 
 class TestSandboxManager:
     """Lazy lifecycle around a single backend."""

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -27,18 +27,17 @@ class TestSessionClose:
     def _session_with_sandbox(self):
         session = Session(environment=Environment())
         fake = FakeSandbox()
-        session.sandbox = SandboxManager(
-            SandboxSpec(backend="local"), session.id, sandbox=fake
-        )
-        session.sandbox.get()  # start the backend
+        spec = SandboxSpec(backend="local")
+        session.sandboxes[spec] = SandboxManager(spec, session.id, sandbox=fake)
+        session.sandboxes[spec].get()  # start the backend
         return session, fake
 
     def test_close_stops_the_sandbox_and_clears_it(self):
-        """close() tears down the sandbox and drops the reference."""
+        """close() tears down every sandbox and clears the registry."""
         session, fake = self._session_with_sandbox()
         session.close()
         assert fake.stopped
-        assert session.sandbox is None
+        assert session.sandboxes == {}
 
     def test_close_is_idempotent(self):
         """close() twice, and on a session that never made a sandbox, is safe."""
@@ -48,17 +47,16 @@ class TestSessionClose:
         Session(environment=Environment()).close()  # never had a sandbox
 
     def test_context_manager_closes_on_exit(self):
-        """Leaving a `with Session(...)` block tears the sandbox down."""
+        """Leaving a `with Session(...)` block tears the sandboxes down."""
         session = Session(environment=Environment())
         fake = FakeSandbox()
-        session.sandbox = SandboxManager(
-            SandboxSpec(backend="local"), session.id, sandbox=fake
-        )
-        session.sandbox.get()
+        spec = SandboxSpec(backend="local")
+        session.sandboxes[spec] = SandboxManager(spec, session.id, sandbox=fake)
+        session.sandboxes[spec].get()
         with session:
-            assert session.sandbox is not None
+            assert session.sandboxes
         assert fake.stopped
-        assert session.sandbox is None
+        assert session.sandboxes == {}
 
 
 class TestSessionBasic:


### PR DESCRIPTION
## Summary

Three de-risking foundation changes for the bash sandbox, all prerequisites
for the docker/ssh backends (task 024). None change local-backend behaviour;
each removes an assumption that only held because `local` is the only backend
and one agent owns the session's sandbox.

## Changes

- **Backend registry** — backends are registered as lazy-import loader thunks
  keyed by name (`register_backend` / `registered_backends`), replacing the
  hardcoded factory `if/elif`. `SandboxSpec.backend` is now a free `str`
  validated against the registry in `from_dict`, so a backend can be added
  without editing the factory, and an unknown backend fails with a clear error.
- **Storage-derived sandbox root** — a single `sandbox_root_for(storage_base)`
  derives `<base>/sandboxes` from the session's storage base path, replacing the
  cwd-relative `"./storage/sandboxes"` literal that was duplicated in four
  places. A custom `--storage-path` run now keeps its sandboxes with its
  sessions, and the startup reaper looks in the right place.
- **Per-spec sandbox ownership** — `session.sandbox` (a single manager built
  first-writer-wins from whichever agent ran bash first) becomes
  `session.sandboxes: Dict[SandboxSpec, SandboxManager]`. The tool resolves the
  manager for the calling agent's own spec; agents that share an isolation
  profile share a backend, an agent with a different profile gets its own.
  `Session.close()` tears them all down. This is what lets a `backend: docker`
  agent and a `backend: local` agent coexist in one session with the isolation
  each asked for, instead of the first one winning.

Task 024's checklist is updated to mark these three items done.

## Testing

- `uv run pytest -q` -> 877 passed, 25 skipped, 2 xfailed.
- New tests: backend registry (register / list / unknown-backend rejection),
  `sandbox_root_for` derivation and default fallback, audit root follows session
  storage, and per-spec ownership (agent B runs in B's backend even when A ran
  bash first; same-spec agents share one backend).
- `uv run pre-commit run --all-files` clean (black/isort/flake8/mypy).