### PR TITLE
Add ssh port support + a local harness to run all backends for real

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,60 @@
+# Running the sandbox backends for real (locally)
+
+The sandbox test suites parametrize over all three backends (`local` / `docker`
+/ `ssh`), but `docker` and `ssh` are `slow`-marked and **skip unless their
+runtime is present** — so a plain `uv run pytest` only truly exercises `local`.
+To run the real boundaries (containment, lifecycle, the ssh sentinel path), bring
+up their runtimes first. All you need is a working local docker.
+
+## docker backend
+
+The docker/contract/e2e tests use `python:3.12-slim`. Pull it once:
+
+```bash
+docker pull python:3.12-slim
+```
+
+With a reachable daemon + that image present, the `slow` docker tests run:
+
+```bash
+uv run pytest tests/test_sandbox_docker.py -m slow
+```
+
+## ssh backend — a throwaway sshd container
+
+`ssh-test.Dockerfile` is a **test-only** sshd box (python3 + bash + coreutils —
+the ssh backend's documented remote baseline) that authorizes a throwaway key
+handed in at runtime. It is NOT hardened; never use it for anything but tests.
+
+```bash
+# 1. build the image
+docker build -f docker/ssh-test.Dockerfile -t hugin-ssh-test .
+
+# 2. a throwaway keypair
+ssh-keygen -t ed25519 -f /tmp/hugin_ssh_key -N '' -q
+
+# 3. run it, mapping sshd to localhost:2222 with your public key authorized
+docker run -d --name hugin-ssh-test -p 2222:22 \
+  -e AUTHORIZED_KEY="$(cat /tmp/hugin_ssh_key.pub)" hugin-ssh-test
+
+# 4. point the suite at it (the `port` spec field targets 2222)
+export HUGIN_SSH_TEST_HOST=agent@127.0.0.1
+export HUGIN_SSH_TEST_PORT=2222
+export HUGIN_SSH_TEST_KEY=/tmp/hugin_ssh_key
+
+# 5. the ssh real-host tests + the cross-backend contract/e2e now run for real
+uv run pytest tests/test_sandbox_ssh.py -m slow
+uv run pytest tests/test_sandbox_contract.py tests/test_bash_e2e_backends.py
+
+# cleanup
+docker rm -f hugin-ssh-test
+```
+
+## everything at once
+
+With `python:3.12-slim` pulled, the sshd container up, and the three
+`HUGIN_SSH_TEST_*` vars exported, a full `uv run pytest` exercises all three
+backends end to end (locally this is ~1012 passed vs ~976 with only `local`).
+
+> Wiring this into CI needs a runner with docker (the current self-hosted runner
+> has none). See `tasks/open/031-bash-sandbox-e2e-test-harness.md`.

--- a/docker/ssh-test-entrypoint.sh
+++ b/docker/ssh-test-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Install the throwaway public key handed in via AUTHORIZED_KEY, then run sshd in
+# the foreground. Test-only (see ssh-test.Dockerfile).
+set -e
+
+if [ -z "$AUTHORIZED_KEY" ]; then
+    echo "AUTHORIZED_KEY not set; refusing to start a keyless sshd" >&2
+    exit 1
+fi
+
+mkdir -p /home/agent/.ssh
+printf '%s\n' "$AUTHORIZED_KEY" > /home/agent/.ssh/authorized_keys
+chmod 700 /home/agent/.ssh
+chmod 600 /home/agent/.ssh/authorized_keys
+chown -R agent:agent /home/agent/.ssh
+
+ssh-keygen -A  # generate host keys
+exec /usr/sbin/sshd -D -e

--- a/docker/ssh-test.Dockerfile
+++ b/docker/ssh-test.Dockerfile
@@ -1,0 +1,22 @@
+# A disposable sshd box for exercising the ssh sandbox backend in CI (and
+# locally). It is NOT a hardened image and must never be used for anything but
+# tests: it authorizes a throwaway key handed in at runtime and runs sshd in the
+# foreground. It carries exactly the remote baseline the ssh backend assumes —
+# bash + coreutils (timeout/base64/find) + python3 — so the containment gate
+# (`python3 -c 'os.system("id")'`) and the env-scrubbed wrapper run for real.
+FROM python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        openssh-server bash coreutils findutils \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/run/sshd \
+    && useradd -m -s /bin/bash agent \
+    && printf 'PasswordAuthentication no\nPermitRootLogin no\n' \
+        >> /etc/ssh/sshd_config
+
+COPY docker/ssh-test-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 22
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -170,14 +170,15 @@ class SandboxSpec:
     runs. The three backends are peers with no Docker dependency: ``local``
     (no isolation, honest about it), ``docker`` (container boundary), ``ssh``
     (the remote machine is the boundary). ``image`` applies to ``docker`` only;
-    ``host`` / ``ssh_key`` to ``ssh`` only; the resource knobs to the container
-    backends only.
+    ``host`` / ``ssh_key`` / ``port`` to ``ssh`` only; the resource knobs to the
+    container backends only.
     """
 
     backend: str
     image: Optional[str] = None
     host: Optional[str] = None
     ssh_key: Optional[str] = None
+    port: Optional[int] = None
     network: bool = False
     cpu: float = 2.0
     memory: str = "2g"

--- a/src/gimle/hugin/sandbox/ssh.py
+++ b/src/gimle/hugin/sandbox/ssh.py
@@ -140,6 +140,7 @@ class SSHSandbox(Sandbox):
         self._session_id = session_id
         self._host = spec.host
         self._key = spec.ssh_key
+        self._port = spec.port
         # Our ControlMaster socket lives in a per-user 0700 directory under the
         # system temp dir (so another local user cannot connect to or hijack the
         # multiplexed session), under a short collision-resistant name (unix
@@ -181,6 +182,8 @@ class SSHSandbox(Sandbox):
         ]
         if self._key:
             opts += ["-i", self._key]
+        if self._port:
+            opts += ["-p", str(self._port)]
         return opts
 
     def _ssh_argv(self, remote_command: str) -> List[str]:

--- a/tasks/open/031-bash-sandbox-e2e-test-harness.md
+++ b/tasks/open/031-bash-sandbox-e2e-test-harness.md
@@ -113,9 +113,21 @@ leak into a `-m "not slow"` run, and local always runs.
   simulated-abrupt exit already exist per-backend (docker lifecycle tests, ssh
   TTL sweep); a unified cross-backend leak sweep waits on the reaper
   generalization (024/030) so it has one seam to drive.
-- **CI matrix decision** (docker/ssh as a nightly job vs. manual gate). v1 keeps
-  `local` always-on and the others `slow`-gated; wiring a daemon/box into CI is a
-  separate infra change.
+- **Run all three backends for real — locally (2026-07-16).** A coverage audit
+  showed CI was only truly exercising the `local` backend: `docker.py` sat at
+  41% in CI (its container-boundary tests are daemon-gated and the self-hosted
+  Hetzner runner has **no docker** — `docker: command not found`), and ssh's real
+  remote path was 0% automated anywhere. Landed a **reusable local harness** so a
+  developer with docker runs all three for real: a throwaway sshd container
+  (`docker/ssh-test.Dockerfile`) reached via a new `port` field on the ssh spec,
+  wired into the real-host fixture and the contract/e2e opts via
+  `HUGIN_SSH_TEST_{HOST,PORT,KEY}`; `docker/README.md` documents the three
+  commands. Validated: **1012 passed** with the container up (vs 976 in CI, where
+  docker/ssh skip). **Wiring this into CI is deferred** — it needs a runner with
+  docker (install docker on the Hetzner runner, or a GitHub-hosted job); the
+  mechanism degrades gracefully either way. Also still deferred: a **real
+  mid-command partition** test for ssh (kill sshd mid-command → assert
+  do-not-retry) — the logic is already unit-tested via the mocked `_run` seam.
 - **Per-test wall-clock timeout** (panel, LOW). No `pytest-timeout` is installed,
   so a wedged docker daemon on a `slow` run could hang the job (the sandbox exec
   paths self-bound, but `containers.run` at `start()` does not). Add a

--- a/tests/sandbox_backends.py
+++ b/tests/sandbox_backends.py
@@ -18,6 +18,7 @@ from gimle.hugin.sandbox import SandboxSpec
 DAEMON_IMAGE = "python:3.12-slim"
 SSH_HOST = os.environ.get("HUGIN_SSH_TEST_HOST")
 SSH_KEY = os.environ.get("HUGIN_SSH_TEST_KEY")
+SSH_PORT = os.environ.get("HUGIN_SSH_TEST_PORT")
 
 # local always runs; docker/ssh are slow-marked so `-m "not slow"` narrows the
 # default run to the always-available backend.
@@ -69,7 +70,10 @@ def opts_for(name: str) -> dict:
     if name == "ssh":
         if not SSH_HOST:
             pytest.skip("set HUGIN_SSH_TEST_HOST=user@box to run")
-        return {"backend": "ssh", "host": SSH_HOST, "ssh_key": SSH_KEY}
+        opts: dict = {"backend": "ssh", "host": SSH_HOST, "ssh_key": SSH_KEY}
+        if SSH_PORT:
+            opts["port"] = int(SSH_PORT)
+        return opts
     raise AssertionError(f"unknown backend param: {name}")
 
 

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -25,20 +25,11 @@ from gimle.hugin.sandbox.docker import (
 from gimle.hugin.sandbox.policy import Policy
 from gimle.hugin.sandbox.sandbox import PolicyDenied
 
-
-def _docker_available() -> bool:
-    """Return whether a docker SDK and a reachable daemon are both present."""
-    try:
-        import docker
-
-        docker.from_env().ping()
-        return True
-    except Exception:
-        return False
-
+from .sandbox_backends import docker_available as _docker_available
 
 requires_docker = pytest.mark.skipif(
-    not _docker_available(), reason="requires a reachable docker daemon"
+    not _docker_available(),
+    reason="requires a reachable docker daemon with the test image pulled",
 )
 
 

--- a/tests/test_sandbox_ssh.py
+++ b/tests/test_sandbox_ssh.py
@@ -97,6 +97,12 @@ class TestCommandConstruction:
         assert opts[opts.index("-i") + 1] == "/keys/id"
         assert "-i" not in _sandbox()._ssh_opts()
 
+    def test_port_is_wired_when_configured(self):
+        """A configured port becomes -p <port>; absent -> default (no -p)."""
+        opts = _sandbox(port=2222)._ssh_opts()
+        assert opts[opts.index("-p") + 1] == "2222"
+        assert "-p" not in _sandbox()._ssh_opts()
+
     def test_remote_wrapper_scrubs_env_and_bounds_time(self):
         """The wrapper cds, scrubs env (env -i), and runs under a remote timeout."""
         wrapper = _sandbox()._remote_wrapper("/home/u/ws", 15)
@@ -461,11 +467,17 @@ requires_real_host = pytest.mark.skipif(
 
 @pytest.fixture
 def real_sandbox(tmp_path):
-    """Start a real SSHSandbox against HUGIN_SSH_TEST_HOST; always tear down."""
+    """Start a real SSHSandbox against HUGIN_SSH_TEST_HOST; always tear down.
+
+    ``HUGIN_SSH_TEST_PORT`` targets a non-standard port (e.g. a disposable sshd
+    container mapped to 2222 in CI).
+    """
+    port = os.environ.get("HUGIN_SSH_TEST_PORT")
     spec = SandboxSpec(
         backend="ssh",
         host=REAL_HOST,
         ssh_key=os.environ.get("HUGIN_SSH_TEST_KEY"),
+        port=int(port) if port else None,
     )
     sandbox = create_sandbox(spec, "itest-sess", str(tmp_path))
     sandbox.start()


### PR DESCRIPTION
## Summary

A coverage audit found the suite only truly exercises the `local` backend by default: docker's container-boundary tests are daemon-gated, and ssh's real remote path was **0% automated anywhere**. This lands a **reusable local harness** so anyone with docker can run all three backends for real — and validates the whole cross-backend contract/e2e/containment suite against real boundaries.

(The original goal was to wire this into CI, but the self-hosted Hetzner runner has no docker — `docker: command not found` — so CI activation is deferred; run locally per `docker/README.md`.)

## Changes

- **`port` on the ssh spec** — a real feature (a disposable box on a non-standard port): `SandboxSpec.port` → `-p <port>` in the ssh options. It's what lets the suite reach a containerized sshd at `127.0.0.1:2222` without an ssh-config hack (ssh on macOS resolves `~/.ssh/config` from the passwd home, not `$HOME`). Wired into the real-host fixture and the contract/e2e opts via `HUGIN_SSH_TEST_PORT`, with a `-p` unit test.
- **`docker/ssh-test.Dockerfile` + entrypoint** — a **test-only** sshd box (python3 + bash + coreutils, the ssh backend's documented remote baseline) that authorizes a throwaway key at runtime.
- **`docker/README.md`** — the three commands to bring up docker + the sshd container and run all three backends locally.
- **Dedup** — the docker suite's availability check now uses the image-aware `docker_available()`, so a daemon-up-but-image-absent box **skips** rather than **errors**.

## Testing

- **Validated locally against the real sshd container:** the 3 ssh real-host containment tests pass, and the full contract + e2e suite runs green across **all three backends** (local + docker + the ssh container). Full suite with all three live: **1012 passed, 25 skipped** (vs 976 with only `local`).
- Mocked ssh unit tests unchanged + the new `-p` wiring test; docker suite unchanged after the dedup.
- `uv run pre-commit run --all-files` — clean.

Deferred (noted in task 031): wiring this into CI (needs a runner with docker), and a real mid-command ssh **partition** test (the do-not-retry logic is already unit-tested via the mocked `_run` seam).