### PR TITLE
Bash sandbox: consistent rm-target deny + policy-key config hint (task 024)

### DIFF
--- a/src/gimle/hugin/sandbox/policy.py
+++ b/src/gimle/hugin/sandbox/policy.py
@@ -106,6 +106,31 @@ _DANGEROUS_RM_TARGETS = frozenset(
     {"/", "~", "~/", "/*", "*", "/.", "$HOME", "${HOME}"}
 )
 
+# System top-level directories: a recursive-force ``rm`` of one is almost never a
+# legitimate agent action (the agent's own files live deeper, under the backend's
+# workspace root), so deny it like the bare-root targets above — closing the
+# inconsistency where ``/`` was caught but ``/etc`` / ``/usr`` slipped through.
+_SYSTEM_RM_TARGETS = frozenset(
+    {
+        "/etc",
+        "/usr",
+        "/bin",
+        "/sbin",
+        "/lib",
+        "/lib64",
+        "/var",
+        "/boot",
+        "/dev",
+        "/proc",
+        "/sys",
+        "/root",
+        "/opt",
+        "/home",
+        "/srv",
+        "/run",
+    }
+)
+
 # Environment assignments that redirect execution into attacker-controlled code
 # regardless of the (allowlisted) binary being run.
 DANGEROUS_ASSIGNMENTS = frozenset(
@@ -359,7 +384,18 @@ def _is_dangerous_rm(args: List[str]) -> bool:
     if not (recursive and force):
         return False
     targets = [a for a in args if not a.startswith("-")]
-    return any(t in _DANGEROUS_RM_TARGETS for t in targets)
+    return any(_is_dangerous_rm_target(t) for t in targets)
+
+
+def _is_dangerous_rm_target(target: str) -> bool:
+    """Whether ``target`` is a catastrophic recursive-``rm`` destination.
+
+    The exact bare-root set, or a system top-level directory (normalized so a
+    trailing slash — ``/etc/`` — is still caught).
+    """
+    if target in _DANGEROUS_RM_TARGETS:
+        return True
+    return target.rstrip("/") in _SYSTEM_RM_TARGETS
 
 
 def _is_force_push(args: List[str]) -> bool:

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -210,7 +210,10 @@ class SandboxSpec:
         provided = {k: v for k, v in data.items() if k != "policy"}
         unknown = set(provided) - known
         if unknown:
-            raise ValueError(f"unknown sandbox keys: {sorted(unknown)}")
+            raise ValueError(
+                f"unknown sandbox keys: {sorted(unknown)}"
+                f"{_misplaced_policy_hint(unknown)}"
+            )
         if "backend" not in provided:
             raise ValueError(
                 "options.bash.backend is required "
@@ -226,6 +229,23 @@ class SandboxSpec:
             # hashable (it keys ``session.sandboxes``).
             provided["egress_allowlist"] = tuple(provided["egress_allowlist"])
         return cls(**provided)
+
+
+def _misplaced_policy_hint(unknown: set) -> str:
+    """Suggest nesting under ``policy:`` for keys that are Policy fields.
+
+    A common config mistake is putting a policy knob (``deny``, ``timeout_s``, …)
+    at the top level of ``options.bash`` instead of under
+    ``options.bash.policy``. Turn the bare "unknown sandbox keys" error into an
+    actionable hint when that's what happened; empty otherwise.
+    """
+    misplaced = sorted(unknown & {f.name for f in fields(Policy)})
+    if not misplaced:
+        return ""
+    return (
+        f" — {misplaced} look like policy settings; "
+        "nest them under options.bash.policy"
+    )
 
 
 def create_sandbox(

--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -71,6 +71,19 @@ class TestBackendRegistry:
         with pytest.raises(ValueError, match="invalid backend"):
             SandboxSpec.from_dict({"backend": "nope"})
 
+    def test_from_dict_hints_at_misplaced_policy_keys(self):
+        """A Policy key at the top level suggests nesting under policy:."""
+        with pytest.raises(ValueError, match="options.bash.policy"):
+            SandboxSpec.from_dict(
+                {"backend": "local", "deny": ["rm"], "timeout_s": 30}
+            )
+
+    def test_from_dict_rejects_a_truly_unknown_key_without_the_hint(self):
+        """A key that isn't a Policy field errors plainly, with no policy hint."""
+        with pytest.raises(ValueError, match="unknown sandbox keys") as excinfo:
+            SandboxSpec.from_dict({"backend": "local", "wibble": 1})
+        assert "options.bash.policy" not in str(excinfo.value)
+
 
 class TestSandboxRoot:
     """The sandbox root is derived from the session's storage base path."""

--- a/tests/test_sandbox_policy.py
+++ b/tests/test_sandbox_policy.py
@@ -107,6 +107,43 @@ class TestDenylistCatchesAccidents:
         assert isinstance(_decision("cat x | mkfs.ext4 /dev/sda1"), Deny)
 
 
+class TestRecursiveRmTargets:
+    """rm -rf of a system top-level dir is denied, like the bare-root targets.
+
+    Fixes the inconsistency where only ``/`` was caught while ``/etc``/``/usr``
+    slipped through. The agent's own files live deeper (under the backend's
+    workspace root), so a relative or deep path stays allowed.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "rm -rf /etc",
+            "rm -rf /usr",
+            "rm -rf /var/",  # trailing slash still caught
+            "rm -fr /bin",  # flag order does not matter
+            "rm --recursive --force /home",
+            "ls && rm -rf /lib",  # anywhere in the AST
+        ],
+    )
+    def test_system_dir_removal_is_denied(self, command):
+        """A recursive-force rm of a system top-level directory is refused."""
+        assert isinstance(_decision(command), Deny)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "rm -rf ./build",  # relative — an accident, not catastrophic
+            "rm -rf /workspace/agents/a/build",  # deep, under the workspace
+            "rm -rf /etc/hosts.d",  # a file/subdir, not the system dir itself
+            "rm file.txt",  # not recursive-force
+        ],
+    )
+    def test_legitimate_removals_stay_allowed(self, command):
+        """Relative, deep, or non-recursive removals are not denied."""
+        assert isinstance(_decision(command), Allow)
+
+
 class TestWrapperPrefixesDoNotBypass:
     """A denied binary run *through* a wrapper (env/timeout/…) is still caught.
 


### PR DESCRIPTION
## Summary

Second slice of **task 024** (bash-sandbox phase-2 follow-ups): two small
agent-usability wins from the Phase-1 panel. (The larger usability items —
environment affordance and the cross-backend spill-path fix — are each getting
their own focused PR.)

## Changes

- **Consistent `rm` deny.** The recursive-force `rm` guard caught the bare-root
  targets (`/`, `~`, `/*`, …) but let `rm -rf /etc` / `/usr` / `/var` slip
  through. It now denies a recursive-force `rm` of any **system top-level
  directory** too (normalized, so `/etc/` is caught), while relative
  (`rm -rf ./build`), deep (`/workspace/agents/a/build`), and non-recursive
  removals stay allowed — the guard is a blunt-accident backstop, not a
  capability boundary.
- **Actionable config hint.** `SandboxSpec.from_dict` used to report a bare
  `unknown sandbox keys: ['deny', 'timeout_s']` when a **policy** knob was put
  at the top level of `options.bash` instead of under `options.bash.policy`. It
  now appends a hint naming the misplaced keys and pointing at
  `options.bash.policy`; a genuinely unknown key still errors plainly (no hint).

## Testing

- Test-first (both were confirmed red before the fix).
- New tests: `TestRecursiveRmTargets` (system dirs denied; relative/deep/
  non-recursive allowed) and two `from_dict` cases (policy-key hint vs. a truly
  unknown key with no hint).
- Full suite: `uv run pytest` → 1072 passed, 38 skipped, 2 xfailed. Pre-commit
  clean.