### PR TITLE
Make docker network:true fail-closed (egress foot-gun; task 030)

### DIFF
--- a/src/gimle/hugin/sandbox/docker.py
+++ b/src/gimle/hugin/sandbox/docker.py
@@ -30,11 +30,12 @@ configuration this code cannot set per-container:
   daemon for defence in depth. As a fail-closed guard, ``start()`` refuses to
   run as uid 0 unless the daemon has userns-remap on (else container-root would
   equal host-root).
-- **``network: true`` is not egress-filtered.** The default (``network: false``)
-  is the safe path — no network at all. Opting in attaches the default bridge
-  with *unrestricted* egress, including the cloud metadata endpoint
-  (169.254.169.254); it warns loudly and must not be used with untrusted input
-  until the egress-allowlist proxy lands (task 025 follow-ups).
+- **``network: true`` is fail-closed (no egress filtering yet).** The default
+  (``network: false``) is the safe path — no network at all. Opting in would
+  attach the default bridge with *unrestricted* egress, including the cloud
+  metadata endpoint (169.254.169.254), so it is **refused** unless
+  ``allow_unrestricted_egress: true`` explicitly accepts the risk (and even then
+  it warns). Real egress filtering (an allowlist proxy) is task 030.
 """
 
 import hashlib
@@ -232,7 +233,7 @@ class DockerSandbox(Sandbox):
         if self._client is None:
             self._client = docker.from_env()
         self._assert_not_unsafe_root()
-        self._warn_if_network_opted_in()
+        self._assert_egress_acknowledged()
         os.makedirs(self._host_root, exist_ok=True)
         self._write_owner_stamp()
         self._ensure_image()
@@ -275,18 +276,41 @@ class DockerSandbox(Sandbox):
             "user, or enable docker userns-remap on the daemon."
         )
 
-    def _warn_if_network_opted_in(self) -> None:
-        """Warn once that ``network: true`` has unrestricted (unsafe) egress."""
+    def _assert_egress_acknowledged(self) -> None:
+        """Refuse unfiltered egress unless the operator explicitly opted in.
+
+        ``network: true`` attaches the default bridge with **no egress
+        filtering** — the container has ``cap_drop=ALL`` so in-container iptables
+        is out, and real destination-IP filtering needs an allowlist proxy (a
+        separate subsystem, task 030). Until that lands, unfiltered egress is a
+        foot-gun: on a cloud host an injected command can read the instance
+        metadata endpoint (169.254.169.254) and exfiltrate IAM credentials. So it
+        is **fail-closed**: ``network: true`` is refused unless
+        ``allow_unrestricted_egress: true`` explicitly accepts the risk (and even
+        then it warns). The default ``network: false`` (no network) is untouched.
+        """
         if not self._spec.network:
             return
+        if not self._spec.allow_unrestricted_egress:
+            raise RuntimeError(
+                "backend: docker network:true attaches UNFILTERED egress "
+                "(no egress filtering is implemented yet), so an injected "
+                "command can read the cloud metadata endpoint 169.254.169.254 "
+                "and exfiltrate IAM credentials — refused by default. Either "
+                "keep network:false (the safe default, no network), or set "
+                "options.bash.allow_unrestricted_egress:true to accept the risk "
+                "explicitly. Real egress filtering (an allowlist proxy) is "
+                "tracked in task 030; for filtered egress today, run an "
+                "operator-provided proxy and pass it via the command env."
+            )
         global _network_warned
         if not _network_warned:
             logger.warning(
                 "DockerSandbox network:true attaches UNRESTRICTED egress "
                 "(including the cloud metadata endpoint 169.254.169.254); an "
-                "injected command can exfiltrate cloud IAM credentials. Do NOT "
-                "use network:true with untrusted input until egress filtering "
-                "lands. The default network:false is the safe path."
+                "injected command can exfiltrate cloud IAM credentials. You "
+                "accepted this with allow_unrestricted_egress:true. Do NOT use "
+                "it with untrusted input until egress filtering lands."
             )
             _network_warned = True
 

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -180,6 +180,12 @@ class SandboxSpec:
     ssh_key: Optional[str] = None
     port: Optional[int] = None
     network: bool = False
+    # Explicit, informed opt-in to UNFILTERED egress on ``docker`` when
+    # ``network: true``. Off by default: unfiltered egress lets an injected
+    # command read the cloud metadata endpoint (169.254.169.254) and exfiltrate
+    # IAM credentials, so ``network: true`` is refused unless this acknowledges
+    # the risk. Real egress filtering (an allowlist proxy) is task 030.
+    allow_unrestricted_egress: bool = False
     cpu: float = 2.0
     memory: str = "2g"
     pids: int = 512

--- a/tasks/open/030-bash-sandbox-docker-followups.md
+++ b/tasks/open/030-bash-sandbox-docker-followups.md
@@ -29,15 +29,21 @@ task is picked up first.
 
 ## Security (do before recommending `docker` for untrusted input at scale)
 
-- [ ] **`network: true` egress control.** *(security, HIGH — effectively
-  CRITICAL on a cloud host)* Today `network:true` attaches the default bridge
-  with unrestricted egress; an injected `curl http://169.254.169.254/...`
-  exfiltrates cloud IAM credentials. The code warns loudly and the default
-  (`network:false`) is safe, but the opt-in path needs real filtering: block
-  link-local/metadata (`169.254.0.0/16`) and RFC1918 by default, ideally via an
-  egress-allowlist proxy (the container has `cap_drop=ALL`, so in-container
-  iptables is out — filter at the network/proxy layer). Until then, consider
-  refusing `network:true` unless an explicit allow-flag is set.
+- [x] **`network: true` egress control — INTERIM DONE (2026-07-16).**
+  *(security, HIGH — effectively CRITICAL on a cloud host)* `network:true`
+  attaches the default bridge with unrestricted egress; an injected `curl
+  http://169.254.169.254/...` exfiltrates cloud IAM credentials. Since the
+  container has `cap_drop=ALL` (in-container iptables is out) and real
+  destination-IP filtering needs host root or an allowlist proxy — neither fits
+  an unprivileged library — `network:true` is now **fail-closed**: it is
+  *refused* at `start()` unless `allow_unrestricted_egress: true` explicitly
+  accepts the risk (and even then it warns). The default `network:false` (no
+  network) is untouched. This converts the silent foot-gun into an explicit,
+  informed choice. **Still deferred (the real filter):** an egress-allowlist
+  proxy that blocks link-local/metadata (`169.254.0.0/16`) + RFC1918 while
+  permitting an allowed set — a whole subsystem (filter at the network/proxy
+  layer). A lightweight interim for operators who need filtered egress today:
+  run your own HTTP(S) proxy allowlist and pass it into the command env.
 - [ ] **True userns-remap.** *(security, HIGH)* The backend runs the container as
   the host uid (non-root *inside* the container) and refuses root-without-userns,
   but it does not itself remap container-root to a subuid — that is a daemon-level

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -136,6 +136,32 @@ class TestHardeningContract:
         assert kwargs["memswap_limit"] == kwargs["mem_limit"] == "1g"
 
 
+class TestEgressGating:
+    """network:true is fail-closed: unfiltered egress needs explicit opt-in.
+
+    Pure spec checks — no daemon — so they run everywhere and can never silently
+    regress (an accidentally-unfiltered container on a cloud host is the whole
+    metadata-exfil risk).
+    """
+
+    def test_network_true_is_refused_by_default(self, tmp_path):
+        """network:true without the ack raises, naming the metadata risk."""
+        sandbox = _sandbox(tmp_path, network=True)
+        with pytest.raises(RuntimeError, match="169.254.169.254"):
+            sandbox._assert_egress_acknowledged()
+
+    def test_explicit_ack_allows_it(self, tmp_path):
+        """allow_unrestricted_egress:true lets network:true through (with a warn)."""
+        sandbox = _sandbox(
+            tmp_path, network=True, allow_unrestricted_egress=True
+        )
+        sandbox._assert_egress_acknowledged()  # must not raise
+
+    def test_no_network_is_never_gated(self, tmp_path):
+        """The safe default (no network) is unaffected by the gate."""
+        _sandbox(tmp_path)._assert_egress_acknowledged()  # must not raise
+
+
 class TestExitClassification:
     """124/137/hung map to the right (timed_out, oom_killed) signals."""
 
@@ -398,6 +424,18 @@ class TestContainerLifecycle:
         client = docker.from_env()
         with pytest.raises(docker.errors.NotFound):
             client.containers.get(name)
+
+    def test_network_true_is_refused_at_start_with_no_container(self, tmp_path):
+        """A network:true start() fails closed and creates no container."""
+        import docker
+
+        spec = SandboxSpec(backend="docker", image=DAEMON_IMAGE, network=True)
+        sandbox = create_sandbox(spec, "egress-sess", str(tmp_path))
+        with pytest.raises(RuntimeError, match="169.254.169.254"):
+            sandbox.start()
+        client = docker.from_env()
+        with pytest.raises(docker.errors.NotFound):
+            client.containers.get(sandbox._name)
 
     def test_resume_reattaches_the_same_workspace(self, tmp_path):
         """A file written in one session is present after a resume (same id)."""


### PR DESCRIPTION
## Summary

Closes the one blocking security item on the docker backend (task 030): `network:true` attaches the default bridge with **unfiltered egress**, so on a cloud host an injected command can read the instance metadata endpoint (`169.254.169.254`) and exfiltrate IAM credentials. Today it only *warns*.

Real destination-IP egress filtering needs host root (iptables) or an allowlist-proxy subsystem — **neither fits an unprivileged library**, and the container's `cap_drop=ALL` rules out in-container iptables. So per task 030's sanctioned interim, `network:true` is now **fail-closed**: an explicit, informed choice instead of a silent foot-gun.

## Changes

- **`SandboxSpec.allow_unrestricted_egress` (default `False`)** — the explicit acknowledgement.
- **`DockerSandbox` refuses `network:true` at `start()`** unless `allow_unrestricted_egress:true`, with a remediation error naming the metadata-exfil risk (and it still warns even when acknowledged). The safe default `network:false` (no network) is untouched.
- No bypass: the gate runs in `start()` **before** any container is created (`_container_kwargs` is only reached via `_create_container`, after the gate). The `network=none` default and every other hardening flag are unchanged.
- Docs: the docker module docstring + task 030's egress item (marked interim-done) now describe the fail-closed posture; the real egress-allowlist proxy stays a documented follow-up (a whole subsystem).

## Testing

- No-daemon unit tests on the gate: refused by default (message names `169.254.169.254`), allowed with the ack, never gated with no network.
- A daemon-gated end-to-end test: `start()` on `network:true` raises **and leaks no container**.
- Full suite: **1003 passed** (incl. the live docker suite here). `uv run pre-commit run --all-files` clean.

## Scope note

This is the **gating** interim, not IP-level filtering — deliberately, because unprivileged egress filtering isn't achievable without an allowlist proxy (tracked in task 030). It converts fail-open-with-a-warning into fail-closed-unless-acknowledged, which is the meaningful, honest security improvement available here. Happy to build the proxy subsystem as a follow-up if you want the real filter.