### PR TITLE
Bash sandbox: unique, absolute per-command spill path (tasks 024/030)

### DIFF
--- a/src/gimle/hugin/sandbox/background.py
+++ b/src/gimle/hugin/sandbox/background.py
@@ -69,8 +69,8 @@ def result_content(command: str, result: ExecResult) -> Dict[str, Any]:
         "timed_out": result.timed_out,
         "oom_killed": result.oom_killed,
     }
-    if result.truncated:
-        content["full_output"] = ".hugin/last_output.txt"
+    if result.truncated and result.spill_path:
+        content["full_output"] = result.spill_path
     return content
 
 

--- a/src/gimle/hugin/sandbox/docker.py
+++ b/src/gimle/hugin/sandbox/docker.py
@@ -47,6 +47,7 @@ configuration this code cannot set per-container:
 import hashlib
 import logging
 import os
+import posixpath
 import threading
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
@@ -64,6 +65,7 @@ from gimle.hugin.sandbox.sandbox import (
     Sandbox,
     SandboxSpec,
     classify_timeout_exit,
+    new_spill_relpath,
     truncate_output,
 )
 
@@ -83,7 +85,6 @@ CONTAINER_WORKSPACE = "/workspace"
 _NAME_PREFIX = "hugin-sbx-"
 _PROXY_PREFIX = "hugin-proxy-"
 _EGRESS_NET_PREFIX = "hugin-egress-"
-_SPILL_RELATIVE = os.path.join(".hugin", "last_output.txt")
 
 # The egress proxy listens here inside its sidecar; the sandbox's HTTP_PROXY
 # points at ``http://<proxy-name>:<port>`` (resolved by the internal network's
@@ -838,8 +839,9 @@ class DockerSandbox(Sandbox):
         out, out_trunc = truncate_output(stdout_raw, max_output_bytes)
         err, err_trunc = truncate_output(stderr_raw, max_output_bytes)
         truncated = out_trunc or err_trunc or capped
-        if truncated:
-            self._spill(cwd, stdout_raw, stderr_raw)
+        spill_path = (
+            self._spill(cwd, stdout_raw, stderr_raw) if truncated else None
+        )
 
         return ExecResult(
             exit_code=exit_code,
@@ -849,6 +851,7 @@ class DockerSandbox(Sandbox):
             truncated=truncated,
             timed_out=timed_out,
             oom_killed=oom_killed,
+            spill_path=spill_path,
         )
 
     @staticmethod
@@ -956,24 +959,30 @@ class DockerSandbox(Sandbox):
         except Exception:  # pragma: no cover - if we can't tell, assume running
             return True
 
-    def _spill(self, cwd: str, stdout: str, stderr: str) -> None:
+    def _spill(self, cwd: str, stdout: str, stderr: str) -> Optional[str]:
         """Write full output host-side so the agent can read past the cap.
 
         ``cwd`` is a container path under ``/workspace``; it maps to the host
         bind-mount root, so the file is visible both to the host and, at the
-        same relative path, to the agent inside the container.
+        same relative path, to the agent inside the container. Returns the
+        *container* absolute path (what the agent reads, from any cwd), or None
+        if the best-effort write failed.
         """
+        relpath = new_spill_relpath()
         try:
-            host_cwd = self._host_path(cwd)
-            spill_path = os.path.join(host_cwd, _SPILL_RELATIVE)
-            os.makedirs(os.path.dirname(spill_path), exist_ok=True)
-            with open(spill_path, "w", encoding="utf-8") as handle:
+            host_spill = os.path.join(self._host_path(cwd), relpath)
+            os.makedirs(os.path.dirname(host_spill), exist_ok=True)
+            with open(host_spill, "w", encoding="utf-8") as handle:
                 handle.write(stdout)
                 if stderr:
                     handle.write("\n--- stderr ---\n")
                     handle.write(stderr)
+            # The agent reads it inside the container: the same relative path
+            # under the container-side cwd (posix, absolute).
+            return posixpath.join(cwd, relpath)
         except OSError as error:  # best-effort; never fail the command over it
             logger.debug("could not spill full output: %s", error)
+            return None
 
     def _host_path(self, container_path: str) -> str:
         """Map a ``/workspace/...`` container path to its host bind-mount path."""

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -27,6 +27,7 @@ from gimle.hugin.sandbox.sandbox import (
     PolicyDenied,
     Sandbox,
     SandboxSpec,
+    new_spill_relpath,
     truncate_output,
 )
 
@@ -35,8 +36,6 @@ logger = logging.getLogger(__name__)
 # Warn once per process that the local backend is not a sandbox — an operator
 # selecting ``backend: local`` should see it, not have to read a docstring.
 _isolation_warned = False
-
-_SPILL_RELATIVE = os.path.join(".hugin", "last_output.txt")
 # Owner stamp read by the reaper to decide whether a workspace is abandoned.
 OWNER_FILE = ".hugin_owner.json"
 
@@ -221,8 +220,9 @@ class LocalSandbox(Sandbox):
         out, out_trunc = truncate_output(full_stdout, max_output_bytes)
         err, err_trunc = truncate_output(full_stderr, max_output_bytes)
         truncated = out_trunc or err_trunc or capped
-        if truncated:
-            self._spill(cwd, full_stdout, full_stderr)
+        spill_path = (
+            self._spill(cwd, full_stdout, full_stderr) if truncated else None
+        )
 
         return ExecResult(
             exit_code=proc.returncode if proc.returncode is not None else -1,
@@ -232,6 +232,7 @@ class LocalSandbox(Sandbox):
             truncated=truncated,
             timed_out=timed_out,
             oom_killed=False,  # a bare subprocess cannot bound or detect OOM
+            spill_path=spill_path,
         )
 
     def _capture(
@@ -328,18 +329,24 @@ class LocalSandbox(Sandbox):
         except (ProcessLookupError, PermissionError):
             pass  # already gone, or not ours to kill
 
-    def _spill(self, cwd: str, stdout: str, stderr: str) -> None:
-        """Write full output to the workspace so the agent can read past the cap."""
+    def _spill(self, cwd: str, stdout: str, stderr: str) -> Optional[str]:
+        """Write full output under ``cwd`` so the agent can read past the cap.
+
+        Returns the absolute path written (readable from any cwd), or None if the
+        best-effort write failed — never fails the command over it.
+        """
+        spill_path = os.path.join(cwd, new_spill_relpath())
         try:
-            spill_path = os.path.join(cwd, _SPILL_RELATIVE)
             os.makedirs(os.path.dirname(spill_path), exist_ok=True)
             with open(spill_path, "w", encoding="utf-8") as handle:
                 handle.write(stdout)
                 if stderr:
                     handle.write("\n--- stderr ---\n")
                     handle.write(stderr)
+            return spill_path
         except OSError as error:  # best-effort; never fail the command over it
             logger.debug("could not spill full output: %s", error)
+            return None
 
     # -- files --
 

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -12,6 +12,7 @@ a fake backend first.
 """
 
 import os
+import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields
 from typing import Any, Callable, Dict, Optional, Tuple, Type, cast
@@ -20,6 +21,21 @@ from gimle.hugin.sandbox.policy import Policy
 
 # Default storage base when a session has no explicit path (in-memory storage).
 DEFAULT_STORAGE_BASE = "./storage"
+
+# Directory (relative to a workspace) that per-command output spills land in, and
+# a factory for a unique spill filename. Forward slashes so the one relative path
+# is valid on the host, in a Linux container, and on a remote box alike; each
+# backend joins it onto its own base and returns the absolute result.
+SPILL_DIR = ".hugin"
+
+
+def new_spill_relpath() -> str:
+    """Return a unique, workspace-relative spill filename for one command.
+
+    Unique per call so a later truncated command never clobbers an earlier
+    command's spilled output (a fixed ``last_output.txt`` did).
+    """
+    return f"{SPILL_DIR}/output-{uuid.uuid4().hex[:12]}.txt"
 
 
 def sandbox_root_for(storage_base: Optional[str]) -> str:
@@ -160,6 +176,12 @@ class ExecResult:
     truncated: bool = False
     timed_out: bool = False
     oom_killed: bool = False
+    # When ``truncated``, the absolute path (in the command's own namespace —
+    # host / container / remote) of the file the full output was spilled to, so
+    # a follow-up can read past the cap. Unique per command (so a later
+    # truncation doesn't clobber an earlier one) and absolute (so it reads from
+    # any cwd). None if nothing was spilled or the spill write failed.
+    spill_path: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/src/gimle/hugin/sandbox/ssh.py
+++ b/src/gimle/hugin/sandbox/ssh.py
@@ -62,6 +62,7 @@ from gimle.hugin.sandbox.sandbox import (
     Sandbox,
     SandboxSpec,
     classify_timeout_exit,
+    new_spill_relpath,
     truncate_output,
 )
 
@@ -112,8 +113,6 @@ _EXIT_SENTINEL = "__HUGIN_EXIT_b9f2c1a4__"
 _SENTINEL_RE = re.compile(
     rb"\n" + re.escape(_EXIT_SENTINEL.encode("ascii")) + rb"=(-?\d+)\n?$"
 )
-
-_SPILL_RELATIVE = ".hugin/last_output.txt"
 
 
 def _safe_component(value: str) -> str:
@@ -469,8 +468,11 @@ class SSHSandbox(Sandbox):
         out, out_trunc = truncate_output(stdout_raw, max_output_bytes)
         err, err_trunc = truncate_output(stderr_raw, max_output_bytes)
         truncated = out_trunc or err_trunc or capped
-        if truncated:
+        spill_path = (
             self._spill_remote(cwd, stdout_bytes, err_bytes)
+            if truncated
+            else None
+        )
 
         return ExecResult(
             exit_code=exit_code,
@@ -480,6 +482,7 @@ class SSHSandbox(Sandbox):
             truncated=truncated,
             timed_out=timed_out,
             oom_killed=oom_killed,
+            spill_path=spill_path,
         )
 
     @staticmethod
@@ -500,19 +503,31 @@ class SSHSandbox(Sandbox):
 
     def _spill_remote(
         self, remote_cwd: str, stdout: bytes, stderr: bytes
-    ) -> None:
-        """Write the full output to the remote workspace so the agent can read it."""
+    ) -> Optional[str]:
+        """Write the full output to the remote workspace so the agent can read it.
+
+        Returns the absolute remote path written (readable from any cwd), or None
+        if the best-effort write failed — never fails the command over it.
+        """
         blob = stdout
         if stderr:
             blob = blob + b"\n--- stderr ---\n" + stderr
-        spill = posixpath.join(remote_cwd, _SPILL_RELATIVE)
+        spill = posixpath.join(remote_cwd, new_spill_relpath())
         parent = posixpath.dirname(spill)
-        self._safe_run(
-            self._ssh_argv(
-                f"mkdir -p {shlex.quote(parent)} && cat > {shlex.quote(spill)}"
-            ),
-            input_bytes=blob,
-        )
+        try:
+            self._safe_run(
+                self._ssh_argv(
+                    f"mkdir -p {shlex.quote(parent)} && "
+                    f"cat > {shlex.quote(spill)}"
+                ),
+                input_bytes=blob,
+            )
+            return spill
+        except (
+            Exception
+        ) as error:  # best-effort; never fail the command over it
+            logger.debug("could not spill full output remotely: %s", error)
+            return None
 
     # -- files --
 

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -60,8 +60,8 @@ backgrounded command you never collect is lost). Only the last few command \
 outputs stay visible to you — write anything you need to keep into a file.
 
 Large output is truncated (tail-biased); when that happens the response \
-carries a `full_output` path (`.hugin/last_output.txt`) holding the complete \
-output — inspect it with `rg` or `sed -n`. A non-zero exit code is normal \
+carries a `full_output` path holding the complete output — inspect that path \
+with `rg` or `sed -n`. A non-zero exit code is normal \
 information (e.g. `grep` finding no matches), not a tool failure. A command \
 refused by policy comes back with a `denied` reason — try a permitted \
 alternative; an `unparseable` reason means the guard's parser choked, so \

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -131,7 +131,7 @@ class TestResultMapping:
         assert response.content["oom_killed"] is True
 
     def test_truncated_output_carries_the_spill_path(self):
-        """When output is truncated, the response tells the model where to read."""
+        """A truncated result reports the exact spill path the backend wrote."""
         fake = FakeSandbox(
             ExecResult(
                 exit_code=0,
@@ -139,10 +139,29 @@ class TestResultMapping:
                 stderr="",
                 duration_s=0.1,
                 truncated=True,
+                spill_path="/workspace/agents/a/default/.hugin/output-abc123.txt",
             )
         )
         response = bash("cat big", stack=_stack_with_fake(fake))
-        assert response.content["full_output"] == ".hugin/last_output.txt"
+        assert (
+            response.content["full_output"]
+            == "/workspace/agents/a/default/.hugin/output-abc123.txt"
+        )
+
+    def test_truncated_without_a_spill_path_omits_full_output(self):
+        """If the spill write failed (no path), no full_output is advertised."""
+        fake = FakeSandbox(
+            ExecResult(
+                exit_code=0,
+                stdout="tail",
+                stderr="",
+                duration_s=0.1,
+                truncated=True,
+                spill_path=None,
+            )
+        )
+        response = bash("cat big", stack=_stack_with_fake(fake))
+        assert "full_output" not in response.content
 
     def test_timeout_argument_is_passed_to_exec(self):
         """A caller-supplied timeout_s reaches the sandbox exec."""

--- a/tests/test_sandbox_contract.py
+++ b/tests/test_sandbox_contract.py
@@ -126,13 +126,16 @@ class TestBackendContract:
         # The returned view is genuinely shortened, not just flagged — a backend
         # that set the flag but returned all 500 bytes would flood the context.
         assert "x" * 300 not in result.stdout
+        # The result names exactly where the full output was spilled, and that
+        # path is usable as-is (absolute, so it reads from any cwd).
+        assert result.spill_path is not None
         spilled = backend.box.exec(
-            "cat .hugin/last_output.txt",
+            f"cat {result.spill_path}",
             policy=Policy(),
             cwd=cwd,
             timeout_s=15,
         )
-        # ...but the spill holds the full output the view dropped.
+        # ...and the spill holds the full output the view dropped.
         assert "x" * 300 in spilled.stdout
 
     def test_workspaces_are_isolated_per_agent(self, backend):

--- a/tests/test_sandbox_local.py
+++ b/tests/test_sandbox_local.py
@@ -171,6 +171,36 @@ class TestOutputTruncation:
             "echo small", policy=Policy(), cwd=_cwd(sandbox), timeout_s=10
         )
         assert not result.truncated
+        assert result.spill_path is None  # nothing spilled, nothing to point at
+
+    def test_each_truncation_spills_a_distinct_readable_file(self, sandbox):
+        """Two truncated commands spill to different files, both recoverable.
+
+        Regression: a single overwritten ``last_output.txt`` meant a deferred
+        read of the earlier command got the later command's output.
+        """
+        import os
+
+        cwd = _cwd(sandbox)
+
+        def big(marker: str):
+            return sandbox.exec(
+                f"for i in $(seq 1 1000); do echo {marker}-$i; done",
+                policy=Policy(max_output_bytes=300),
+                cwd=cwd,
+                timeout_s=10,
+                max_output_bytes=300,
+            )
+
+        first = big("alpha")
+        second = big("beta")
+        assert first.spill_path and second.spill_path
+        assert first.spill_path != second.spill_path  # unique per call
+        assert os.path.isabs(first.spill_path)  # usable from any cwd
+        with open(first.spill_path, encoding="utf-8") as handle:
+            assert "alpha-1000" in handle.read()  # earlier output not clobbered
+        with open(second.spill_path, encoding="utf-8") as handle:
+            assert "beta-1000" in handle.read()
 
     def test_runaway_output_is_capped_without_hanging(self, sandbox):
         """Unbounded output is bounded in memory and the process is killed.

--- a/tests/test_sandbox_ssh.py
+++ b/tests/test_sandbox_ssh.py
@@ -298,9 +298,13 @@ class TestExec:
             max_output_bytes=1000,
         )
         assert result.truncated is True
-        # The spill call wrote the full output to .hugin/last_output.txt.
+        # The spill call wrote the full output to a unique .hugin/output-* file,
+        # and the result names its absolute remote path.
         spill_call = sandbox._run.calls[-1]
-        assert any("last_output.txt" in a for a in spill_call.argv)
+        assert any("/.hugin/output-" in a for a in spill_call.argv)
+        assert result.spill_path is not None
+        assert result.spill_path.endswith(".txt")
+        assert result.spill_path.startswith("/home/u/.hugin-sandbox/sess-1/")
 
     def test_byte_capped_output_is_completed_with_unknown_exit(self):
         """Output past the byte cap loses the sentinel; report a completed run."""


### PR DESCRIPTION
## Summary

A truncated command spilled its full output to a fixed `.hugin/last_output.txt`
under the command cwd, with two bugs the panels flagged (tasks 024 & 030):
a later truncated command **overwrote** it (so a deferred read got the *wrong*
output), and with `cwd: subdir` it landed under the subdir where a follow-up at
the workspace root **couldn't find it**.

Now each backend spills to a **unique per-command file** and `ExecResult`
carries its **absolute path** (in the command's own namespace — host / container
/ remote), reported to the model as `full_output`. Absolute so it reads from any
cwd; unique so an earlier command's output is never clobbered. Done once across
all three backends (the item appears in both task 024 and 030).

## Changes

- `ExecResult.spill_path` + a shared `new_spill_relpath()` factory
  (`.hugin/output-<uuid>.txt`, forward-slashed so one relative path is valid on
  host / Linux container / remote).
- `local` / `docker` / `ssh` `_spill*` write the unique file and return the
  absolute path the agent reads — docker returns the **container** path while
  writing host-side through the bind mount; ssh returns the **remote** path. A
  failed best-effort spill returns `None`.
- `result_content` advertises `full_output` only when a spill path is present,
  so a failed spill no longer claims a path that isn't there.
- Tool description no longer hardcodes the old filename.

## Testing

- Test-first; the three tests that pinned the old fixed path were updated to the
  new contract.
- New: a local test that **two** truncated commands spill to **distinct**,
  independently-readable absolute files (the overwrite regression); a bash-tool
  test that `full_output` echoes the backend's `spill_path` (and is omitted when
  the spill failed).
- **End-to-end**: the cross-backend contract truncation test `cat`s the returned
  path and recovers the full output — it **passed for docker against a real
  daemon** (proving the container-absolute path is readable inside the
  container) and for local; ssh skips without a host.
- Full suite: `uv run pytest` → 1080 passed, 38 skipped, 2 xfailed. Pre-commit
  clean.