### PR TITLE
Bash sandbox: thread-safe manager + audit observability (task 024)

### DIFF
--- a/src/gimle/hugin/agent/session.py
+++ b/src/gimle/hugin/agent/session.py
@@ -220,8 +220,17 @@ class Session:
         """
         for manager in self.sandboxes.values():
             manager.close()
-        self.sandboxes.clear()
         self.background.shutdown()
+        # Emit the audit counters only *after* the workers are joined, so an
+        # interrupted background command's teardown-time outcome (the very
+        # failure the summary is meant to surface) is already recorded. Guarded:
+        # observability must never break teardown (close's never-raise contract).
+        for manager in self.sandboxes.values():
+            try:
+                manager.log_summary()
+            except Exception as error:  # never let logging break close()
+                logger.warning("sandbox audit summary failed: %s", error)
+        self.sandboxes.clear()
 
     def __enter__(self) -> "Session":
         """Enter a context that guarantees ``close`` on exit."""

--- a/src/gimle/hugin/sandbox/audit.py
+++ b/src/gimle/hugin/sandbox/audit.py
@@ -16,23 +16,54 @@ import os
 import threading
 import time
 from collections import Counter
-from typing import Optional
+from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+# The JSONL audit is append-only; without a bound a long-lived / chatty session
+# grows it without limit. Rotate to a single ``.jsonl.1`` backup past this size,
+# so on-disk audit is bounded to ~2x this (the live file plus one backup).
+DEFAULT_MAX_AUDIT_BYTES = 5_000_000
 
 
 class CommandAudit:
     """Append-only audit of bash commands plus outcome counters."""
 
-    def __init__(self, path: Optional[str] = None) -> None:
-        """Record to ``path`` (JSONL) if given; always keep in-memory counters."""
+    def __init__(
+        self,
+        path: Optional[str] = None,
+        max_bytes: int = DEFAULT_MAX_AUDIT_BYTES,
+    ) -> None:
+        """Record to ``path`` (JSONL) if given; always keep in-memory counters.
+
+        ``max_bytes`` bounds the JSONL file: past it, the file rotates to one
+        ``.1`` backup before the next append, so audit-on-disk never grows
+        without limit.
+        """
         self.path = path
+        self.max_bytes = max_bytes
         self.counters: Counter = Counter()
         # A background command records its outcome from a worker thread while a
         # foreground command records from the scheduler thread, so the counter
         # bump + file append must be serialized (a ``Counter[k] += 1`` is not
-        # atomic across threads).
+        # atomic across threads). Out-of-record bumps (``bump``) and snapshots
+        # (``summary``) take the same lock.
         self._lock = threading.Lock()
+
+    def bump(self, key: str, amount: int = 1) -> None:
+        """Increment a counter under the lock (for outcomes outside ``record``).
+
+        Lifecycle events like ``sandbox_starts`` / ``sandbox_start_failures`` are
+        tallied here rather than via ``record`` (no command line to log), and may
+        come from any thread — so they take the same lock as the record path.
+        """
+        with self._lock:
+            self.counters[key] += amount
+
+    def summary(self) -> Dict[str, int]:
+        """Return a thread-safe snapshot copy of the outcome counters."""
+        with self._lock:
+            return dict(self.counters)
 
     def record(
         self,
@@ -68,7 +99,26 @@ class CommandAudit:
             }
             try:
                 os.makedirs(os.path.dirname(self.path), exist_ok=True)
+                self._rotate_if_large()
                 with open(self.path, "a", encoding="utf-8") as handle:
                     handle.write(json.dumps(entry) + "\n")
             except OSError as error:  # best-effort; never fail over it
                 logger.debug("could not write audit entry: %s", error)
+
+    def _rotate_if_large(self) -> None:
+        """Rotate the JSONL file to a single ``.1`` backup once it exceeds the cap.
+
+        Called under ``self._lock`` from ``record``. Keeps exactly one backup
+        (``os.replace`` overwrites any prior one), so on-disk audit is bounded.
+        Best-effort: a failed rotation just lets the file keep growing this turn.
+        """
+        assert self.path is not None
+        try:
+            if os.path.getsize(self.path) < self.max_bytes:
+                return
+        except OSError:
+            return  # not there yet / unstatable — nothing to rotate
+        try:
+            os.replace(self.path, self.path + ".1")
+        except OSError as error:  # keep appending rather than fail the command
+            logger.debug("could not rotate audit file: %s", error)

--- a/src/gimle/hugin/sandbox/manager.py
+++ b/src/gimle/hugin/sandbox/manager.py
@@ -9,6 +9,7 @@ here the manager is the single object that holds the live backend handle.
 
 import logging
 import os
+import threading
 from typing import Optional
 
 from gimle.hugin.sandbox.audit import CommandAudit
@@ -20,6 +21,16 @@ from gimle.hugin.sandbox.sandbox import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Outcomes that make a session's bash usage "hot" — worth a WARN at teardown so
+# a misbehaving agent (a loop of timeouts, repeated denials, a flaky backend)
+# surfaces without a metrics pipeline.
+_HOT_OUTCOMES = (
+    "denied",
+    "timed_out",
+    "infra_error",
+    "sandbox_start_failures",
+)
 
 
 class SandboxManager:
@@ -43,6 +54,11 @@ class SandboxManager:
         self._session_id = session_id
         self._workspace_root = workspace_root
         self._sandbox = sandbox
+        # Serializes first-creation in ``get`` so two threads can't each build a
+        # backend (check-then-act). The step loop is single-threaded today, so
+        # this is defensive — but background exec already runs off-thread, so
+        # keep the invariant explicit rather than load-bearing on call order.
+        self._lock = threading.Lock()
         audit_path = None
         if record_audit_to_file:
             audit_path = os.path.join(
@@ -51,8 +67,29 @@ class SandboxManager:
         self.audit = CommandAudit(audit_path)
 
     def get(self) -> Sandbox:
-        """Return the session's sandbox, creating and starting it on first use."""
-        if self._sandbox is None:
+        """Return the session's sandbox, creating and starting it on first use.
+
+        First-creation is serialized (double-checked under ``self._lock`` in
+        ``_create_locked``) so concurrent callers build one backend, not one
+        each. The common case — an already-created backend — takes no lock and
+        just re-``start``s it (idempotent).
+        """
+        sandbox = self._sandbox
+        if sandbox is not None:
+            # A re-start() raising here is a *different* failure class than
+            # first-bring-up: it's not counted as sandbox_start_failures (the
+            # caller records it as infra_error), by design.
+            sandbox.start()  # idempotent, no lock on the hot path
+            return sandbox
+        return self._create_locked()
+
+    def _create_locked(self) -> Sandbox:
+        """Create + start the backend under the lock (double-checked)."""
+        with self._lock:
+            existing = self._sandbox
+            if existing is not None:  # another thread won the creation race
+                existing.start()
+                return existing
             try:
                 sandbox = create_sandbox(
                     self._spec, self._session_id, self._workspace_root
@@ -61,13 +98,37 @@ class SandboxManager:
             except Exception:
                 # Bringing a backend up is the classic ops failure (daemon
                 # down, host unreachable); count it so the rate is visible.
-                self.audit.counters["sandbox_start_failures"] += 1
+                self.audit.bump("sandbox_start_failures")
                 raise
             self._sandbox = sandbox
-            self.audit.counters["sandbox_starts"] += 1
-            return self._sandbox
-        self._sandbox.start()  # idempotent
-        return self._sandbox
+            self.audit.bump("sandbox_starts")
+            return sandbox
+
+    def log_summary(self) -> None:
+        """Emit the audit outcome counters as a structured log line.
+
+        The counters otherwise live only in memory and are discarded at exit,
+        leaving no trace of a misbehaving agent. Logged at ``Session.close``: an
+        INFO line always, plus a WARNING naming the failing outcomes when any are
+        present. A never-used sandbox (no outcomes) logs nothing.
+        """
+        summary = self.audit.summary()
+        if not summary:
+            return
+        logger.info(
+            "bash sandbox audit: session=%s backend=%s outcomes=%s",
+            self._session_id,
+            self._spec.backend,
+            summary,  # already a plain dict snapshot
+        )
+        hot = {k: summary[k] for k in _HOT_OUTCOMES if summary.get(k)}
+        if hot:
+            logger.warning(
+                "bash sandbox had failing outcomes: session=%s backend=%s %s",
+                self._session_id,
+                self._spec.backend,
+                hot,
+            )
 
     def close(self) -> None:
         """Tear the sandbox down. Idempotent; safe if never started."""

--- a/tests/test_sandbox_audit.py
+++ b/tests/test_sandbox_audit.py
@@ -91,3 +91,74 @@ class TestFile:
         audit = CommandAudit(path)
         audit.record(session_id="s", agent_id="a", command="ls", outcome="run")
         assert audit.counters["run"] == 1  # counted despite the write failing
+
+
+class TestBumpAndSummary:
+    """Thread-safe counter increments and snapshots for out-of-record bumps."""
+
+    def test_bump_increments_under_the_lock(self):
+        """bump() tallies a counter not tied to a recorded command outcome."""
+        audit = CommandAudit()
+        audit.bump("sandbox_starts")
+        audit.bump("sandbox_starts")
+        audit.bump("sandbox_start_failures")
+        assert audit.counters["sandbox_starts"] == 2
+        assert audit.counters["sandbox_start_failures"] == 1
+
+    def test_summary_is_a_snapshot_copy(self):
+        """summary() returns a plain dict copy, decoupled from later changes."""
+        audit = CommandAudit()
+        audit.record(session_id="s", agent_id="a", command="ls", outcome="run")
+        snap = audit.summary()
+        audit.record(session_id="s", agent_id="a", command="ls", outcome="run")
+        assert snap == {"run": 1}  # frozen at the moment it was taken
+        assert audit.summary() == {"run": 2}
+
+    def test_empty_summary_is_an_empty_dict(self):
+        """An unused audit summarizes to an empty dict (nothing to log)."""
+        assert CommandAudit().summary() == {}
+
+
+class TestRotation:
+    """The JSONL file is bounded: it rotates to one .1 backup past the cap."""
+
+    def test_rotates_past_the_cap_and_keeps_writing(self, tmp_path):
+        """Once the file exceeds max_bytes it rotates; new lines still land."""
+        path = str(tmp_path / "audit.jsonl")
+        audit = CommandAudit(path, max_bytes=300)
+        for i in range(50):
+            audit.record(
+                session_id="s", agent_id="a", command=f"cmd-{i}", outcome="run"
+            )
+        assert os.path.isfile(path + ".1")  # a backup was rotated out
+        # The live file stays bounded (roughly the cap plus one entry).
+        assert os.path.getsize(path) <= 300 + 1000
+        # The most recent command is in the live file — not lost to rotation.
+        assert _entries(path)[-1]["command"] == "cmd-49"
+
+    def test_no_rotation_under_the_cap(self, tmp_path):
+        """A small log never creates a backup."""
+        path = str(tmp_path / "audit.jsonl")
+        audit = CommandAudit(path, max_bytes=1_000_000)
+        audit.record(session_id="s", agent_id="a", command="ls", outcome="run")
+        assert not os.path.exists(path + ".1")
+
+    def test_rotation_failure_is_swallowed(self, tmp_path, monkeypatch):
+        """A failing rotation never fails the command; it keeps appending."""
+        path = str(tmp_path / "audit.jsonl")
+        audit = CommandAudit(path, max_bytes=10)
+        audit.record(
+            session_id="s", agent_id="a", command="first", outcome="run"
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("rotate failed")
+
+        monkeypatch.setattr(os, "replace", _boom)
+        # This record is now over the cap, so rotation is attempted and fails —
+        # the command must still be counted and appended, never raise.
+        audit.record(
+            session_id="s", agent_id="a", command="second", outcome="run"
+        )
+        assert audit.counters["run"] == 2
+        assert _entries(path)[-1]["command"] == "second"

--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -151,3 +151,118 @@ class TestLifecycleCounters:
             assert manager.audit.counters["sandbox_starts"] == 0
         finally:
             sandbox_mod._BACKENDS.pop("boomtest", None)
+
+    def test_restart_failure_is_not_a_start_failure(self):
+        """A re-start() failure on an already-created backend isn't miscounted.
+
+        ``sandbox_start_failures`` is for *bringing a backend up*; a later
+        idempotent re-start raising is a different class (the caller records it
+        as ``infra_error``) and must not inflate the start-failure rate.
+        """
+
+        class _FailsOnRestart(FakeSandbox):
+            def __init__(self) -> None:
+                super().__init__()
+                self._starts = 0
+
+            def start(self) -> None:
+                self._starts += 1
+                if self._starts > 1:
+                    raise RuntimeError("restart boom")
+                super().start()
+
+        manager = SandboxManager(LOCAL, "s", sandbox=_FailsOnRestart())
+        manager.get()  # first start succeeds
+        with pytest.raises(RuntimeError, match="restart boom"):
+            manager.get()  # the idempotent re-start raises
+        assert manager.audit.counters["sandbox_start_failures"] == 0
+
+
+class TestAuditSummaryLogging:
+    """log_summary emits counters at teardown, escalating on failing outcomes."""
+
+    def test_logs_an_info_summary(self, caplog, tmp_path):
+        """A used sandbox logs an INFO line naming the session and outcomes."""
+        manager = SandboxManager(LOCAL, "sess-x", workspace_root=str(tmp_path))
+        manager.audit.record(
+            session_id="sess-x", agent_id="a", command="ls", outcome="run"
+        )
+        with caplog.at_level("INFO"):
+            manager.log_summary()
+        assert any(
+            "bash sandbox audit" in r.getMessage()
+            and "sess-x" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_warns_on_failing_outcomes(self, caplog, tmp_path):
+        """A denied/timed-out/infra-error outcome escalates to a WARNING."""
+        manager = SandboxManager(LOCAL, "s", workspace_root=str(tmp_path))
+        manager.audit.record(
+            session_id="s", agent_id="a", command="rm /", outcome="denied"
+        )
+        with caplog.at_level("WARNING"):
+            manager.log_summary()
+        assert any(
+            r.levelname == "WARNING" and "failing outcomes" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_a_clean_session_does_not_warn(self, caplog, tmp_path):
+        """Only successful outcomes: an INFO line but no WARNING."""
+        manager = SandboxManager(LOCAL, "s", workspace_root=str(tmp_path))
+        manager.audit.record(
+            session_id="s", agent_id="a", command="ls", outcome="run"
+        )
+        with caplog.at_level("INFO"):
+            manager.log_summary()
+        assert not any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_unused_sandbox_logs_nothing(self, caplog, tmp_path):
+        """A sandbox with no recorded outcomes logs no audit line."""
+        manager = SandboxManager(LOCAL, "s", workspace_root=str(tmp_path))
+        with caplog.at_level("INFO"):
+            manager.log_summary()
+        assert not any(
+            "bash sandbox audit" in r.getMessage() for r in caplog.records
+        )
+
+
+class TestConcurrentGet:
+    """First-creation is serialized: concurrent callers share one backend."""
+
+    def test_concurrent_get_creates_exactly_one_backend(self):
+        """8 threads racing get() build the backend once and all get that one."""
+        import threading
+        import time as _time
+
+        from gimle.hugin.sandbox import sandbox as sandbox_mod
+        from gimle.hugin.sandbox.sandbox import register_backend
+
+        built = []
+
+        class _Slow:
+            def __init__(self, spec, session_id, workspace_root):
+                built.append(1)
+                _time.sleep(0.05)  # widen the check-then-act race window
+
+            def start(self):
+                """No-op start."""
+
+        register_backend("slowtest", lambda: _Slow)
+        try:
+            manager = SandboxManager(SandboxSpec(backend="slowtest"), "s")
+            results: list = []
+            threads = [
+                threading.Thread(target=lambda: results.append(manager.get()))
+                for _ in range(8)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+            assert len(built) == 1  # created once despite 8 concurrent callers
+            assert all(r is results[0] for r in results)  # all share the one
+            assert manager.audit.counters["sandbox_starts"] == 1
+        finally:
+            sandbox_mod._BACKENDS.pop("slowtest", None)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -46,6 +46,50 @@ class TestSessionClose:
         session.close()  # no error on the second call
         Session(environment=Environment()).close()  # never had a sandbox
 
+    def test_close_emits_the_audit_summary(self, caplog):
+        """close() logs each sandbox's audit counters when tearing it down."""
+        session, _ = self._session_with_sandbox()
+        spec = next(iter(session.sandboxes))
+        session.sandboxes[spec].audit.record(
+            session_id=session.id, agent_id="a", command="ls", outcome="run"
+        )
+        with caplog.at_level("INFO"):
+            session.close()
+        assert any(
+            "bash sandbox audit" in r.getMessage() for r in caplog.records
+        )
+
+    def test_summary_includes_teardown_time_outcomes(self, caplog):
+        """An outcome recorded *during* teardown still lands in the summary.
+
+        A background command interrupted by the sandbox stop records its
+        ``infra_error`` during teardown; the summary is emitted after teardown,
+        so it must reflect it (regression: emitting before close() missed it).
+        """
+        session = Session(environment=Environment())
+        spec = SandboxSpec(backend="local")
+
+        class _RecordsOnClose(SandboxManager):
+            def close(self) -> None:
+                self.audit.record(
+                    session_id="s",
+                    agent_id="a",
+                    command="sleep 99",
+                    outcome="infra_error",
+                )
+                super().close()
+
+        manager = _RecordsOnClose(spec, session.id, sandbox=FakeSandbox())
+        manager.get()
+        session.sandboxes[spec] = manager
+        with caplog.at_level("WARNING"):
+            session.close()
+        assert any(
+            "failing outcomes" in r.getMessage()
+            and "infra_error" in r.getMessage()
+            for r in caplog.records
+        )
+
     def test_context_manager_closes_on_exit(self):
         """Leaving a `with Session(...)` block tears the sandboxes down."""
         session = Session(environment=Environment())


### PR DESCRIPTION
## Summary

First of a few focused PRs closing out **task 024** (bash-sandbox phase-2
follow-ups). This one is the **concurrency + observability** cluster in
`manager.py` / `audit.py` / `session.py` — the deferred "thread-safety",
"emit the audit counters", and "bound `audit.jsonl` growth" items.

## Changes

- **Thread-safety** — `SandboxManager.get()` serializes first-creation with
  double-checked locking (`_create_locked`), so concurrent callers build one
  backend, not one each (proven by an 8-thread test). Its lifecycle counters now
  go through the audit lock (`audit.bump`) instead of a raw `Counter += 1` that
  raced worker-thread `record()`s. Defensive today (the step loop is
  single-threaded), but background exec already records off-thread, so the
  invariant is explicit rather than call-order luck.
- **Observability** — `Session.close()` emits each sandbox's audit outcome
  counters as a structured log line (INFO), plus a WARNING naming the failing
  outcomes (`denied` / `timed_out` / `infra_error` / `sandbox_start_failures`).
  Emitted **after** the workers are joined so an interrupted background
  command's teardown-time outcome is included, and **guarded** so logging can
  never break the never-raise teardown.
- **Bounded audit** — `CommandAudit` rotates the JSONL file to a single `.1`
  backup past a size cap (default 5 MB), so a long/chatty session can't grow it
  without limit. Best-effort: a failed rotation keeps appending.

## Testing

- Test-first: the 8-thread concurrency test was confirmed red on the old
  unguarded `get()` before the lock landed.
- New tests: double-checked-lock single-creation, `bump`/`summary`, rotation +
  rotation-failure-swallowed, `log_summary` INFO/WARN/quiet paths,
  teardown-time-outcome counting, and the re-start-is-not-a-start-failure
  asymmetry.
- A focused concurrency/correctness review confirmed the DCL and rotation are
  race-free; its two teardown findings (guard `log_summary`, order it after
  `background.shutdown()`) are folded in.
- Full suite: `uv run pytest` → 1060 passed, 38 skipped, 2 xfailed.
  Pre-commit (black/isort/flake8/mypy) clean.
