### PR TITLE
Bash sandbox: one-time environment affordance on first use (task 024)

### DIFF
--- a/src/gimle/hugin/sandbox/manager.py
+++ b/src/gimle/hugin/sandbox/manager.py
@@ -10,7 +10,7 @@ here the manager is the single object that holds the live backend handle.
 import logging
 import os
 import threading
-from typing import Optional
+from typing import Optional, Set
 
 from gimle.hugin.sandbox.audit import CommandAudit
 from gimle.hugin.sandbox.sandbox import (
@@ -59,6 +59,9 @@ class SandboxManager:
         # this is defensive — but background exec already runs off-thread, so
         # keep the invariant explicit rather than load-bearing on call order.
         self._lock = threading.Lock()
+        # Agents that have already received the one-time environment note (the
+        # manager is shared across same-spec agents, so track per agent id).
+        self._announced: Set[str] = set()
         audit_path = None
         if record_audit_to_file:
             audit_path = os.path.join(
@@ -103,6 +106,23 @@ class SandboxManager:
             self._sandbox = sandbox
             self.audit.bump("sandbox_starts")
             return sandbox
+
+    @property
+    def spec(self) -> SandboxSpec:
+        """The spec this manager runs — read-only; the env note renders from it."""
+        return self._spec
+
+    def announce_once(self, agent_id: str) -> bool:
+        """Return True the first time an agent should get the environment note.
+
+        Thread-safe and idempotent per agent id: True exactly once per agent
+        (the manager is shared across same-spec agents), False thereafter.
+        """
+        with self._lock:
+            if agent_id in self._announced:
+                return False
+            self._announced.add(agent_id)
+            return True
 
     def log_summary(self) -> None:
         """Emit the audit outcome counters as a structured log line.

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -234,7 +234,7 @@ def bash(
     session = stack.agent.session
     bg = getattr(session, "background", None)
     if bg is None:  # a hand-rolled session without the executor: run inline
-        return _run_sync(
+        response = _run_sync(
             manager,
             stack,
             command,
@@ -243,6 +243,7 @@ def bash(
             effective_cwd,
             requested_timeout,
         )
+        return _with_env_note(response, manager, stack, sandbox, branch)
 
     try:
         job = bg.submit(
@@ -282,7 +283,8 @@ def bash(
 
     if bg.wait(job.job_id, DEFAULT_DEFER_AFTER_S):
         content, is_error = bg.collect(job.job_id, agent_id=stack.agent.id)
-        return ToolResponse(is_error=is_error, content=content)
+        response = ToolResponse(is_error=is_error, content=content)
+        return _with_env_note(response, manager, stack, sandbox, branch)
     return ToolResponse(
         is_error=False,
         content={"job_id": job.job_id, "status": "running"},
@@ -556,3 +558,71 @@ def _to_response(command: str, result: ExecResult) -> ToolResponse:
         is_error=result.timed_out or result.oom_killed,
         content=result_content(command, result),
     )
+
+
+def _network_note(spec: SandboxSpec) -> str:
+    """Return a one-line, spec-derived description of what the shell can reach.
+
+    The load-bearing field of the environment note: an agent that doesn't know
+    the network is off wastes turns on ``curl``/``pip``/``npm`` that can't
+    connect. Derived from the resolved spec so it can never drift from reality.
+    """
+    if spec.backend == "local":
+        return "on (host network — the local backend has no isolation)"
+    if spec.backend == "ssh":
+        return "the remote host's network (whatever that host can reach)"
+    # docker
+    if not spec.network:
+        return "OFF — curl/uv/pip/npm cannot reach the internet; work offline"
+    if spec.egress_allowlist:
+        allowed = ", ".join(spec.egress_allowlist)
+        return f"filtered — only these hosts are reachable: {allowed}"
+    if spec.allow_unrestricted_egress:
+        return "on (unrestricted egress)"
+    return "OFF"  # network:true without a policy is refused at start()
+
+
+def _environment_note(spec: SandboxSpec, workspace: str) -> Dict[str, Any]:
+    """Return a one-time description of the shell's environment for the agent.
+
+    Rendered from the resolved spec (no probe command), so it never drifts: the
+    backend, whether the network is reachable (and how), where files persist,
+    and the fresh-shell reminder.
+    """
+    return {
+        "backend": spec.backend,
+        "network": _network_note(spec),
+        "workspace": workspace,
+        "note": "Each call is a FRESH shell — cd/export/source do not persist. "
+        "Write files in the workspace to keep state between calls.",
+    }
+
+
+def _with_env_note(
+    response: ToolResponse,
+    manager: Optional[SandboxManager],
+    stack: "Stack",
+    sandbox: Any,
+    branch: Optional[str],
+) -> ToolResponse:
+    """Attach a one-time environment note to an agent's first successful bash use.
+
+    Only on a non-error, dict-content result, and the announcement is consumed
+    (``announce_once``) *only* when the note is actually attached — so a first
+    command that errored or was backgrounded still gets the note next time.
+    """
+    if (
+        manager is None
+        or response.is_error
+        or not isinstance(response.content, dict)
+    ):
+        return response
+    try:
+        workspace = sandbox.workspace_for(stack.agent.id, branch)
+        note = _environment_note(manager.spec, workspace)
+    except Exception as error:  # the note is a nicety; never break the result
+        logger.debug("environment note skipped: %s", error)
+        return response
+    if manager.announce_once(stack.agent.id):
+        response.content["environment"] = note
+    return response

--- a/tests/test_bash_background.py
+++ b/tests/test_bash_background.py
@@ -417,3 +417,23 @@ def _resolved_tool_result(agent):
         ):
             return interaction
     return None
+
+
+class TestBackgroundEnvironmentNote:
+    """The one-time environment note also lands on the grace-completed path."""
+
+    def test_grace_completed_first_command_carries_the_note(self):
+        """A fast command (no defer) collects with the env note on first use."""
+        executor = BackgroundExecutor()
+        fake = FakeSandbox(
+            ExecResult(exit_code=0, stdout="ok", stderr="", duration_s=0.0)
+        )
+        stack = _bg_stack(fake, executor)
+        try:
+            # Completes within the grace window, so it collects synchronously
+            # (path 2), not parked — the env note attaches there too.
+            response = bash("echo hi", stack=stack)
+            assert response.is_error is False
+            assert response.content["environment"]["backend"] == "local"
+        finally:
+            executor.shutdown()

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -429,3 +429,66 @@ class TestSandboxResolution:
         """Called without a stack, the tool errors instead of crashing."""
         response = bash("echo hi", stack=None)
         assert response.is_error is True
+
+
+class TestEnvironmentAffordance:
+    """The first successful bash use per agent carries a one-time env note."""
+
+    def test_first_use_announces_environment_then_stops(self):
+        """The first result carries an `environment` note; the second does not."""
+        fake = FakeSandbox(
+            ExecResult(exit_code=0, stdout="hi", stderr="", duration_s=0.0)
+        )
+        manager = SandboxManager(LOCAL, "session-1", sandbox=fake)
+        stack = _stack(sandbox_manager=manager)
+
+        first = bash("echo hi", stack=stack)
+        assert "environment" in first.content
+        env = first.content["environment"]
+        assert env["backend"] == "local"
+        assert "network" in env
+        assert env["workspace"].startswith("/workspace/agents/agent-a")
+
+        second = bash("echo again", stack=stack)
+        assert "environment" not in second.content
+
+    def test_error_result_does_not_carry_or_consume_the_note(self):
+        """An infra_error first result gets no note (and doesn't consume it)."""
+        fake = FakeSandbox(raises=RuntimeError("daemon down"))
+        manager = SandboxManager(LOCAL, "session-1", sandbox=fake)
+        first = bash("echo hi", stack=_stack(sandbox_manager=manager))
+        assert first.is_error is True
+        assert "environment" not in first.content
+        assert manager.announce_once("agent-a") is True  # still un-announced
+
+    def test_network_note_is_rendered_from_the_spec(self):
+        """The network line is derived from the spec (no probe, never drifts)."""
+        from gimle.hugin.tools.builtins.bash import _environment_note
+
+        ws = "/workspace/agents/a/default"
+        local = _environment_note(SandboxSpec(backend="local"), ws)["network"]
+        assert "host network" in local
+
+        off = _environment_note(SandboxSpec(backend="docker"), ws)["network"]
+        assert "OFF" in off
+
+        filtered = _environment_note(
+            SandboxSpec(
+                backend="docker", network=True, egress_allowlist=("pypi.org",)
+            ),
+            ws,
+        )["network"]
+        assert "filtered" in filtered and "pypi.org" in filtered
+
+        unrestricted = _environment_note(
+            SandboxSpec(
+                backend="docker", network=True, allow_unrestricted_egress=True
+            ),
+            ws,
+        )["network"]
+        assert "unrestricted" in unrestricted
+
+        remote = _environment_note(SandboxSpec(backend="ssh", host="h"), ws)[
+            "network"
+        ]
+        assert "remote host" in remote

--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -191,6 +191,24 @@ class TestLifecycleCounters:
         assert manager.audit.counters["sandbox_start_failures"] == 0
 
 
+class TestAnnounceOnce:
+    """First-use tracking for the per-agent one-time environment note."""
+
+    def test_true_only_the_first_time_per_agent(self):
+        """announce_once returns True once per agent id, then False."""
+        manager = SandboxManager(LOCAL, "s")
+        assert manager.announce_once("agent-a") is True
+        assert manager.announce_once("agent-a") is False
+        # A different agent sharing the manager gets its own first announcement.
+        assert manager.announce_once("agent-b") is True
+        assert manager.announce_once("agent-b") is False
+
+    def test_spec_is_exposed(self):
+        """The manager exposes its spec (the env note is rendered from it)."""
+        manager = SandboxManager(LOCAL, "s")
+        assert manager.spec is LOCAL
+
+
 class TestAuditSummaryLogging:
     """log_summary emits counters at teardown, escalating on failing outcomes."""
 


### PR DESCRIPTION
## Summary

Third slice of **task 024**: the panel's HIGH-priority agent-usability item. The
agent used to discover its shell environment by trial and error — most costly,
it didn't know when the network was **off**, so it wasted turns on
`curl`/`uv`/`pip`/`npm` that couldn't connect. Now the first successful bash
result per agent carries a one-time `environment` note.

## Changes

- The note is rendered **purely from the resolved spec** (no probe command, so
  it can never drift from reality): `backend`, `network` (the load-bearing line:
  `OFF` / `filtered — only these hosts` / `unrestricted` / host / remote),
  `workspace` (where files persist), and the fresh-shell reminder.
- `SandboxManager.announce_once(agent_id)` — thread-safe, returns True exactly
  once per agent (the manager is shared across same-spec agents), False after;
  plus a read-only `spec` accessor.
- `_with_env_note` attaches the note on the two synchronous result paths (inline
  run and the grace-completed background collect), **only on a non-error
  result**, and consumes the announcement **only when the note is actually
  attached** — so a first command that errored or was backgrounded still gets
  the note next time. Parked / fire-and-forget results defer it to the next
  ordinary result.

## Testing

- Test-first. New tests: `announce_once` per-agent semantics; the network note
  rendered for all five backend/egress cases (local / docker-off / filtered /
  unrestricted / ssh); first-use-then-stops; an infra_error neither carries nor
  consumes the note; and the grace-completed background path also carries it.
- Full suite: `uv run pytest` → 1077 passed, 38 skipped, 2 xfailed. Pre-commit
  clean.