### PR TITLE
Add the docker execution backend: a real containment boundary (Phase 2)

### DIFF
--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -1,0 +1,59 @@
+# The Hugin bash-sandbox image: thick and boring on purpose.
+#
+# A thin image is a false economy — every binary the agent reaches for and does
+# not find is a wasted turn (a failed command, a re-plan). So this ships the
+# tools an agent actually uses, and nothing about Hugin itself: NO Hugin source,
+# NO credentials, NO secrets. The sandbox is dumb; the stack, interactions, and
+# artifacts stay host-side. Its only writable locations at runtime are the
+# bind-mounted /workspace and a small tmpfs /tmp (the rootfs is mounted
+# read-only by DockerSandbox).
+#
+# Build (from repo root):
+#   docker build -f docker/sandbox.Dockerfile -t gimle/hugin-sandbox:latest .
+#
+# In production this should be pinned by digest, scanned (Trivy/Grype), signed
+# (cosign), and verified on pull — the tag here is for local iteration.
+
+# Pin the base by digest in production; the tag is the human-readable anchor.
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+# Boring, widely-used tooling: a POSIX userland, git, search/JSON, an HTTP
+# client, and the three runtimes agents most often shell out to (python, uv,
+# node). Kept to one layer; caches removed so the image stays lean-ish.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        coreutils \
+        curl \
+        findutils \
+        git \
+        jq \
+        less \
+        nodejs \
+        npm \
+        python3 \
+        python3-venv \
+        ripgrep \
+        tini; \
+    rm -rf /var/lib/apt/lists/*
+
+# uv (fast Python package manager) into a system path on PATH for every user.
+RUN set -eux; \
+    curl -LsSf https://astral.sh/uv/install.sh \
+      | env UV_INSTALL_DIR=/usr/local/bin sh; \
+    uv --version
+
+# The workspace is a bind mount at runtime; declare it so tools relying on the
+# directory existing behave even if run before the mount is populated.
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# DockerSandbox runs the container as the host user (a non-root uid) with an
+# idle PID and execs each command; keep a default that is harmless if run bare.
+CMD ["sleep", "infinity"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,12 @@ test = [
     "pytest-mock>=3.10.0",
     "pytest-cov>=4.0.0",
 ]
+# The docker execution backend. Optional so the package installs and the
+# local/ssh backends run with no docker dependency; only `backend: docker`
+# needs this. Install with `pip install "gimle-hugin[sandbox]"`.
+sandbox = [
+    "docker>=7.1",
+]
 apps = [
     "matplotlib>=3.8.0",
     "scipy>=1.11.0",

--- a/src/gimle/hugin/cli/cli.py
+++ b/src/gimle/hugin/cli/cli.py
@@ -295,9 +295,16 @@ def reap_sandboxes_quietly(root: str = DEFAULT_SANDBOX_ROOT) -> None:
     try:
         import time
 
-        from gimle.hugin.sandbox.reaper import reap_local_workspaces
+        from gimle.hugin.sandbox.reaper import (
+            reap_abandoned_containers,
+            reap_local_workspaces,
+        )
 
-        reap_local_workspaces(root, now=time.time())
+        now = time.time()
+        reap_local_workspaces(root, now=now)
+        # Container reaping is daemon-optional: a no-op without the docker SDK
+        # or a running daemon, so local/ssh-only users pay nothing here.
+        reap_abandoned_containers(now=now)
     except Exception:  # cleanup is best-effort and must never break a command
         pass
 
@@ -308,6 +315,7 @@ def cmd_sandbox(args: argparse.Namespace) -> int:
 
     from gimle.hugin.sandbox.reaper import (
         list_local_workspaces,
+        reap_abandoned_containers,
         reap_local_workspaces,
     )
 
@@ -316,12 +324,17 @@ def cmd_sandbox(args: argparse.Namespace) -> int:
 
     if args.action == "prune":
         reaped = reap_local_workspaces(root, now=now)
+        containers = reap_abandoned_containers(now=now)
         if reaped:
             print(f"Reaped {len(reaped)} abandoned workspace(s):")
             for name in reaped:
                 print(f"  {name}")
         else:
             print("No abandoned workspaces to reap.")
+        if containers:
+            print(f"Reaped {len(containers)} abandoned container(s):")
+            for name in containers:
+                print(f"  {name}")
         return 0
 
     # default: list

--- a/src/gimle/hugin/sandbox/__init__.py
+++ b/src/gimle/hugin/sandbox/__init__.py
@@ -11,6 +11,7 @@ The pieces are deliberately orthogonal (see ``tasks/open/023-bash-tool``):
 Backends and the tool that drives them land in later phases.
 """
 
+from gimle.hugin.sandbox.docker import DockerSandbox
 from gimle.hugin.sandbox.fake import FakeSandbox
 from gimle.hugin.sandbox.local import LocalSandbox
 from gimle.hugin.sandbox.manager import SandboxManager
@@ -39,6 +40,7 @@ __all__ = [
     "Allow",
     "Decision",
     "Deny",
+    "DockerSandbox",
     "Escalate",
     "ExecResult",
     "FakeSandbox",

--- a/src/gimle/hugin/sandbox/docker.py
+++ b/src/gimle/hugin/sandbox/docker.py
@@ -20,10 +20,27 @@ machinery — per-``(agent, branch)`` directories, output spill, ``put_file`` /
 unchanged, and a resumed session reattaches its files instead of getting an
 empty container. The container runs as the host user so those files stay
 host-readable.
+
+Two honest limits of this backend's isolation, both dependent on host/daemon
+configuration this code cannot set per-container:
+
+- **No userns-remap here.** The container process runs as the host uid, which
+  makes it non-root *inside* the container but does not remap container-root to
+  a subuid. True userns-remap is a daemon-level setting; enable it on the docker
+  daemon for defence in depth. As a fail-closed guard, ``start()`` refuses to
+  run as uid 0 unless the daemon has userns-remap on (else container-root would
+  equal host-root).
+- **``network: true`` is not egress-filtered.** The default (``network: false``)
+  is the safe path — no network at all. Opting in attaches the default bridge
+  with *unrestricted* egress, including the cloud metadata endpoint
+  (169.254.169.254); it warns loudly and must not be used with untrusted input
+  until the egress-allowlist proxy lands (task 025 follow-ups).
 """
 
+import hashlib
 import logging
 import os
+import threading
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -57,6 +74,9 @@ CONTAINER_WORKSPACE = "/workspace"
 _NAME_PREFIX = "hugin-sbx-"
 _SPILL_RELATIVE = os.path.join(".hugin", "last_output.txt")
 
+# Warn once per process that network:true has unrestricted egress (see start()).
+_network_warned = False
+
 # Container labels the reaper reads to decide abandonment (mirrors the local
 # backend's owner stamp: PID + process-incarnation token, never session alone).
 LABEL_SESSION = "hugin.session"
@@ -80,6 +100,21 @@ _MAX_CAPTURE_BYTES = 2_000_000
 # SIGKILL (so a process ignoring SIGTERM cannot hang past its limit).
 _KILL_AFTER_S = 5
 
+# Extra host-side slack on top of the in-container timeout before ``exec`` gives
+# up waiting for output — covers SDK/daemon latency. The in-container ``timeout``
+# should always fire first; this only backstops a wedged daemon or a command
+# that backgrounded a child holding the output pipe (which ``timeout`` can't
+# reach), so a bash call can never hang the agent's turn indefinitely.
+_HOST_GRACE_S = 10
+
+# How long to keep draining after the foreground process exits, for a lingering
+# background child that still holds the pipe (mirrors LocalSandbox).
+_DRAIN_GRACE_S = 0.5
+
+# Short client timeout for the reaper's daemon calls so a wedged daemon can't
+# stall every ``hugin`` startup (the reaper runs on each invocation).
+REAPER_CLIENT_TIMEOUT_S = 5
+
 
 def import_docker() -> Any:
     """Import and return the docker SDK module, typed ``Any`` for callers.
@@ -96,11 +131,41 @@ def import_docker() -> Any:
 
 
 def _sanitize_name(session_id: str) -> str:
-    """Return a docker-legal container name for ``session_id``."""
-    safe = "".join(
+    """Return a docker-legal name fragment for ``session_id``."""
+    return "".join(
         c if (c.isalnum() or c in "_.-") else "-" for c in session_id
     )
-    return f"{_NAME_PREFIX}{safe}"
+
+
+def _identity_hash(session_id: str, spec: SandboxSpec) -> str:
+    """Return a short stable hash of the raw session id and the spec.
+
+    Folded into the container name for two reasons: two agents in one session
+    with *different* specs (image / network / cpu / memory / pids) must get
+    *different* containers — an agent's hardening profile follows its own config,
+    not whichever agent started a container first — and the *raw* session id is
+    hashed (not just its sanitized fragment) so two ids that sanitize alike
+    (``weird/id`` and ``weird-id`` both -> ``weird-id``) never collide onto one
+    container.
+    """
+    identity = "|".join(
+        str(part)
+        for part in (
+            session_id,
+            spec.image,
+            spec.network,
+            spec.cpu,
+            spec.memory,
+            spec.pids,
+        )
+    )
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:12]
+
+
+def container_name(session_id: str, spec: SandboxSpec) -> str:
+    """Return the docker container name for a ``(session, spec)`` pair."""
+    fragment = _sanitize_name(session_id)[:40]
+    return f"{_NAME_PREFIX}{fragment}-{_identity_hash(session_id, spec)}"
 
 
 class DockerSandbox(Sandbox):
@@ -118,7 +183,7 @@ class DockerSandbox(Sandbox):
         self._host_root = os.path.abspath(
             os.path.join(workspace_root, session_id)
         )
-        self._name = _sanitize_name(session_id)
+        self._name = container_name(session_id, spec)
         self._image = spec.image or DEFAULT_IMAGE
         self._client: Any = None
         self._container: Optional["Container"] = None
@@ -145,25 +210,101 @@ class DockerSandbox(Sandbox):
     def start(self) -> None:
         """Create or reattach the session container; refresh its liveness stamp.
 
-        Idempotent: a running container is reused (resume reattaches the same
-        bind-mounted files), a stopped one is restarted, and only a missing one
-        is created with the mandatory hardening flags. Also writes the host-side
-        owner stamp so the filesystem reaper treats this exactly like a local
-        workspace.
+        Idempotent. A container this same process owns is reused; a container
+        left by a *dead* prior owner (a resume after an abrupt exit) is recreated
+        so its immutable owner labels — which the reaper judges liveness by —
+        refresh to this live process, and any changed hardening spec takes
+        effect. Only a missing container is created fresh. Also writes the
+        host-side owner stamp so the filesystem reaper treats this like a local
+        workspace, and fails closed on an unsafe (root, no userns) configuration.
         """
         docker = self._docker()
         if self._client is None:
             self._client = docker.from_env()
+        self._assert_not_unsafe_root()
+        self._warn_if_network_opted_in()
         os.makedirs(self._host_root, exist_ok=True)
         self._write_owner_stamp()
+        self._ensure_image()
 
         container = self._existing_container()
+        if container is not None and not self._owner_is_current(container):
+            # A dead prior owner's container: its frozen labels name a dead PID,
+            # so the reaper would treat this resumed (live) session as abandoned.
+            # Recreate — the bind-mounted files persist, so this is cheap.
+            self._remove_container(container)
+            container = None
         if container is None:
             container = self._create_container(docker)
         elif container.status != "running":
             container.start()
         self._container = container
-        self._touch_heartbeat()
+
+    def _assert_not_unsafe_root(self) -> None:
+        """Fail closed if running as root without daemon userns-remap.
+
+        Running as the host uid makes the container process non-root only when
+        the orchestrator itself is non-root. If Hugin runs as root (CI, some
+        servers), the sandbox would run as container-root — and without
+        userns-remap container-root *is* host-root, so a single escape primitive
+        is host root. Allowed only when the daemon has userns-remap on (which
+        decouples them); otherwise refused with remediation.
+        """
+        if self._host_uid_gid() != "0:0":
+            return
+        try:
+            security = self._client.info().get("SecurityOptions", []) or []
+        except Exception:  # can't tell — fail closed
+            security = []
+        if any("userns" in str(opt) for opt in security):
+            return
+        raise RuntimeError(
+            "refusing to run the docker sandbox as root without userns-remap: "
+            "container-root would equal host-root. Run Hugin as a non-root "
+            "user, or enable docker userns-remap on the daemon."
+        )
+
+    def _warn_if_network_opted_in(self) -> None:
+        """Warn once that ``network: true`` has unrestricted (unsafe) egress."""
+        if not self._spec.network:
+            return
+        global _network_warned
+        if not _network_warned:
+            logger.warning(
+                "DockerSandbox network:true attaches UNRESTRICTED egress "
+                "(including the cloud metadata endpoint 169.254.169.254); an "
+                "injected command can exfiltrate cloud IAM credentials. Do NOT "
+                "use network:true with untrusted input until egress filtering "
+                "lands. The default network:false is the safe path."
+            )
+            _network_warned = True
+
+    def _ensure_image(self) -> None:
+        """Verify the image is present locally, or raise a clear build/pull hint.
+
+        Fails fast with remediation instead of the SDK's cryptic registry-pull
+        404 thirty steps into a run — the default image is built locally, not
+        published, so a first run would otherwise 404 opaquely.
+        """
+        docker = self._docker()
+        try:
+            self._client.images.get(self._image)
+        except docker.errors.ImageNotFound as error:
+            raise RuntimeError(
+                f"sandbox image {self._image!r} is not available locally. "
+                "Build the default image with: "
+                f"docker build -f docker/sandbox.Dockerfile -t {self._image} ."
+                " — or `docker pull` it, or set options.bash.image to an image "
+                "you already have."
+            ) from error
+
+    def _owner_is_current(self, container: "Container") -> bool:
+        """Return whether ``container``'s owner label is this live process."""
+        labels = container.labels or {}
+        try:
+            return int(labels.get(LABEL_OWNER_PID, "")) == os.getpid()
+        except (ValueError, TypeError):
+            return False
 
     def _existing_container(self) -> Optional["Container"]:
         """Return the session's container if one already exists, else None."""
@@ -181,6 +322,19 @@ class DockerSandbox(Sandbox):
             for (name, soft, hard) in kwargs["ulimits"]
         ]
         return self._client.containers.run(self._image, **kwargs)
+
+    @staticmethod
+    def _remove_container(container: "Container") -> None:
+        """Force-remove a container (SIGKILL + remove) idempotently.
+
+        ``force=True`` kills and removes in one step, so there is no wasted
+        graceful-stop wait; ``v=False`` keeps any volumes (we use a bind mount,
+        which is untouched regardless).
+        """
+        try:
+            container.remove(force=True, v=False)
+        except Exception as error:  # already gone / daemon down — nothing to do
+            logger.debug("container remove failed: %s", error)
 
     def _container_kwargs(self) -> Dict[str, Any]:
         """Build the container-creation kwargs — the whole hardening contract.
@@ -202,8 +356,16 @@ class DockerSandbox(Sandbox):
             "cap_drop": ["ALL"],
             "security_opt": ["no-new-privileges:true"],
             "read_only": True,  # rootfs is immutable; only the mounts below write
-            "tmpfs": {"/tmp": "rw,noexec,nosuid,size=256m"},
+            # Both writable scratch mounts are noexec,nosuid,size-capped —
+            # /dev/shm too, which docker otherwise mounts rw+exec even under a
+            # read-only rootfs (a would-be drop-and-exec path).
+            "tmpfs": {
+                "/tmp": "rw,noexec,nosuid,size=256m",
+                "/dev/shm": "rw,noexec,nosuid,size=64m",
+            },
             "mem_limit": self._spec.memory,
+            # Pin swap to the memory limit so the cap can't be doubled via swap.
+            "memswap_limit": self._spec.memory,
             "nano_cpus": int(self._spec.cpu * 1_000_000_000),
             "pids_limit": self._spec.pids,
             "ulimits": [
@@ -280,18 +442,8 @@ class DockerSandbox(Sandbox):
         ) as error:  # best-effort; the reaper falls back to age/TTL
             logger.debug("could not write owner stamp: %s", error)
 
-    def _touch_heartbeat(self) -> None:
-        """Touch a host-side heartbeat file each start (a TTL freshness signal)."""
-        try:
-            beat = os.path.join(self._host_root, ".hugin", "heartbeat")
-            os.makedirs(os.path.dirname(beat), exist_ok=True)
-            with open(beat, "w", encoding="utf-8") as handle:
-                handle.write(str(time.time()))
-        except OSError as error:  # best-effort
-            logger.debug("could not touch heartbeat: %s", error)
-
     def stop(self) -> None:
-        """Stop and remove the container. Idempotent; safe if never started.
+        """Remove the container. Idempotent; safe if never started.
 
         Unlike ``local`` (whose ``stop`` is a no-op), this releases a real
         resource, so a clean exit does not leak a container. The reaper is the
@@ -301,14 +453,7 @@ class DockerSandbox(Sandbox):
         container = self._container
         if container is None:
             return
-        try:
-            container.stop(timeout=5)
-        except Exception as error:  # already gone / daemon down — nothing to do
-            logger.debug("container stop failed: %s", error)
-        try:
-            container.remove(force=True, v=False)
-        except Exception as error:  # remove is best-effort; reaper is the net
-            logger.debug("container remove failed: %s", error)
+        self._remove_container(container)
         self._container = None
 
     # -- workspaces --
@@ -366,21 +511,25 @@ class DockerSandbox(Sandbox):
             "TERM": "dumb",
         }
 
+        host_deadline = effective_timeout + _KILL_AFTER_S + _HOST_GRACE_S
         started = time.monotonic()
-        exit_code, stdout_raw, stderr_raw, capped = self._exec_capture(
-            wrapped, cwd, env
+        exit_code, stdout_raw, stderr_raw, capped, hung = self._exec_capture(
+            wrapped, cwd, env, host_deadline
         )
         duration = time.monotonic() - started
 
-        # `timeout` reports 124 on a wall-clock timeout; a child SIGKILLed
-        # before that (a memory-cap OOM kill is the common cause) surfaces as
-        # 137. The 137->OOM mapping is a documented heuristic, not certainty.
-        timed_out = exit_code == 124
-        oom_killed = exit_code == 137
+        timed_out, oom_killed = self._classify_exit(
+            exit_code, hung, duration, effective_timeout
+        )
         if capped:
             stderr_raw += (
                 f"\n[hugin: output exceeded {_MAX_CAPTURE_BYTES} bytes; "
                 "stopped reading]"
+            )
+        if hung:
+            stderr_raw += (
+                "\n[hugin: command exceeded its time budget and was abandoned "
+                "(it may have left a background process)]"
             )
 
         out, out_trunc = truncate_output(stdout_raw, max_output_bytes)
@@ -399,15 +548,43 @@ class DockerSandbox(Sandbox):
             oom_killed=oom_killed,
         )
 
-    def _exec_capture(
-        self, cmd: List[str], cwd: str, env: Dict[str, str]
-    ) -> Tuple[int, str, str, bool]:
-        """Stream one exec, capping buffered bytes; return code, out, err, capped.
+    @staticmethod
+    def _classify_exit(
+        exit_code: int, hung: bool, duration: float, timeout_s: int
+    ) -> Tuple[bool, bool]:
+        """Map an exit code to ``(timed_out, oom_killed)``.
 
-        Uses the low-level exec API so output can be drained incrementally and
-        stopped at :data:`_MAX_CAPTURE_BYTES` — past the cap we stop reading and
-        let the in-container ``timeout`` end the process, bounding host memory
-        the same way ``LocalSandbox`` does.
+        ``timeout`` reports 124 on a wall-clock timeout. Exit 137 is a SIGKILL,
+        which is ambiguous: a memory-cap OOM kill *or* ``timeout``'s kill-after
+        finishing off a SIGTERM-ignoring process — so 137 at/after the deadline
+        is classed as a timeout (the more actionable signal for the model),
+        otherwise as OOM. A host-side abandonment (``hung``) is always a timeout.
+        """
+        if hung or exit_code == 124:
+            return True, False
+        if exit_code == 137 and duration >= timeout_s:
+            return True, False  # kill-after finished off a TERM-ignoring hang
+        if exit_code == 137:
+            return False, True  # SIGKILL well before the deadline — likely OOM
+        return False, False
+
+    def _exec_capture(
+        self,
+        cmd: List[str],
+        cwd: str,
+        env: Dict[str, str],
+        deadline_s: float,
+    ) -> Tuple[int, str, str, bool, bool]:
+        """Stream one exec under a byte cap and a host-side deadline.
+
+        Returns ``(exit_code, stdout, stderr, capped, hung)``. Output is drained
+        in a worker thread so a command that backgrounds a child holding the
+        output pipe — which the in-container ``timeout`` cannot reach — can never
+        block the agent's turn: the reader is joined against ``deadline_s``, and
+        once the foreground exec exits, only a short grace. Buffered bytes are
+        hard-capped at :data:`_MAX_CAPTURE_BYTES` so a runaway ``yes`` can't OOM
+        the orchestrator. ``hung`` means the deadline was hit with the reader
+        still blocked; ``exit_code`` is -1 when the process had not exited.
         """
         assert (
             self._container is not None
@@ -424,33 +601,70 @@ class DockerSandbox(Sandbox):
 
         out = bytearray()
         err = bytearray()
-        total = 0
-        capped = False
-        for stdout_chunk, stderr_chunk in stream:
-            for chunk, buf in (
-                (stdout_chunk, out),
-                (stderr_chunk, err),
-            ):
-                if not chunk:
-                    continue
-                total += len(chunk)
-                room = _MAX_CAPTURE_BYTES - len(buf)
-                if room > 0:
-                    buf.extend(chunk[:room])
-            if total > _MAX_CAPTURE_BYTES:
-                capped = True
+        total = [0]  # boxed so the reader thread can mutate it
+        capped = threading.Event()
+        done = threading.Event()
+
+        def drain() -> None:
+            try:
+                for stdout_chunk, stderr_chunk in stream:
+                    for chunk, buf in (
+                        (stdout_chunk, out),
+                        (stderr_chunk, err),
+                    ):
+                        if not chunk:
+                            continue
+                        total[0] += len(chunk)
+                        room = _MAX_CAPTURE_BYTES - len(buf)
+                        if room > 0:
+                            buf.extend(chunk[:room])
+                    if total[0] > _MAX_CAPTURE_BYTES:
+                        capped.set()
+                        break
+            except Exception:  # pipe closed under us / stream error
+                pass
+            finally:
+                done.set()
+
+        reader = threading.Thread(target=drain, daemon=True)
+        reader.start()
+
+        deadline = time.monotonic() + deadline_s
+        while not done.is_set():
+            if not self._exec_running(api, exec_id):
+                # Foreground exec finished; a lingering background child may
+                # still hold the pipe. Give the drain a short grace, then stop.
+                done.wait(timeout=_DRAIN_GRACE_S)
                 break
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.05)
+
+        hung = not done.is_set()
+        try:
+            stream.close()  # release our socket even if the drain is abandoned
+        except Exception:  # pragma: no cover - best-effort
+            pass
 
         info = api.exec_inspect(exec_id)
         exit_code = info.get("ExitCode")
-        if exit_code is None:  # still running (we stopped draining on the cap)
+        if exit_code is None:  # still running (cap break or host-side timeout)
             exit_code = -1
         return (
-            exit_code,
+            int(exit_code),
             bytes(out).decode("utf-8", "replace"),
             bytes(err).decode("utf-8", "replace"),
-            capped,
+            capped.is_set(),
+            hung,
         )
+
+    @staticmethod
+    def _exec_running(api: Any, exec_id: str) -> bool:
+        """Return whether the exec'd process is still running (True if unknown)."""
+        try:
+            return bool(api.exec_inspect(exec_id).get("Running", False))
+        except Exception:  # pragma: no cover - if we can't tell, assume running
+            return True
 
     def _spill(self, cwd: str, stdout: str, stderr: str) -> None:
         """Write full output host-side so the agent can read past the cap.

--- a/src/gimle/hugin/sandbox/docker.py
+++ b/src/gimle/hugin/sandbox/docker.py
@@ -1,0 +1,510 @@
+"""``DockerSandbox`` — run commands inside a hardened, throwaway container.
+
+This is the first backend with a *real* isolation boundary. The container — not
+the policy allowlist — is what makes running an interpreter safe: a denylist by
+design lets ``python3 -c '...'`` through, and the whole point is that it can,
+because the runtime contains it. Every hardening flag below is therefore
+**mandatory** when this backend is chosen (no network, all caps dropped,
+no-new-privileges, read-only root, resource caps, non-root user, no docker
+socket) — they are not tuning knobs, they are the boundary.
+
+The ``docker`` SDK is imported lazily, inside methods, so a user who never
+selects this backend needs neither the library nor a daemon: ``local`` and
+``ssh`` stay true peers. Selecting ``backend: docker`` without the ``sandbox``
+extra installed fails with a clear remediation message at ``start()``.
+
+Workspace model: the session's host directory (``<workspace_root>/<session>``)
+is bind-mounted to ``/workspace`` in the container, so the existing host-side
+machinery — per-``(agent, branch)`` directories, output spill, ``put_file`` /
+``get_file``, and the startup reaper's filesystem GC — all keep working
+unchanged, and a resumed session reattaches its files instead of getting an
+empty container. The container runs as the host user so those files stay
+host-readable.
+"""
+
+import logging
+import os
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+from gimle.hugin.sandbox.local import (
+    OWNER_FILE,
+    process_start_time,
+)
+from gimle.hugin.sandbox.policy import Allow, Policy, evaluate
+from gimle.hugin.sandbox.sandbox import (
+    DEFAULT_SANDBOX_ROOT,
+    ExecResult,
+    PolicyDenied,
+    Sandbox,
+    SandboxSpec,
+    truncate_output,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, never imported at runtime
+    from docker.models.containers import Container
+
+logger = logging.getLogger(__name__)
+
+# The image ships thick and boring on purpose (see docker/sandbox.Dockerfile):
+# a missing binary is a wasted agent turn. Override per-config with ``image:``.
+DEFAULT_IMAGE = "gimle/hugin-sandbox:latest"
+
+# The container's single writable, bind-mounted tree; the host side is
+# ``<workspace_root>/<session_id>``.
+CONTAINER_WORKSPACE = "/workspace"
+
+_NAME_PREFIX = "hugin-sbx-"
+_SPILL_RELATIVE = os.path.join(".hugin", "last_output.txt")
+
+# Container labels the reaper reads to decide abandonment (mirrors the local
+# backend's owner stamp: PID + process-incarnation token, never session alone).
+LABEL_SESSION = "hugin.session"
+LABEL_OWNER_PID = "hugin.owner_pid"
+LABEL_OWNER_START = "hugin.owner_start"
+LABEL_CREATED = "hugin.created"
+LABEL_TTL = "hugin.ttl"
+
+# Backstop lifetime for a container whose owner we can no longer positively
+# identify (PID reused, start-time unreadable). Owner-liveness is the primary
+# signal; this only bounds the pathological case.
+DEFAULT_TTL_S = 24 * 3600
+
+# Hard ceiling on output buffered per command (matches LocalSandbox): a runaway
+# ``yes`` must not OOM the orchestrator. On hitting it we stop draining; the
+# container's pipe buffer fills, the writer blocks, and the in-container
+# ``timeout`` kills it.
+_MAX_CAPTURE_BYTES = 2_000_000
+
+# Grace after the wall-clock timeout before the in-container ``timeout`` sends
+# SIGKILL (so a process ignoring SIGTERM cannot hang past its limit).
+_KILL_AFTER_S = 5
+
+
+def import_docker() -> Any:
+    """Import and return the docker SDK module, typed ``Any`` for callers.
+
+    Central lazy entry point for the SDK: returning the module as ``Any`` keeps
+    every ``docker.from_env()`` / ``docker.errors`` call site free of mypy
+    attribute noise, and keeps the import in one place so ``local``/``ssh`` never
+    pull it in. Raises ``ImportError`` if the optional ``sandbox`` extra is
+    absent; callers translate that into a remediation message or a no-op.
+    """
+    import docker
+
+    return docker
+
+
+def _sanitize_name(session_id: str) -> str:
+    """Return a docker-legal container name for ``session_id``."""
+    safe = "".join(
+        c if (c.isalnum() or c in "_.-") else "-" for c in session_id
+    )
+    return f"{_NAME_PREFIX}{safe}"
+
+
+class DockerSandbox(Sandbox):
+    """Execute commands inside one hardened, session-scoped container."""
+
+    def __init__(
+        self,
+        spec: SandboxSpec,
+        session_id: str,
+        workspace_root: str = DEFAULT_SANDBOX_ROOT,
+    ) -> None:
+        """Bind this sandbox to ``session_id``'s container and host workspace."""
+        self._spec = spec
+        self._session_id = session_id
+        self._host_root = os.path.abspath(
+            os.path.join(workspace_root, session_id)
+        )
+        self._name = _sanitize_name(session_id)
+        self._image = spec.image or DEFAULT_IMAGE
+        self._client: Any = None
+        self._container: Optional["Container"] = None
+
+    # -- docker SDK access (lazy) --
+
+    def _docker(self) -> Any:
+        """Import the docker SDK on demand, or raise a clear remediation error.
+
+        Kept out of module import so selecting ``local`` / ``ssh`` never needs
+        the library; the error names the extra to install.
+        """
+        try:
+            return import_docker()
+        except ImportError as error:  # pragma: no cover - env-dependent
+            raise RuntimeError(
+                "the docker backend needs the 'docker' SDK; install it with "
+                '`pip install "gimle-hugin[sandbox]"` (or `uv pip install '
+                "docker>=7.1`)"
+            ) from error
+
+    # -- lifecycle --
+
+    def start(self) -> None:
+        """Create or reattach the session container; refresh its liveness stamp.
+
+        Idempotent: a running container is reused (resume reattaches the same
+        bind-mounted files), a stopped one is restarted, and only a missing one
+        is created with the mandatory hardening flags. Also writes the host-side
+        owner stamp so the filesystem reaper treats this exactly like a local
+        workspace.
+        """
+        docker = self._docker()
+        if self._client is None:
+            self._client = docker.from_env()
+        os.makedirs(self._host_root, exist_ok=True)
+        self._write_owner_stamp()
+
+        container = self._existing_container()
+        if container is None:
+            container = self._create_container(docker)
+        elif container.status != "running":
+            container.start()
+        self._container = container
+        self._touch_heartbeat()
+
+    def _existing_container(self) -> Optional["Container"]:
+        """Return the session's container if one already exists, else None."""
+        docker = self._docker()
+        try:
+            return self._client.containers.get(self._name)
+        except docker.errors.NotFound:
+            return None
+
+    def _create_container(self, docker: Any) -> "Container":
+        """Create and start the hardened container from ``_container_kwargs``."""
+        kwargs = self._container_kwargs()
+        kwargs["ulimits"] = [
+            docker.types.Ulimit(name=name, soft=soft, hard=hard)
+            for (name, soft, hard) in kwargs["ulimits"]
+        ]
+        return self._client.containers.run(self._image, **kwargs)
+
+    def _container_kwargs(self) -> Dict[str, Any]:
+        """Build the container-creation kwargs — the whole hardening contract.
+
+        Pure and SDK-free (``ulimits`` are plain ``(name, soft, hard)`` tuples,
+        finalized into ``docker.types.Ulimit`` in :meth:`_create_container`) so
+        the flags can be asserted in a unit test without a daemon. Every value
+        here is load-bearing for containment; changing one weakens the boundary.
+        """
+        uid_gid = self._host_uid_gid()
+        return {
+            "name": self._name,
+            "command": ["sleep", "infinity"],  # idle PID; we exec per command
+            "detach": True,
+            "init": True,  # PID 1 reaps double-forked children (local can't)
+            # No network at all unless the operator opts in; the default is the
+            # safe path (a container that cannot reach the metadata endpoint).
+            "network_mode": "bridge" if self._spec.network else "none",
+            "cap_drop": ["ALL"],
+            "security_opt": ["no-new-privileges:true"],
+            "read_only": True,  # rootfs is immutable; only the mounts below write
+            "tmpfs": {"/tmp": "rw,noexec,nosuid,size=256m"},
+            "mem_limit": self._spec.memory,
+            "nano_cpus": int(self._spec.cpu * 1_000_000_000),
+            "pids_limit": self._spec.pids,
+            "ulimits": [
+                ("nofile", 1024, 4096),
+                ("nproc", self._spec.pids, self._spec.pids),
+            ],
+            # Run as the host user so bind-mounted files stay host-readable and
+            # the process is provably non-root inside the container.
+            "user": uid_gid,
+            "hostname": "sandbox",
+            "working_dir": CONTAINER_WORKSPACE,
+            # Empty of inherited secrets; HOME is set per-command to the agent's
+            # own workspace in exec().
+            "environment": {
+                "HOME": CONTAINER_WORKSPACE,
+                "PATH": "/usr/local/bin:/usr/bin:/bin",
+                "LANG": "C.UTF-8",
+                "TERM": "dumb",
+            },
+            "volumes": {
+                self._host_root: {"bind": CONTAINER_WORKSPACE, "mode": "rw"}
+            },
+            "labels": self._labels(),
+        }
+
+    @staticmethod
+    def _host_uid_gid() -> str:
+        """Return ``"uid:gid"`` of the host user (``"0:0"`` where unavailable)."""
+        getuid = getattr(os, "getuid", None)
+        getgid = getattr(os, "getgid", None)
+        if getuid is None or getgid is None:  # pragma: no cover - non-POSIX
+            return "0:0"
+        return f"{getuid()}:{getgid()}"
+
+    def _labels(self) -> Dict[str, str]:
+        """Labels the container reaper reads to find and judge abandonment."""
+        pid = os.getpid()
+        return {
+            LABEL_SESSION: self._session_id,
+            LABEL_OWNER_PID: str(pid),
+            LABEL_OWNER_START: process_start_time(pid) or "",
+            LABEL_CREATED: str(int(time.time())),
+            LABEL_TTL: str(DEFAULT_TTL_S),
+        }
+
+    def _write_owner_stamp(self) -> None:
+        """Stamp the host workspace with the live owner (reused by the reaper).
+
+        Mirrors ``LocalSandbox``: rewritten every ``start()`` with the current
+        PID + start time, so a resumed session (new process, same id) is not
+        mistaken for a dead one and swept out from under itself.
+        """
+        import json
+
+        stamp = os.path.join(self._host_root, OWNER_FILE)
+        pid = os.getpid()
+        record = {
+            "pid": pid,
+            "start_time": process_start_time(pid),
+            "created": time.time(),
+        }
+        try:
+            with open(stamp, encoding="utf-8") as handle:
+                existing = json.load(handle)
+            if isinstance(existing, dict) and "created" in existing:
+                record["created"] = existing["created"]
+        except (OSError, ValueError):
+            pass
+        try:
+            with open(stamp, "w", encoding="utf-8") as handle:
+                json.dump(record, handle)
+        except (
+            OSError
+        ) as error:  # best-effort; the reaper falls back to age/TTL
+            logger.debug("could not write owner stamp: %s", error)
+
+    def _touch_heartbeat(self) -> None:
+        """Touch a host-side heartbeat file each start (a TTL freshness signal)."""
+        try:
+            beat = os.path.join(self._host_root, ".hugin", "heartbeat")
+            os.makedirs(os.path.dirname(beat), exist_ok=True)
+            with open(beat, "w", encoding="utf-8") as handle:
+                handle.write(str(time.time()))
+        except OSError as error:  # best-effort
+            logger.debug("could not touch heartbeat: %s", error)
+
+    def stop(self) -> None:
+        """Stop and remove the container. Idempotent; safe if never started.
+
+        Unlike ``local`` (whose ``stop`` is a no-op), this releases a real
+        resource, so a clean exit does not leak a container. The reaper is the
+        backstop for an abrupt exit that skips this. The bind-mounted host
+        directory is intentionally left for the filesystem reaper / resume.
+        """
+        container = self._container
+        if container is None:
+            return
+        try:
+            container.stop(timeout=5)
+        except Exception as error:  # already gone / daemon down — nothing to do
+            logger.debug("container stop failed: %s", error)
+        try:
+            container.remove(force=True, v=False)
+        except Exception as error:  # remove is best-effort; reaper is the net
+            logger.debug("container remove failed: %s", error)
+        self._container = None
+
+    # -- workspaces --
+
+    def workspace_for(self, agent_id: str, branch: Optional[str]) -> str:
+        """Return the container path for ``(agent, branch)``; create it host-side.
+
+        The returned path is a **container** path under ``/workspace``; the
+        matching host directory (visible in the container through the bind
+        mount) is created so a command has somewhere to run.
+        """
+        rel = os.path.join("agents", agent_id, branch or "default")
+        os.makedirs(os.path.join(self._host_root, rel), exist_ok=True)
+        return f"{CONTAINER_WORKSPACE}/{rel}"
+
+    # -- execution --
+
+    def exec(
+        self,
+        command: str,
+        *,
+        policy: Policy,
+        cwd: str,
+        timeout_s: int,
+        max_output_bytes: int = 16_000,
+    ) -> ExecResult:
+        """Run ``command`` in the container; enforce policy fail-closed.
+
+        Policy is a guardrail against accidents, not the boundary — but it is
+        still enforced here so no route to ``exec`` runs unchecked. The command
+        is wrapped in the container's own ``timeout`` so a hang or a
+        SIGTERM-ignoring loop cannot outlive its limit even if the caller stops
+        reading its output.
+        """
+        decision = evaluate(command, policy)
+        if not isinstance(decision, Allow):
+            raise PolicyDenied(getattr(decision, "reason", "command refused"))
+        if self._container is None:
+            raise RuntimeError("sandbox not started")
+
+        effective_timeout = min(timeout_s, policy.max_timeout_s)
+        wrapped = [
+            "timeout",
+            "-k",
+            str(_KILL_AFTER_S),
+            str(effective_timeout),
+            "bash",
+            "-c",
+            command,
+        ]
+        env = {
+            "HOME": cwd,
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "LANG": "C.UTF-8",
+            "TERM": "dumb",
+        }
+
+        started = time.monotonic()
+        exit_code, stdout_raw, stderr_raw, capped = self._exec_capture(
+            wrapped, cwd, env
+        )
+        duration = time.monotonic() - started
+
+        # `timeout` reports 124 on a wall-clock timeout; a child SIGKILLed
+        # before that (a memory-cap OOM kill is the common cause) surfaces as
+        # 137. The 137->OOM mapping is a documented heuristic, not certainty.
+        timed_out = exit_code == 124
+        oom_killed = exit_code == 137
+        if capped:
+            stderr_raw += (
+                f"\n[hugin: output exceeded {_MAX_CAPTURE_BYTES} bytes; "
+                "stopped reading]"
+            )
+
+        out, out_trunc = truncate_output(stdout_raw, max_output_bytes)
+        err, err_trunc = truncate_output(stderr_raw, max_output_bytes)
+        truncated = out_trunc or err_trunc or capped
+        if truncated:
+            self._spill(cwd, stdout_raw, stderr_raw)
+
+        return ExecResult(
+            exit_code=exit_code,
+            stdout=out,
+            stderr=err,
+            duration_s=duration,
+            truncated=truncated,
+            timed_out=timed_out,
+            oom_killed=oom_killed,
+        )
+
+    def _exec_capture(
+        self, cmd: List[str], cwd: str, env: Dict[str, str]
+    ) -> Tuple[int, str, str, bool]:
+        """Stream one exec, capping buffered bytes; return code, out, err, capped.
+
+        Uses the low-level exec API so output can be drained incrementally and
+        stopped at :data:`_MAX_CAPTURE_BYTES` — past the cap we stop reading and
+        let the in-container ``timeout`` end the process, bounding host memory
+        the same way ``LocalSandbox`` does.
+        """
+        assert (
+            self._container is not None
+        )  # exec() guarantees a started sandbox
+        api = self._client.api
+        exec_id = api.exec_create(
+            self._container.id,
+            cmd,
+            workdir=cwd,
+            environment=env,
+            user=self._host_uid_gid(),
+        )["Id"]
+        stream = api.exec_start(exec_id, stream=True, demux=True)
+
+        out = bytearray()
+        err = bytearray()
+        total = 0
+        capped = False
+        for stdout_chunk, stderr_chunk in stream:
+            for chunk, buf in (
+                (stdout_chunk, out),
+                (stderr_chunk, err),
+            ):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                room = _MAX_CAPTURE_BYTES - len(buf)
+                if room > 0:
+                    buf.extend(chunk[:room])
+            if total > _MAX_CAPTURE_BYTES:
+                capped = True
+                break
+
+        info = api.exec_inspect(exec_id)
+        exit_code = info.get("ExitCode")
+        if exit_code is None:  # still running (we stopped draining on the cap)
+            exit_code = -1
+        return (
+            exit_code,
+            bytes(out).decode("utf-8", "replace"),
+            bytes(err).decode("utf-8", "replace"),
+            capped,
+        )
+
+    def _spill(self, cwd: str, stdout: str, stderr: str) -> None:
+        """Write full output host-side so the agent can read past the cap.
+
+        ``cwd`` is a container path under ``/workspace``; it maps to the host
+        bind-mount root, so the file is visible both to the host and, at the
+        same relative path, to the agent inside the container.
+        """
+        try:
+            host_cwd = self._host_path(cwd)
+            spill_path = os.path.join(host_cwd, _SPILL_RELATIVE)
+            os.makedirs(os.path.dirname(spill_path), exist_ok=True)
+            with open(spill_path, "w", encoding="utf-8") as handle:
+                handle.write(stdout)
+                if stderr:
+                    handle.write("\n--- stderr ---\n")
+                    handle.write(stderr)
+        except OSError as error:  # best-effort; never fail the command over it
+            logger.debug("could not spill full output: %s", error)
+
+    def _host_path(self, container_path: str) -> str:
+        """Map a ``/workspace/...`` container path to its host bind-mount path."""
+        rel = os.path.relpath(container_path, CONTAINER_WORKSPACE)
+        return os.path.normpath(os.path.join(self._host_root, rel))
+
+    # -- files --
+
+    def put_file(self, path: str, content: bytes) -> None:
+        """Write ``content`` into the workspace (host-side, confined)."""
+        target = self._confine(path)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "wb") as handle:
+            handle.write(content)
+
+    def get_file(self, path: str) -> bytes:
+        """Read ``path`` from the workspace, refusing a symlink escape."""
+        target = self._confine(path)
+        with open(target, "rb") as handle:
+            return handle.read()
+
+    def _confine(self, path: str) -> str:
+        """Resolve ``path`` within the host workspace root or raise PolicyDenied.
+
+        Accepts either a container ``/workspace/...`` path or a host/relative
+        one, mapping the former to the host side first, then realpath-checks the
+        result so a symlink planted in the workspace cannot point outside it.
+        """
+        if path == CONTAINER_WORKSPACE or path.startswith(
+            CONTAINER_WORKSPACE + "/"
+        ):
+            path = self._host_path(path)
+        root = os.path.realpath(self._host_root)
+        candidate = path if os.path.isabs(path) else os.path.join(root, path)
+        resolved = os.path.realpath(candidate)
+        if resolved != root and not resolved.startswith(root + os.sep):
+            raise PolicyDenied(f"path escapes the workspace: {path}")
+        return resolved

--- a/src/gimle/hugin/sandbox/fake.py
+++ b/src/gimle/hugin/sandbox/fake.py
@@ -29,8 +29,14 @@ class FakeSandbox(Sandbox):
         self,
         result: Optional[ExecResult] = None,
         raises: Optional[Exception] = None,
+        raises_on_start: Optional[Exception] = None,
     ) -> None:
-        """Return ``result`` (or a benign default) from every exec, or raise."""
+        """Return ``result`` (or a benign default) from every exec, or raise.
+
+        ``raises`` is raised from ``exec``; ``raises_on_start`` from ``start``
+        (modelling a backend that fails to come up — daemon down, image
+        missing, extra not installed).
+        """
         self._result = result or ExecResult(
             exit_code=0,
             stdout="ok",
@@ -38,13 +44,16 @@ class FakeSandbox(Sandbox):
             duration_s=0.0,
         )
         self._raises = raises
+        self._raises_on_start = raises_on_start
         self.started = False
         self.stopped = False
         self.calls: List[_ExecCall] = []
         self.files: Dict[str, bytes] = {}
 
     def start(self) -> None:
-        """Record that the sandbox was started."""
+        """Record that the sandbox was started, or raise if configured to fail."""
+        if self._raises_on_start is not None:
+            raise self._raises_on_start
         self.started = True
 
     def stop(self) -> None:

--- a/src/gimle/hugin/sandbox/reaper.py
+++ b/src/gimle/hugin/sandbox/reaper.py
@@ -148,6 +148,114 @@ def reap_local_workspaces(
     return reaped
 
 
+def reap_abandoned_containers(
+    *,
+    now: float,
+    pid_alive: Callable[[int], bool] = _pid_alive,
+    start_time_of: Callable[[int], Optional[str]] = process_start_time,
+) -> List[str]:
+    """Stop and remove docker sandbox containers whose owner process is gone.
+
+    The container counterpart of :func:`reap_local_workspaces`: a
+    ``DockerSandbox`` labels its container with the owning PID and that
+    process's start-time token, so the same dead-owner test (never session
+    label alone — that would race a live peer) decides abandonment here. A
+    container we cannot positively judge is kept until its TTL elapses.
+
+    Best-effort and **daemon-optional**: if the ``docker`` SDK is absent or the
+    daemon is unreachable, this is a no-op returning ``[]`` — reaping must never
+    require docker, so ``local``/``ssh``-only users are unaffected.
+
+    Returns:
+        The names of the containers that were removed.
+    """
+    from gimle.hugin.sandbox.docker import (
+        LABEL_CREATED,
+        LABEL_OWNER_PID,
+        LABEL_OWNER_START,
+        LABEL_SESSION,
+        LABEL_TTL,
+        import_docker,
+    )
+
+    try:
+        client = import_docker().from_env()
+        containers = client.containers.list(
+            all=True, filters={"label": LABEL_SESSION}
+        )
+    except Exception as error:  # no SDK / daemon down — cleanup stays optional
+        logger.debug("container reap skipped (docker unavailable): %s", error)
+        return []
+
+    reaped: List[str] = []
+    for container in containers:
+        try:
+            labels = container.labels or {}
+            if _container_is_abandoned(
+                labels,
+                now=now,
+                pid_alive=pid_alive,
+                start_time_of=start_time_of,
+                created_key=LABEL_CREATED,
+                pid_key=LABEL_OWNER_PID,
+                start_key=LABEL_OWNER_START,
+                ttl_key=LABEL_TTL,
+            ):
+                container.stop(timeout=5)
+                container.remove(force=True, v=False)
+                reaped.append(container.name)
+        except Exception as error:  # one bad container never aborts the sweep
+            logger.debug("could not reap container %s: %s", container, error)
+
+    if reaped:
+        logger.info("reaped %d abandoned sandbox container(s)", len(reaped))
+    return reaped
+
+
+def _container_is_abandoned(
+    labels: dict,
+    *,
+    now: float,
+    pid_alive: Callable[[int], bool],
+    start_time_of: Callable[[int], Optional[str]],
+    created_key: str,
+    pid_key: str,
+    start_key: str,
+    ttl_key: str,
+) -> bool:
+    """Decide whether a labelled container is abandoned (dead owner, or past TTL).
+
+    Dead owner is the primary signal, using the same start-time disambiguation
+    as the local reaper: a PID that is gone — or now belongs to a different
+    incarnation — means the owner is dead and the container is abandoned. A
+    container whose owner cannot be identified at all (missing/garbled PID
+    label) is kept until its TTL elapses, never removed while its owner is
+    provably alive.
+    """
+    try:
+        pid = int(labels[pid_key])
+    except (KeyError, ValueError, TypeError):
+        pid = 0
+    if pid <= 0:  # unidentifiable owner — lean on the TTL backstop only
+        return _past_ttl(
+            labels, now=now, created_key=created_key, ttl_key=ttl_key
+        )
+    start_time = labels.get(start_key) or None
+    return not _owner_is_alive(pid, start_time, pid_alive, start_time_of)
+
+
+def _past_ttl(
+    labels: dict, *, now: float, created_key: str, ttl_key: str
+) -> bool:
+    """Return whether ``now`` is past the container's ``created + ttl``."""
+    try:
+        created = float(labels[created_key])
+        ttl = float(labels[ttl_key])
+    except (KeyError, ValueError, TypeError):
+        return False  # cannot tell — keep it
+    return now - created > ttl
+
+
 def list_local_workspaces(
     workspace_root: str,
     *,

--- a/src/gimle/hugin/sandbox/reaper.py
+++ b/src/gimle/hugin/sandbox/reaper.py
@@ -175,11 +175,14 @@ def reap_abandoned_containers(
         LABEL_OWNER_START,
         LABEL_SESSION,
         LABEL_TTL,
+        REAPER_CLIENT_TIMEOUT_S,
         import_docker,
     )
 
     try:
-        client = import_docker().from_env()
+        # Short client timeout so a wedged daemon can't stall the startup reap
+        # (this runs on every `hugin` invocation, before the real command).
+        client = import_docker().from_env(timeout=REAPER_CLIENT_TIMEOUT_S)
         containers = client.containers.list(
             all=True, filters={"label": LABEL_SESSION}
         )
@@ -201,7 +204,8 @@ def reap_abandoned_containers(
                 start_key=LABEL_OWNER_START,
                 ttl_key=LABEL_TTL,
             ):
-                container.stop(timeout=5)
+                # force=True SIGKILLs and removes in one step (the owner is
+                # already dead — no graceful stop to wait on).
                 container.remove(force=True, v=False)
                 reaped.append(container.name)
         except Exception as error:  # one bad container never aborts the sweep

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -62,6 +62,18 @@ def _load_local() -> Type["Sandbox"]:
     return LocalSandbox
 
 
+def _load_docker() -> Type["Sandbox"]:
+    """Import the docker backend on demand.
+
+    Importing the module is cheap and dependency-free — ``DockerSandbox`` pulls
+    in the ``docker`` SDK lazily inside its methods — so a missing extra
+    surfaces as a clear remediation error at ``start()``, not an import crash.
+    """
+    from gimle.hugin.sandbox.docker import DockerSandbox
+
+    return DockerSandbox
+
+
 def _phase2_loader(name: str) -> Callable[[], Type["Sandbox"]]:
     """Build a loader for a not-yet-implemented backend (clear error on use)."""
 
@@ -72,7 +84,7 @@ def _phase2_loader(name: str) -> Callable[[], Type["Sandbox"]]:
 
 
 register_backend("local", _load_local)
-register_backend("docker", _phase2_loader("docker"))
+register_backend("docker", _load_docker)
 register_backend("ssh", _phase2_loader("ssh"))
 
 

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -178,11 +178,23 @@ def bash(
         )
     try:
         sandbox = manager.get()
-    except (ValueError, NotImplementedError) as error:
+    except Exception as error:
+        # Bringing a backend up is the classic infra failure: docker daemon
+        # down, image not built, the `sandbox` extra not installed, a remote
+        # host unreachable. Any of these raise here (RuntimeError,
+        # DockerException, ImageNotFound, ...) and must come back as a clean,
+        # actionable tool result — never propagate as an unhandled exception
+        # (which the model can't see) or invite a pointless retry loop.
         _record(manager, stack, command, "infra_error", reason=str(error))
         return ToolResponse(
             is_error=True,
-            content={"error": f"sandbox unavailable: {error}"},
+            content={
+                "infra_error": str(error),
+                "command": command,
+                "note": "the sandbox could not start; retrying will not fix "
+                "this — it needs an operator (start docker, build/pull the "
+                "image, or install the sandbox extra)",
+            },
         )
 
     workspace = sandbox.workspace_for(stack.agent.id, branch)

--- a/tasks/open/025-bash-sandbox-docker-backend.md
+++ b/tasks/open/025-bash-sandbox-docker-backend.md
@@ -29,13 +29,26 @@ The security judge's containment test IS the definition of done: `python3 -c
 allowlist stopped it. A denylist by design allows interpreter execution; the
 container is what makes that safe.
 
+## Status
+
+**Shipped** (branch `bash_sandbox_docker_backend`): the backend, the reaper
+extension, the optional extra, teardown, the Dockerfile, and the containment
+gate — hardened after a four-judge panel review. Two mandatory-flag items are
+intentionally *approximated* and their full form is deferred to task 030
+(follow-ups): true **userns-remap** (we run as the host non-root uid and refuse
+root-without-userns instead) and **`network:true` egress filtering** (the
+default `network:false` is safe; opt-in warns loudly, filtering is deferred).
+Image **digest-pinning/scan/sign** is likewise deferred (the Dockerfile is
+honest that it's for local iteration). Everything else below is done.
+
 ## Tasks
 
-- [ ] `sandbox/docker.py` — `DockerSandbox(Sandbox)`. **Lazy `docker`-SDK import
+- [x] `sandbox/docker.py` — `DockerSandbox(Sandbox)`. **Lazy `docker`-SDK import
       inside the module** so a user who never selects docker needs neither the
       library nor a daemon. One long-lived container per session; `docker exec`
       per command (or a persistent shell — see task 027 statefulness).
-- [ ] All hardening flags are **mandatory** when this backend is chosen:
+- [x] All hardening flags are **mandatory** when this backend is chosen
+      *(with the userns-remap caveat above — see task 030)*:
   - `--network=none` unless `network: true`
   - `--cap-drop=ALL`, `--security-opt=no-new-privileges:true`
   - `--read-only` root, `--tmpfs /tmp:rw,noexec,nosuid,size=256m`
@@ -44,45 +57,46 @@ container is what makes that safe.
     can't handle)
   - default seccomp + apparmor kept; **never** `--privileged`, never
     `seccomp=unconfined`
-  - userns-remap so container-root ≠ host-root
+  - ~~userns-remap so container-root ≠ host-root~~ *(approximated: runs as the
+    host non-root uid; refuses root-without-userns. True remap → task 030)*
   - `HOME=/workspace/...`, empty env by default (no inherited secrets)
-  - workspace = a **named/bind volume keyed by session-id** so a resumed session
+  - workspace = a **bind volume keyed by session-id** so a resumed session
     reattaches its filesystem instead of getting an empty one
-  - labels `hugin.session` / `hugin.owner_pid` / `hugin.created` / `hugin.ttl` +
-    a heartbeat file touched each step (so the reaper can find/kill it)
+  - labels `hugin.session` / `hugin.owner_pid` / `hugin.owner_start` /
+    `hugin.created` / `hugin.ttl` (the dead heartbeat file was dropped; liveness
+    is the owner PID + start-time token, and a dead-owner container is recreated
+    on resume so its labels refresh)
   - **no docker socket mount, ever**
+  - *(added in review)* `/dev/shm` noexec,nosuid tmpfs; `memswap_limit` pinned
 - [ ] `network: true` egress control — block link-local/metadata
       (`169.254.0.0/16`) and RFC1918 by default, ideally via an egress-allowlist
-      proxy. Otherwise an injected `curl http://169.254.169.254/...` exfiltrates
-      cloud IAM credentials. (`network:false` — the default — is the safe path;
-      this item is only for when an operator opts into network.)
-- [ ] `docker/sandbox.Dockerfile` — **thick and boring** image (a thin image is a
-      false economy — every missing binary is a wasted agent turn): Debian slim +
+      proxy. **Deferred to task 030** — `network:false` (the default) is safe and
+      is the only tested path; `network:true` warns loudly for now.
+- [x] `docker/sandbox.Dockerfile` — **thick and boring** image (Debian slim +
       `bash coreutils findutils git curl ca-certificates ripgrep jq less` +
-      `python3` + `uv` + `node`. Pinned by digest, scanned (Trivy/Grype), signed
-      (cosign), verified on pull. **No Hugin source, no credentials** — the
-      sandbox is dumb; stack/interactions/artifacts stay host-side.
-- [ ] Extend the reaper (`sandbox/reaper.py`) so it reaps abandoned **containers**
-      (by `hugin.owner_pid` label + heartbeat/TTL), not just local dirs — the
-      Phase 1 reaper is local-dir + host-PID only (see task 024). Container
-      liveness is not a host `os.kill`.
-- [ ] `docker` SDK → optional `sandbox` extra in `pyproject.toml`
-      (`docker>=7.1`); `create_sandbox` gives a clear remediation error if
-      `backend: docker` is selected but the extra isn't installed.
-- [ ] Ensure `Session.close()`/`SandboxManager.close()` actually stop+remove the
-      container (Phase 1 `stop()` is a no-op for local; here it releases a real
-      resource — wire it so a clean exit doesn't leak a container, and confirm
-      the reaper is the backstop for abrupt exits).
-- [ ] Tests (`slow` marker, skipped without a daemon): assert every hardening
-      flag is actually set on the created container, and assert the **containment
-      gate** above. Plus: resumed session reattaches its volume; container is
-      removed on `close()`; reaper removes an abandoned container.
+      `python3` + `uv` + `node`; **No Hugin source, no credentials**). Digest
+      pinning / scan (Trivy/Grype) / sign (cosign) / verify-on-pull → task 030.
+- [x] Extend the reaper (`sandbox/reaper.py`) so it reaps abandoned **containers**
+      (by `hugin.owner_pid` label + start-time/TTL), not just local dirs.
+      Daemon-optional; short client timeout. (Cross-host/root scoping → task 030.)
+- [x] `docker` SDK → optional `sandbox` extra in `pyproject.toml`
+      (`docker>=7.1`); a clear remediation error if `backend: docker` is selected
+      but the extra isn't installed (surfaced at `start()`).
+- [x] `Session.close()`/`SandboxManager.close()` actually stop+remove the
+      container; the reaper is the backstop for abrupt exits.
+- [x] Tests (`slow` marker, skipped without a daemon): every hardening flag is
+      asserted on the created container, the **containment gate** is proven, a
+      resumed session reattaches its volume, the container is removed on
+      `close()`, and a dead-owner container is recreated on resume. Plus a
+      daemon-free hardening-contract layer that pins every flag.
 
 ## Success criteria
 
-- [ ] The same config runs unchanged with `backend: docker` — contained, no
+- [x] The same config runs unchanged with `backend: docker` — contained, no
       network by default.
-- [ ] `python3 -c 'os.system("id")'` is provably contained by the container.
-- [ ] Package still installs and `local`/`ssh` still run without the `docker` SDK.
-- [ ] No container or volume leaks on clean OR abrupt exit.
-- [ ] `/panel-review` (security judge's containment test is the gate) before merge.
+- [x] `python3 -c 'os.system("id")'` is provably contained by the container
+      (runs, but host FS unreachable, non-root uid, no network).
+- [x] Package still installs and `local`/`ssh` still run without the `docker` SDK.
+- [x] No container or volume leaks on clean OR abrupt exit.
+- [x] `/panel-review` (security judge's containment test is the gate) — done;
+      load-bearing findings fixed, the rest tracked in task 030.

--- a/tasks/open/030-bash-sandbox-docker-followups.md
+++ b/tasks/open/030-bash-sandbox-docker-followups.md
@@ -1,0 +1,115 @@
+---
+title: Bash sandbox — Docker backend follow-ups (deferred panel findings)
+state: OPEN
+labels: [enhancement, security, sandbox, tech-debt]
+priority: high
+---
+
+# Bash sandbox — Docker backend follow-ups
+
+Deferred items from the four-judge panel review (security / architecture / SRE /
+agent-usability) of the Docker backend (task 025, PR that added
+`sandbox/docker.py`). The load-bearing findings were fixed before that PR merged
+— the narrow-`except` escape, the no-host-deadline hang, resume recreating on a
+dead owner, fail-fast on a missing image, the 137/OOM mislabel, the root-without-
+userns guard, `/dev/shm`/swap hardening, and the `network:true` warning. The
+items below are genuine phase-2 design work or lower-severity polish, tracked
+here so they aren't lost. Several overlap task 024 (reaper generalization,
+observability, `put_file`/`get_file`, env affordance) — do them once, in whichever
+task is picked up first.
+
+## Security (do before recommending `docker` for untrusted input at scale)
+
+- [ ] **`network: true` egress control.** *(security, HIGH — effectively
+  CRITICAL on a cloud host)* Today `network:true` attaches the default bridge
+  with unrestricted egress; an injected `curl http://169.254.169.254/...`
+  exfiltrates cloud IAM credentials. The code warns loudly and the default
+  (`network:false`) is safe, but the opt-in path needs real filtering: block
+  link-local/metadata (`169.254.0.0/16`) and RFC1918 by default, ideally via an
+  egress-allowlist proxy (the container has `cap_drop=ALL`, so in-container
+  iptables is out — filter at the network/proxy layer). Until then, consider
+  refusing `network:true` unless an explicit allow-flag is set.
+- [ ] **True userns-remap.** *(security, HIGH)* The backend runs the container as
+  the host uid (non-root *inside* the container) and refuses root-without-userns,
+  but it does not itself remap container-root to a subuid — that is a daemon-level
+  setting. Document the daemon `userns-remap` requirement prominently and,
+  where detectable via `client.info()` SecurityOptions, prefer/require it.
+- [ ] **Image supply chain.** *(security, MEDIUM)* `DEFAULT_IMAGE` is a mutable
+  `:latest` tag and `containers.run` does no verification; the Dockerfile's
+  `FROM` is a tag and it pipes an unpinned `curl | sh` uv installer as root.
+  Default to a digest, verify digest/signature on pull (cosign), pin `FROM` by
+  digest, replace `curl|sh` with a checksum-verified artifact, and add a
+  Trivy/Grype scan + cosign sign step to the image build/publish pipeline.
+- [ ] **Workspace disk quota.** *(security, MEDIUM)* cpu/memory/pids are capped
+  but the bind-mounted `/workspace` is unquota'd host storage; `yes > f` (not on
+  the denylist) fills the host disk and takes down the orchestrator. Mount the
+  workspace on a size-limited volume or enforce a quota / `fsize` ulimit (chosen
+  generously so legit builds aren't broken).
+- [ ] **`put_file`/`get_file` TOCTOU / `O_NOFOLLOW`.** *(security, MEDIUM,
+  latent — no production caller yet)* `_confine` realpath-checks then does a
+  plain `open`; because the container writes the same tree as the host uid, a
+  symlink swap between check and open escapes. Open with `O_NOFOLLOW` /
+  `openat2(RESOLVE_NO_SYMLINKS)` walking from a dirfd. Overlaps task 024's
+  `put_file`/`get_file` item.
+
+## Architecture / ops
+
+- [ ] **Reaper generalization + scoping.** *(architect/SRE, MEDIUM)* Backend
+  reap logic (`reap_abandoned_containers`) is a bespoke free function in
+  `reaper.py`; SSH will add a third. Give the backend registry a reap seam so the
+  CLI iterates it. Also the container sweep is daemon-global: it lists *every*
+  `hugin.session` container and judges the owner PID against the *local* process
+  table — wrong for a remote/shared daemon, and it can reap another
+  `--storage-path`'s containers. Label the container with a host/boot-id and its
+  workspace-root and filter on both; document the local-daemon assumption.
+  Overlaps task 024's reaper-generalization item.
+- [ ] **Capped / backgrounded exec: explicit state + kill.** *(SRE/architect/
+  usability, MEDIUM)* On the output cap or a host-side abandonment the exec'd
+  process keeps running in-container until its `timeout` fires, and the next
+  command runs as a second concurrent exec competing for pids/cpu. `exit_code`
+  is `-1` and `is_error` is `False`, so a capped runaway reads as success. Add an
+  explicit `output_capped`/`abandoned` field to `ExecResult` (treat as
+  `is_error`) and proactively terminate the lingering exec before returning.
+- [ ] **`start()` atomicity.** *(architect/SRE, MEDIUM)* Assign `self._container`
+  immediately after `containers.run` and wrap the post-create steps so a failure
+  after create stops the container instead of orphaning a live one the manager
+  never learned about.
+- [ ] **Observability.** *(SRE, MEDIUM)* Differentiate `sandbox_start_failures`
+  by exception class (daemon-down vs image-missing vs create-rejected); add
+  `sandbox_containers_reaped`, start/pull duration, and a live labelled-container
+  gauge to `hugin sandbox`. Overlaps task 024's observability item.
+- [ ] **Custom-image `timeout`/`bash` contract.** *(SRE/architect, LOW)* The exec
+  wrapper assumes coreutils `timeout` and `bash` on `PATH`; a minimal/distroless
+  custom `image:` breaks cryptically. Preflight-probe on `start()` for non-default
+  images, or document the contract.
+- [ ] **DRY.** *(architect, LOW)* `_write_owner_stamp` is copied from `local.py`
+  and the container stop/remove appears in both `docker.py` and `reaper.py`.
+  Extract shared `write_owner_stamp(root)` / `remove_container(container)` helpers
+  and move the `LABEL_*` constants into a small shared module (also breaks the
+  `reaper → docker` import).
+
+## Agent usability
+
+- [ ] **Environment affordance in the tool description.** *(usability, HIGH)*
+  The model isn't told its OS, its installed toolset (ripgrep/jq/python3/uv/node),
+  or — critically — that `network:false` means `curl`/`uv`/`npm` cannot reach the
+  internet, so it discovers by trial and error. Render an "Installed: … / NETWORK
+  IS OFF" line from the resolved `Policy`/`SandboxSpec` so it can't drift.
+  Overlaps task 024's env-affordance item.
+- [ ] **Spill path is cwd-relative.** *(usability, MEDIUM)* On truncation the
+  response returns `.hugin/last_output.txt` relative to the command cwd; after a
+  `cwd`-scoped call the follow-up (run at the workspace root) can't find it.
+  Spill to a stable workspace-root path (`/workspace/.hugin/last_output.txt`, per
+  spec §2) and report that. Overlaps task 024's spill item.
+- [ ] **Timeout hint.** *(usability, LOW)* A timeout returns `timed_out: true` +
+  `exit_code: 124` but no in-band pointer at the `timeout_s` argument; add a hint.
+- [ ] **Statefulness / persistent shell.** *(usability)* Cross-ref task 027: each
+  `exec` is a fresh shell, so `cd`/`export`/`source` don't persist between calls
+  (a single call can still chain `cd foo && cmd`). The description states this;
+  the persistent-shell-in-a-disposable-container design lives in task 027.
+
+## Notes
+
+- Panel transcripts and the synthesis live in the PR discussion / session notes.
+- `demux=True` cleanly separates stdout/stderr but loses their relative
+  interleaving order — acceptable, noted for anyone debugging interleaved logs.

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -94,6 +94,22 @@ class TestResultMapping:
         assert response.is_error is True
         assert "daemon down" in response.content["infra_error"]
 
+    def test_backend_that_fails_to_start_is_a_clean_dont_retry_error(self):
+        """A start() failure (any exception) comes back as an actionable result.
+
+        Regression guard: docker's start() raises RuntimeError/DockerException/
+        ImageNotFound, none of which are ValueError/NotImplementedError; a
+        too-narrow handler would let them escape the tool entirely instead of
+        reaching the model.
+        """
+        fake = FakeSandbox(
+            raises_on_start=RuntimeError("Cannot connect to the Docker daemon")
+        )
+        response = bash("echo hi", stack=_stack_with_fake(fake))
+        assert response.is_error is True
+        assert "Docker daemon" in response.content["infra_error"]
+        assert "operator" in response.content["note"]
+
     def test_oom_kill_is_an_error(self):
         """An OOM-killed command is an error, like a timeout — not a plain exit."""
         fake = FakeSandbox(

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -20,6 +20,7 @@ from gimle.hugin.sandbox.docker import (
     LABEL_OWNER_PID,
     LABEL_TTL,
     _sanitize_name,
+    container_name,
 )
 from gimle.hugin.sandbox.policy import Policy
 from gimle.hugin.sandbox.sandbox import PolicyDenied
@@ -132,14 +133,112 @@ class TestHardeningContract:
         assert labels[LABEL_OWNER_PID] == str(os.getpid())
         assert LABEL_CREATED in labels and LABEL_TTL in labels
 
+    def test_dev_shm_is_hardened_too(self, tmp_path):
+        """/dev/shm is a noexec,nosuid tmpfs (docker mounts it rw+exec by default)."""
+        tmpfs = _sandbox(tmp_path)._container_kwargs()["tmpfs"]
+        assert "noexec" in tmpfs["/dev/shm"]
+        assert "nosuid" in tmpfs["/dev/shm"]
+
+    def test_swap_is_pinned_to_the_memory_limit(self, tmp_path):
+        """memswap_limit == mem_limit so the memory cap can't be doubled via swap."""
+        kwargs = _sandbox(tmp_path, memory="1g")._container_kwargs()
+        assert kwargs["memswap_limit"] == kwargs["mem_limit"] == "1g"
+
+
+class TestExitClassification:
+    """124/137/hung map to the right (timed_out, oom_killed) signals."""
+
+    def test_124_is_timeout(self):
+        """`timeout`'s 124 is an unambiguous wall-clock timeout."""
+        assert DockerSandbox._classify_exit(124, False, 15.0, 15) == (
+            True,
+            False,
+        )
+
+    def test_137_near_deadline_is_timeout_not_oom(self):
+        """A TERM-ignoring hang killed after grace (137 at the deadline) = timeout."""
+        assert DockerSandbox._classify_exit(137, False, 15.2, 15) == (
+            True,
+            False,
+        )
+
+    def test_137_well_before_deadline_is_oom(self):
+        """A SIGKILL long before the deadline is most likely a memory-cap OOM."""
+        assert DockerSandbox._classify_exit(137, False, 2.0, 15) == (
+            False,
+            True,
+        )
+
+    def test_hung_is_always_timeout(self):
+        """A host-side abandonment is reported as a timeout regardless of code."""
+        assert DockerSandbox._classify_exit(-1, True, 30.0, 15) == (True, False)
+
+    def test_clean_exit_is_neither(self):
+        """A normal exit (0, or non-zero from the command) is not a failure kind."""
+        assert DockerSandbox._classify_exit(0, False, 1.0, 15) == (False, False)
+        assert DockerSandbox._classify_exit(1, False, 1.0, 15) == (False, False)
+
+
+class TestOwnerIsCurrent:
+    """Reattach reuses only a container this live process owns."""
+
+    class _FakeContainer:
+        def __init__(self, labels):
+            self.labels = labels
+
+        status = "running"
+
+    def test_own_pid_is_current(self, tmp_path):
+        """A container labelled with our PID is reused."""
+        sandbox = _sandbox(tmp_path)
+        c = self._FakeContainer({LABEL_OWNER_PID: str(os.getpid())})
+        assert sandbox._owner_is_current(c) is True
+
+    def test_foreign_or_dead_pid_is_not_current(self, tmp_path):
+        """A container labelled with a different PID (dead prior owner) is not."""
+        sandbox = _sandbox(tmp_path)
+        assert (
+            sandbox._owner_is_current(
+                self._FakeContainer({LABEL_OWNER_PID: "999999999"})
+            )
+            is False
+        )
+
+    def test_garbled_label_is_not_current(self, tmp_path):
+        """A missing/garbled owner label is treated as not-ours (recreate)."""
+        sandbox = _sandbox(tmp_path)
+        assert sandbox._owner_is_current(self._FakeContainer({})) is False
+
 
 class TestNameAndPaths:
     """Naming and the container<->host path mapping."""
 
-    def test_container_name_is_docker_legal(self):
+    def test_container_name_is_docker_legal_and_prefixed(self):
         """A UUID-ish session id becomes a legal, prefixed container name."""
-        assert _sanitize_name("abc-123").startswith("hugin-sbx-")
-        assert _sanitize_name("weird/id:x") == "hugin-sbx-weird-id-x"
+        spec = SandboxSpec(backend="docker")
+        name = container_name("weird/id:x", spec)
+        assert name.startswith("hugin-sbx-weird-id-x-")
+        assert _sanitize_name("weird/id:x") == "weird-id-x"
+
+    def test_distinct_specs_get_distinct_container_names(self):
+        """Two specs in one session map to different containers (per-spec)."""
+        session = "sess-9"
+        a = container_name(session, SandboxSpec(backend="docker", memory="1g"))
+        b = container_name(session, SandboxSpec(backend="docker", memory="2g"))
+        assert a != b
+
+    def test_same_spec_gives_a_stable_name(self):
+        """The same (session, spec) always resolves to the same container name."""
+        spec = SandboxSpec(backend="docker", image="x:1", network=True)
+        assert container_name("s", spec) == container_name("s", spec)
+
+    def test_sanitize_collision_is_disambiguated_by_the_hash(self):
+        """`weird/id` and `weird-id` sanitize alike but don't share a container."""
+        spec = SandboxSpec(backend="docker")
+        # Same sanitized fragment, but the raw ids are hashed, so names differ.
+        assert container_name("weird/id", spec) != container_name(
+            "weird-id", spec
+        )
 
     def test_workspace_for_creates_host_dir_and_returns_container_path(
         self, tmp_path
@@ -249,12 +348,14 @@ class TestContainmentGate:
         assert "TOP-SECRET" not in result.stdout
 
     def test_process_is_not_container_root(self, running_sandbox):
-        """The uid inside the container is the host user, not 0."""
+        """The uid inside the container is the host user, and specifically not 0."""
         cwd = running_sandbox.workspace_for("a", None)
         result = running_sandbox.exec(
             "id -u", policy=Policy(), cwd=cwd, timeout_s=15
         )
-        assert result.stdout.strip() == str(os.getuid())
+        uid = result.stdout.strip()
+        assert uid == str(os.getuid())
+        assert uid != "0"  # not container-root (the guard would refuse root)
 
     def test_no_network_by_default(self, running_sandbox):
         """With network:false the container cannot open an outbound socket."""
@@ -320,3 +421,47 @@ class TestContainerLifecycle:
             assert "persisted" in result.stdout
         finally:
             second.stop()
+
+    def test_resume_by_a_new_owner_recreates_with_fresh_labels(
+        self, tmp_path, monkeypatch
+    ):
+        """A container left by a dead owner is recreated so its labels refresh.
+
+        Otherwise the immutable owner-PID label would name a dead process and
+        the startup reaper would remove the live resumed session's container.
+        Simulate a different owner by faking getpid() on the "resume".
+        """
+        spec = SandboxSpec(backend="docker", image=DAEMON_IMAGE)
+        first = create_sandbox(spec, "reown-sess", str(tmp_path))
+        first.start()
+        first_id = first._container.id
+        try:
+            monkeypatch.setattr(os, "getpid", lambda: 424242)
+            second = create_sandbox(spec, "reown-sess", str(tmp_path))
+            second.start()
+            assert second._container.id != first_id  # recreated
+            assert (
+                second._container.labels[LABEL_OWNER_PID] == "424242"
+            )  # labels now name the live (resumed) owner
+        finally:
+            second.stop()
+
+    def test_missing_image_fails_fast_with_a_build_hint(self, tmp_path):
+        """A never-built default image raises a clear, actionable error."""
+        spec = SandboxSpec(backend="docker", image="gimle/does-not-exist:nope")
+        sandbox = create_sandbox(spec, "noimg-sess", str(tmp_path))
+        with pytest.raises(RuntimeError, match="docker build"):
+            sandbox.start()
+
+    def test_backgrounded_process_does_not_hang_the_call(self, running_sandbox):
+        """A command that backgrounds a pipe-holding child still returns."""
+        cwd = running_sandbox.workspace_for("a", None)
+        # `sleep 30 &` would hold the exec's stdout pipe open; the host-side
+        # deadline (or foreground-exit detection) must let exec() return anyway.
+        result = running_sandbox.exec(
+            "echo started; sleep 30 &",
+            policy=Policy(),
+            cwd=cwd,
+            timeout_s=5,
+        )
+        assert "started" in result.stdout

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -1,0 +1,322 @@
+"""Tests for the DockerSandbox backend.
+
+Two layers. The first asserts the **hardening contract** — every flag that makes
+the container a boundary — purely from ``_container_kwargs``, so it runs with no
+daemon and no ``docker`` SDK installed: these are the ones that must never
+silently regress. The second layer is the real thing: daemon-gated
+(``slow``-marked, skipped without a reachable daemon) tests that start a
+container and prove the acceptance gate — ``python3 -c 'os.system("id")'`` is
+*contained by the runtime*, not denied by the policy.
+"""
+
+import os
+
+import pytest
+
+from gimle.hugin.sandbox import DockerSandbox, SandboxSpec, create_sandbox
+from gimle.hugin.sandbox.docker import (
+    CONTAINER_WORKSPACE,
+    LABEL_CREATED,
+    LABEL_OWNER_PID,
+    LABEL_TTL,
+    _sanitize_name,
+)
+from gimle.hugin.sandbox.policy import Policy
+from gimle.hugin.sandbox.sandbox import PolicyDenied
+
+
+def _docker_available() -> bool:
+    """Return whether a docker SDK and a reachable daemon are both present."""
+    try:
+        import docker
+
+        docker.from_env().ping()
+        return True
+    except Exception:
+        return False
+
+
+requires_docker = pytest.mark.skipif(
+    not _docker_available(), reason="requires a reachable docker daemon"
+)
+
+
+def _sandbox(tmp_path, **spec_kwargs) -> DockerSandbox:
+    """Build a DockerSandbox rooted under tmp_path (no daemon touched)."""
+    spec = SandboxSpec(backend="docker", **spec_kwargs)
+    sandbox = create_sandbox(spec, "sess-1", str(tmp_path))
+    assert isinstance(sandbox, DockerSandbox)
+    return sandbox
+
+
+class TestHardeningContract:
+    """The container-creation flags ARE the boundary; pin every one."""
+
+    def test_no_network_by_default(self, tmp_path):
+        """The default is a container that cannot reach anything (network=none)."""
+        kwargs = _sandbox(tmp_path)._container_kwargs()
+        assert kwargs["network_mode"] == "none"
+
+    def test_network_opt_in_uses_bridge(self, tmp_path):
+        """Only an explicit network:true relaxes to a bridge network."""
+        kwargs = _sandbox(tmp_path, network=True)._container_kwargs()
+        assert kwargs["network_mode"] == "bridge"
+
+    def test_all_capabilities_dropped(self, tmp_path):
+        """Every Linux capability is dropped."""
+        assert _sandbox(tmp_path)._container_kwargs()["cap_drop"] == ["ALL"]
+
+    def test_no_new_privileges(self, tmp_path):
+        """no-new-privileges blocks setuid escalation inside the container."""
+        opts = _sandbox(tmp_path)._container_kwargs()["security_opt"]
+        assert "no-new-privileges:true" in opts
+
+    def test_readonly_root_and_hardened_tmpfs(self, tmp_path):
+        """Rootfs is read-only; /tmp is a noexec,nosuid,size-capped tmpfs."""
+        kwargs = _sandbox(tmp_path)._container_kwargs()
+        assert kwargs["read_only"] is True
+        assert kwargs["tmpfs"]["/tmp"] == "rw,noexec,nosuid,size=256m"
+
+    def test_resource_caps_from_spec(self, tmp_path):
+        """cpu/memory/pids from the spec become the container's hard limits."""
+        kwargs = _sandbox(
+            tmp_path, cpu=1.5, memory="1g", pids=256
+        )._container_kwargs()
+        assert kwargs["mem_limit"] == "1g"
+        assert kwargs["nano_cpus"] == 1_500_000_000
+        assert kwargs["pids_limit"] == 256
+
+    def test_ulimits_present(self, tmp_path):
+        """nproc/nofile ulimits are set (as plain tuples, SDK-free)."""
+        names = {
+            name
+            for (name, _s, _h) in _sandbox(tmp_path)._container_kwargs()[
+                "ulimits"
+            ]
+        }
+        assert names == {"nofile", "nproc"}
+
+    def test_init_reaps_children(self, tmp_path):
+        """--init gives PID 1 that reaps double-forked children."""
+        assert _sandbox(tmp_path)._container_kwargs()["init"] is True
+
+    def test_runs_as_non_root(self, tmp_path):
+        """The container process runs as the host user, never container-root."""
+        user = _sandbox(tmp_path)._container_kwargs()["user"]
+        assert user != "0:0"
+        assert user == f"{os.getuid()}:{os.getgid()}"
+
+    def test_env_has_no_inherited_secrets(self, tmp_path, monkeypatch):
+        """A secret in the host env does not leak into the container env."""
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "super-secret")
+        env = _sandbox(tmp_path)._container_kwargs()["environment"]
+        assert "AWS_SECRET_ACCESS_KEY" not in env
+        assert env["HOME"] == CONTAINER_WORKSPACE
+
+    def test_never_mounts_the_docker_socket(self, tmp_path):
+        """The docker socket is never bind-mounted (would be a full escape)."""
+        volumes = _sandbox(tmp_path)._container_kwargs()["volumes"]
+        assert not any("docker.sock" in key for key in volumes)
+
+    def test_workspace_bind_is_the_only_mount(self, tmp_path):
+        """The one mount is the session workspace, read-write."""
+        volumes = _sandbox(tmp_path)._container_kwargs()["volumes"]
+        assert len(volumes) == 1
+        ((host, mapping),) = volumes.items()
+        assert host == os.path.join(str(tmp_path), "sess-1")
+        assert mapping == {"bind": CONTAINER_WORKSPACE, "mode": "rw"}
+
+    def test_labels_identify_the_owner_for_the_reaper(self, tmp_path):
+        """Labels carry owner PID + created + ttl so the reaper can judge it."""
+        labels = _sandbox(tmp_path)._container_kwargs()["labels"]
+        assert labels[LABEL_OWNER_PID] == str(os.getpid())
+        assert LABEL_CREATED in labels and LABEL_TTL in labels
+
+
+class TestNameAndPaths:
+    """Naming and the container<->host path mapping."""
+
+    def test_container_name_is_docker_legal(self):
+        """A UUID-ish session id becomes a legal, prefixed container name."""
+        assert _sanitize_name("abc-123").startswith("hugin-sbx-")
+        assert _sanitize_name("weird/id:x") == "hugin-sbx-weird-id-x"
+
+    def test_workspace_for_creates_host_dir_and_returns_container_path(
+        self, tmp_path
+    ):
+        """workspace_for returns a /workspace path and makes the host dir."""
+        sandbox = _sandbox(tmp_path)
+        path = sandbox.workspace_for("agent-a", "feature")
+        assert path == f"{CONTAINER_WORKSPACE}/agents/agent-a/feature"
+        assert os.path.isdir(
+            os.path.join(
+                str(tmp_path), "sess-1", "agents", "agent-a", "feature"
+            )
+        )
+
+    def test_host_path_maps_workspace_into_the_bind_root(self, tmp_path):
+        """A container /workspace path maps back to the host bind-mount root."""
+        sandbox = _sandbox(tmp_path)
+        host = sandbox._host_path(f"{CONTAINER_WORKSPACE}/agents/x/default")
+        assert host == os.path.join(
+            str(tmp_path), "sess-1", "agents", "x", "default"
+        )
+
+
+class TestFileConfinement:
+    """put_file/get_file confine to the workspace; symlink escapes are refused."""
+
+    def test_put_then_get_roundtrips(self, tmp_path):
+        """A file written through put_file reads back through get_file."""
+        sandbox = _sandbox(tmp_path)
+        sandbox.put_file("notes.txt", b"hello")
+        assert sandbox.get_file("notes.txt") == b"hello"
+
+    def test_container_path_is_accepted(self, tmp_path):
+        """A /workspace-absolute path is mapped to the host side, not rejected."""
+        sandbox = _sandbox(tmp_path)
+        sandbox.put_file(f"{CONTAINER_WORKSPACE}/a.txt", b"x")
+        assert sandbox.get_file("a.txt") == b"x"
+
+    def test_symlink_escape_is_refused(self, tmp_path):
+        """A symlink pointing outside the workspace cannot be read through."""
+        sandbox = _sandbox(tmp_path)
+        host_root = sandbox._host_root
+        os.makedirs(host_root, exist_ok=True)
+        secret = tmp_path / "outside.txt"
+        secret.write_text("secret")
+        os.symlink(str(secret), os.path.join(host_root, "link"))
+        with pytest.raises(PolicyDenied):
+            sandbox.get_file("link")
+
+
+class TestBackendRegistration:
+    """The docker backend resolves through the registry, no SDK needed to load."""
+
+    def test_create_sandbox_resolves_docker(self, tmp_path):
+        """create_sandbox builds a DockerSandbox for backend: docker."""
+        spec = SandboxSpec(backend="docker")
+        assert isinstance(
+            create_sandbox(spec, "s", str(tmp_path)), DockerSandbox
+        )
+
+
+# --------------------------------------------------------------------------
+# Daemon-gated: the real boundary. Skipped without a reachable docker daemon.
+# --------------------------------------------------------------------------
+
+DAEMON_IMAGE = "python:3.12-slim"
+
+
+@pytest.fixture
+def running_sandbox(tmp_path):
+    """Start a real DockerSandbox on a small public image; always tear it down."""
+    spec = SandboxSpec(backend="docker", image=DAEMON_IMAGE, memory="512m")
+    sandbox = create_sandbox(spec, "itest-sess", str(tmp_path))
+    sandbox.start()
+    try:
+        yield sandbox
+    finally:
+        sandbox.stop()
+
+
+@pytest.mark.slow
+@requires_docker
+class TestContainmentGate:
+    """The acceptance gate: the runtime contains, the policy does not deny."""
+
+    def test_interpreter_runs_it_is_not_denied(self, running_sandbox):
+        """python3 -c 'os.system("id")' RUNS (denylist lets interpreters through)."""
+        cwd = running_sandbox.workspace_for("a", None)
+        result = running_sandbox.exec(
+            "python3 -c 'import os; os.system(\"id\")'",
+            policy=Policy(),
+            cwd=cwd,
+            timeout_s=15,
+        )
+        assert result.exit_code == 0
+        assert "uid=" in result.stdout  # it executed; it was not refused
+
+    def test_host_filesystem_is_not_reachable(self, running_sandbox, tmp_path):
+        """A host secret outside the workspace is invisible in the container."""
+        secret = tmp_path / "host_secret.txt"
+        secret.write_text("TOP-SECRET")
+        cwd = running_sandbox.workspace_for("a", None)
+        result = running_sandbox.exec(
+            f"cat {secret}", policy=Policy(), cwd=cwd, timeout_s=15
+        )
+        assert result.exit_code != 0
+        assert "TOP-SECRET" not in result.stdout
+
+    def test_process_is_not_container_root(self, running_sandbox):
+        """The uid inside the container is the host user, not 0."""
+        cwd = running_sandbox.workspace_for("a", None)
+        result = running_sandbox.exec(
+            "id -u", policy=Policy(), cwd=cwd, timeout_s=15
+        )
+        assert result.stdout.strip() == str(os.getuid())
+
+    def test_no_network_by_default(self, running_sandbox):
+        """With network:false the container cannot open an outbound socket."""
+        cwd = running_sandbox.workspace_for("a", None)
+        result = running_sandbox.exec(
+            'python3 -c "import socket; '
+            "socket.create_connection(('1.1.1.1', 53), 3)\"",
+            policy=Policy(),
+            cwd=cwd,
+            timeout_s=15,
+        )
+        assert result.exit_code != 0  # no route out
+
+
+@pytest.mark.slow
+@requires_docker
+class TestContainerLifecycle:
+    """Real hardening flags, resume-reattach, teardown, and reaping."""
+
+    def test_hardening_flags_are_set_on_the_real_container(
+        self, running_sandbox
+    ):
+        """Inspect the started container: the boundary flags are actually on."""
+        attrs = running_sandbox._container.attrs
+        host = attrs["HostConfig"]
+        assert host["NetworkMode"] == "none"
+        assert host["ReadonlyRootfs"] is True
+        assert "ALL" in host["CapDrop"]
+        assert any("no-new-privileges" in o for o in host["SecurityOpt"])
+        assert host["PidsLimit"] == 512
+
+    def test_stop_removes_the_container(self, tmp_path):
+        """close()/stop() releases the container — no leak on a clean exit."""
+        import docker
+
+        spec = SandboxSpec(backend="docker", image=DAEMON_IMAGE)
+        sandbox = create_sandbox(spec, "stop-sess", str(tmp_path))
+        sandbox.start()
+        name = sandbox._name
+        sandbox.stop()
+        client = docker.from_env()
+        with pytest.raises(docker.errors.NotFound):
+            client.containers.get(name)
+
+    def test_resume_reattaches_the_same_workspace(self, tmp_path):
+        """A file written in one session is present after a resume (same id)."""
+        spec = SandboxSpec(backend="docker", image=DAEMON_IMAGE)
+        first = create_sandbox(spec, "resume-sess", str(tmp_path))
+        first.start()
+        cwd = first.workspace_for("a", None)
+        first.exec(
+            "echo persisted > marker.txt",
+            policy=Policy(),
+            cwd=cwd,
+            timeout_s=15,
+        )
+        try:
+            second = create_sandbox(spec, "resume-sess", str(tmp_path))
+            second.start()
+            result = second.exec(
+                "cat marker.txt", policy=Policy(), cwd=cwd, timeout_s=15
+            )
+            assert "persisted" in result.stdout
+        finally:
+            second.stop()

--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -18,10 +18,12 @@ class TestCreateSandbox:
         box = create_sandbox(LOCAL, "s", workspace_root=str(tmp_path))
         assert isinstance(box, LocalSandbox)
 
-    def test_docker_backend_not_yet_implemented(self):
-        """backend='docker' is a clear NotImplementedError until phase 2."""
-        with pytest.raises(NotImplementedError, match="phase 2"):
-            create_sandbox(SandboxSpec(backend="docker"), "s")
+    def test_docker_backend_builds_docker_sandbox(self):
+        """backend='docker' constructs a DockerSandbox (no daemon touched)."""
+        from gimle.hugin.sandbox.docker import DockerSandbox
+
+        box = create_sandbox(SandboxSpec(backend="docker"), "s")
+        assert isinstance(box, DockerSandbox)
 
     def test_ssh_backend_not_yet_implemented(self):
         """backend='ssh' is a clear NotImplementedError until phase 2."""
@@ -127,9 +129,23 @@ class TestLifecycleCounters:
         assert manager.audit.counters["sandbox_start_failures"] == 0
 
     def test_start_failure_is_counted_and_reraised(self):
-        """A backend that cannot be created counts a failure and propagates."""
-        manager = SandboxManager(SandboxSpec(backend="docker"), "s")
-        with pytest.raises(NotImplementedError):
-            manager.get()
-        assert manager.audit.counters["sandbox_start_failures"] == 1
-        assert manager.audit.counters["sandbox_starts"] == 0
+        """A backend that fails to start counts a failure and propagates."""
+        from gimle.hugin.sandbox import sandbox as sandbox_mod
+        from gimle.hugin.sandbox.sandbox import register_backend
+
+        class _Boom:
+            def __init__(self, spec, session_id, workspace_root):
+                pass
+
+            def start(self):
+                raise RuntimeError("cannot start")
+
+        register_backend("boomtest", lambda: _Boom)
+        try:
+            manager = SandboxManager(SandboxSpec(backend="boomtest"), "s")
+            with pytest.raises(RuntimeError, match="cannot start"):
+                manager.get()
+            assert manager.audit.counters["sandbox_start_failures"] == 1
+            assert manager.audit.counters["sandbox_starts"] == 0
+        finally:
+            sandbox_mod._BACKENDS.pop("boomtest", None)

--- a/tests/test_sandbox_reaper.py
+++ b/tests/test_sandbox_reaper.py
@@ -9,9 +9,18 @@ import json
 import os
 import time
 
+from gimle.hugin.sandbox.docker import (
+    LABEL_CREATED,
+    LABEL_OWNER_PID,
+    LABEL_OWNER_START,
+    LABEL_SESSION,
+    LABEL_TTL,
+)
 from gimle.hugin.sandbox.local import OWNER_FILE
 from gimle.hugin.sandbox.reaper import (
+    _container_is_abandoned,
     list_local_workspaces,
+    reap_abandoned_containers,
     reap_local_workspaces,
 )
 
@@ -151,6 +160,83 @@ class TestPidReuseDisambiguation:
             start_time_of=lambda pid: None,
         )
         assert reaped == []
+
+
+def _labels(pid, start="SAME", created=NOW, ttl=3600):
+    """Build the container labels a DockerSandbox would stamp."""
+    return {
+        LABEL_SESSION: "sess",
+        LABEL_OWNER_PID: str(pid),
+        LABEL_OWNER_START: start,
+        LABEL_CREATED: str(created),
+        LABEL_TTL: str(ttl),
+    }
+
+
+def _abandoned(labels, *, now=NOW, pid_alive=_dead, start_time_of=None):
+    """Call _container_is_abandoned with the real docker label keys."""
+    return _container_is_abandoned(
+        labels,
+        now=now,
+        pid_alive=pid_alive,
+        start_time_of=start_time_of or (lambda pid: "SAME"),
+        created_key=LABEL_CREATED,
+        pid_key=LABEL_OWNER_PID,
+        start_key=LABEL_OWNER_START,
+        ttl_key=LABEL_TTL,
+    )
+
+
+class TestContainerReaping:
+    """Container abandonment mirrors the local reaper's dead-owner rule."""
+
+    def test_dead_owner_container_is_abandoned(self):
+        """A container whose owner PID is gone is abandoned."""
+        assert _abandoned(_labels(4242), pid_alive=_dead) is True
+
+    def test_live_owner_container_is_kept(self):
+        """A container whose owner is alive (same incarnation) is kept."""
+        assert (
+            _abandoned(
+                _labels(222, start="SAME"),
+                pid_alive=_only(222),
+                start_time_of=lambda pid: "SAME",
+            )
+            is False
+        )
+
+    def test_reused_pid_is_abandoned(self):
+        """A live PID with a different start time is not the owner — abandoned."""
+        assert (
+            _abandoned(
+                _labels(222, start="OLD"),
+                pid_alive=_only(222),
+                start_time_of=lambda pid: "NEW",
+            )
+            is True
+        )
+
+    def test_unidentifiable_owner_kept_until_ttl(self):
+        """A garbled PID label leans on the TTL: fresh kept, stale reaped."""
+        fresh = _labels("not-an-int", created=NOW - 10, ttl=3600)
+        stale = _labels("not-an-int", created=NOW - 7200, ttl=3600)
+        assert _abandoned(fresh) is False
+        assert _abandoned(stale) is True
+
+    def test_reap_is_a_noop_without_docker(self, monkeypatch):
+        """Without the docker SDK / a daemon, reaping is a silent no-op."""
+        # docker isn't a hard dependency; simulate its absence deterministically.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def no_docker(name, *args, **kwargs):
+            if name == "docker":
+                raise ImportError("no docker in this env")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", no_docker)
+        assert reap_abandoned_containers(now=NOW) == []
 
 
 class TestCorruptStampIsHandled:

--- a/uv.lock
+++ b/uv.lock
@@ -440,6 +440,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -546,6 +560,9 @@ examples = [
     { name = "seaborn" },
     { name = "yfinance" },
 ]
+sandbox = [
+    { name = "docker" },
+]
 test = [
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -568,6 +585,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.72.0" },
     { name = "bashlex", specifier = ">=0.18" },
+    { name = "docker", marker = "extra == 'sandbox'", specifier = ">=7.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "markdown", specifier = ">=3.7.0" },
     { name = "matplotlib", marker = "extra == 'apps'", specifier = ">=3.8.0" },
@@ -584,7 +602,7 @@ requires-dist = [
     { name = "seaborn", marker = "extra == 'examples'", specifier = ">=0.13.0" },
     { name = "yfinance", marker = "extra == 'examples'", specifier = ">=0.2.0" },
 ]
-provides-extras = ["apps", "examples", "test"]
+provides-extras = ["apps", "examples", "sandbox", "test"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1600,6 +1618,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the `docker` execution backend for the bash tool (task 025) — the first
sandbox backend with a **real isolation boundary**. Where `local` is honest that
it has none, `docker` runs each command inside a hardened, session-scoped
container, and the container — not the policy allowlist — is what makes running
an interpreter safe. A denylist by design lets `python3 -c '...'` through; the
whole point of this backend is that it can, because the runtime contains it.

The acceptance gate is proven against a real daemon: `python3 -c 'os.system("id")'`
**runs** (it is not denied) yet is **contained** — the host filesystem is
unreachable, the process is non-root, and there is no network.

Backends stay true peers: the `docker` SDK is a lazy import, so `local`/`ssh`
install and run with no docker dependency; only `backend: docker` needs the
optional `sandbox` extra.

## Changes

**The backend** (`sandbox/docker.py`)
- Every hardening flag is mandatory, not tunable: `--network=none` unless
  `network:true`, `cap-drop ALL`, `no-new-privileges`, read-only rootfs +
  noexec/nosuid tmpfs (`/tmp` **and** `/dev/shm`), cpu/memory/pids caps +
  `memswap_limit` + nproc/nofile ulimits, `--init`, runs as the host (non-root)
  user, empty-of-secrets env, and never the docker socket. The flags come from a
  pure, SDK-free `_container_kwargs()` so a unit test pins every one with no daemon.
- The session's host dir is bind-mounted to `/workspace`, so a resumed session
  reattaches its files and the existing host-side machinery (per-agent
  workspaces, spill, `put_file`/`get_file`) works unchanged.
- Per-command timeout via the container's own `timeout`, **plus a host-side
  deadline** so a command that backgrounds a pipe-holding child (`sleep 30 &`) or
  a wedged daemon can't hang the agent's turn; output is streamed under a byte
  cap so a runaway can't OOM the orchestrator.
- `start()` is idempotent and recreates a container left by a *dead* owner so its
  labels (which the reaper judges liveness by) and hardening spec refresh; `stop()`
  removes the container so a clean exit doesn't leak one. Container names include a
  hash of the session id **and** the spec, so two agents with different specs get
  different containers.
- Fails fast with a `docker build ...` hint when the (locally-built) default image
  isn't present, and refuses to run as root without daemon userns-remap.

**Registry / packaging / image**
- `create_sandbox` builds a `DockerSandbox` for `backend: docker` via the registry.
- `sandbox` optional extra (`docker>=7.1`) in `pyproject.toml`; missing → clear
  remediation error at `start()`.
- `docker/sandbox.Dockerfile`: a thick, boring image (Debian slim + a POSIX
  userland, git, ripgrep, jq, curl, python3, uv, node) with **no Hugin source and
  no credentials**.

**Reaper** (`sandbox/reaper.py`)
- `reap_abandoned_containers()` removes a container only when its owner process is
  gone, using the same start-time disambiguation as the local reaper. Daemon-
  optional (a no-op without the SDK/daemon) with a short client timeout so a wedged
  daemon can't stall startup. Wired into the every-invocation reap and `hugin
  sandbox prune`.

**Tool** (`tools/builtins/bash.py`)
- Broadened the `manager.get()` handler so a backend that fails to come up (daemon
  down, image missing, extra not installed) returns a clean, do-not-retry
  `infra_error` instead of escaping the tool as an unhandled exception.

## Review

A four-judge panel (security / architecture / SRE / agent-usability) reviewed the
backend; the load-bearing findings are fixed in this PR (the narrow-`except`
escape, the no-host-deadline hang, resume-recreates-on-dead-owner, fail-fast on a
missing image, the 137/OOM mislabel, root-without-userns guard, `/dev/shm`/swap
hardening, `network:true` warning). Genuine phase-2 items (egress filtering, true
userns-remap, image digest/scan/sign, disk quota, `O_NOFOLLOW`, reaper
generalization, env-affordance in the description, observability) are tracked in
**task 030**.

## Testing

- `uv run pytest -q` → **926 passed, 25 skipped, 2 xfailed**.
- **Daemon-gated** (`slow`, skipped without a daemon — so CI stays green without
  docker) run against a real daemon: the containment gate (interpreter runs but is
  contained, host FS unreachable, non-root, no network), hardening flags on the
  real container, clean teardown, resume-reattach, **recreate-on-dead-owner**,
  fail-fast on a missing image, and the backgrounded-process anti-hang.
- **Daemon-free** unit layer pins every hardening flag, the exit classification,
  owner-is-current, and spec-fingerprinted naming — the regression tripwire for
  silent weakening.
- `uv run pre-commit run --all-files` clean (black/isort/flake8/mypy). No container
  leaks after the suite.
