### PR TITLE
Bash sandbox: confine put_file/get_file to the agent's workspace (task 024)

### DIFF
--- a/src/gimle/hugin/sandbox/docker.py
+++ b/src/gimle/hugin/sandbox/docker.py
@@ -749,6 +749,11 @@ class DockerSandbox(Sandbox):
 
     # -- workspaces --
 
+    def _agent_root(self, agent_id: str, branch: Optional[str]) -> str:
+        """Container path for ``(agent, branch)`` (pure, no host dir created)."""
+        rel = posixpath.join("agents", agent_id, branch or "default")
+        return f"{CONTAINER_WORKSPACE}/{rel}"
+
     def workspace_for(self, agent_id: str, branch: Optional[str]) -> str:
         """Return the container path for ``(agent, branch)``; create it host-side.
 
@@ -756,9 +761,9 @@ class DockerSandbox(Sandbox):
         matching host directory (visible in the container through the bind
         mount) is created so a command has somewhere to run.
         """
-        rel = os.path.join("agents", agent_id, branch or "default")
-        os.makedirs(os.path.join(self._host_root, rel), exist_ok=True)
-        return f"{CONTAINER_WORKSPACE}/{rel}"
+        container = self._agent_root(agent_id, branch)
+        os.makedirs(self._host_path(container), exist_ok=True)
+        return container
 
     # -- execution --
 
@@ -991,31 +996,39 @@ class DockerSandbox(Sandbox):
 
     # -- files --
 
-    def put_file(self, path: str, content: bytes) -> None:
-        """Write ``content`` into the workspace (host-side, confined)."""
-        target = self._confine(path)
+    def put_file(
+        self, agent_id: str, branch: Optional[str], path: str, content: bytes
+    ) -> None:
+        """Write ``content`` into the agent's workspace (host-side, confined)."""
+        target = self._confine(agent_id, branch, path)
         os.makedirs(os.path.dirname(target), exist_ok=True)
         with open(target, "wb") as handle:
             handle.write(content)
 
-    def get_file(self, path: str) -> bytes:
-        """Read ``path`` from the workspace, refusing a symlink escape."""
-        target = self._confine(path)
+    def get_file(
+        self, agent_id: str, branch: Optional[str], path: str
+    ) -> bytes:
+        """Read ``path`` from the agent's workspace, refusing a symlink escape."""
+        target = self._confine(agent_id, branch, path)
         with open(target, "rb") as handle:
             return handle.read()
 
-    def _confine(self, path: str) -> str:
-        """Resolve ``path`` within the host workspace root or raise PolicyDenied.
+    def _confine(self, agent_id: str, branch: Optional[str], path: str) -> str:
+        """Resolve ``path`` within the ``(agent, branch)`` host workspace, or raise.
 
-        Accepts either a container ``/workspace/...`` path or a host/relative
-        one, mapping the former to the host side first, then realpath-checks the
-        result so a symlink planted in the workspace cannot point outside it.
+        Confined to the *agent's own* workspace (not the whole session), so a
+        traversal into a sibling agent's tree is refused. Accepts either a
+        container ``/workspace/...`` path or a host/relative one, mapping the
+        former to the host side first, then realpath-checks the result so a
+        symlink planted in the workspace cannot point outside it.
         """
+        root = os.path.realpath(
+            self._host_path(self._agent_root(agent_id, branch))
+        )
         if path == CONTAINER_WORKSPACE or path.startswith(
             CONTAINER_WORKSPACE + "/"
         ):
             path = self._host_path(path)
-        root = os.path.realpath(self._host_root)
         candidate = path if os.path.isabs(path) else os.path.join(root, path)
         resolved = os.path.realpath(candidate)
         if resolved != root and not resolved.startswith(root + os.sep):

--- a/src/gimle/hugin/sandbox/fake.py
+++ b/src/gimle/hugin/sandbox/fake.py
@@ -8,7 +8,7 @@ with no subprocess, no container, and no daemon.
 import os
 import threading
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from gimle.hugin.sandbox.policy import Policy
 from gimle.hugin.sandbox.sandbox import ExecResult, Sandbox
@@ -54,7 +54,7 @@ class FakeSandbox(Sandbox):
         self.started = False
         self.stopped = False
         self.calls: List[_ExecCall] = []
-        self.files: Dict[str, bytes] = {}
+        self.files: Dict[Tuple[str, Optional[str], str], bytes] = {}
 
     def start(self) -> None:
         """Record that the sandbox was started, or raise if configured to fail."""
@@ -97,13 +97,17 @@ class FakeSandbox(Sandbox):
             raise self._raises
         return self._result
 
-    def put_file(self, path: str, content: bytes) -> None:
-        """Store ``content`` in the in-memory file map."""
-        self.files[path] = content
+    def put_file(
+        self, agent_id: str, branch: Optional[str], path: str, content: bytes
+    ) -> None:
+        """Store ``content`` in the in-memory file map, keyed per agent."""
+        self.files[(agent_id, branch, path)] = content
 
-    def get_file(self, path: str) -> bytes:
-        """Return previously stored content for ``path``."""
-        return self.files[path]
+    def get_file(
+        self, agent_id: str, branch: Optional[str], path: str
+    ) -> bytes:
+        """Return previously stored content for this agent's ``path``."""
+        return self.files[(agent_id, branch, path)]
 
     @property
     def last_call(self) -> Optional[_ExecCall]:

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -164,11 +164,15 @@ class LocalSandbox(Sandbox):
 
     # -- workspaces --
 
-    def workspace_for(self, agent_id: str, branch: Optional[str]) -> str:
-        """Return this ``(agent, branch)`` directory, creating it if absent."""
-        path = os.path.join(
+    def _agent_root(self, agent_id: str, branch: Optional[str]) -> str:
+        """Compute this ``(agent, branch)`` directory path (pure, no I/O)."""
+        return os.path.join(
             self._session_root, "agents", agent_id, branch or "default"
         )
+
+    def workspace_for(self, agent_id: str, branch: Optional[str]) -> str:
+        """Return this ``(agent, branch)`` directory, creating it if absent."""
+        path = self._agent_root(agent_id, branch)
         os.makedirs(path, exist_ok=True)
         return path
 
@@ -350,27 +354,33 @@ class LocalSandbox(Sandbox):
 
     # -- files --
 
-    def put_file(self, path: str, content: bytes) -> None:
-        """Write ``content`` to ``path`` inside the workspace."""
-        target = self._confine(path)
+    def put_file(
+        self, agent_id: str, branch: Optional[str], path: str, content: bytes
+    ) -> None:
+        """Write ``content`` to ``path`` inside the agent's workspace."""
+        target = self._confine(agent_id, branch, path)
         os.makedirs(os.path.dirname(target), exist_ok=True)
         with open(target, "wb") as handle:
             handle.write(content)
 
-    def get_file(self, path: str) -> bytes:
-        """Read ``path`` from the workspace, refusing a symlink escape."""
-        target = self._confine(path)
+    def get_file(
+        self, agent_id: str, branch: Optional[str], path: str
+    ) -> bytes:
+        """Read ``path`` from the agent's workspace, refusing a symlink escape."""
+        target = self._confine(agent_id, branch, path)
         with open(target, "rb") as handle:
             return handle.read()
 
-    def _confine(self, path: str) -> str:
-        """Resolve ``path`` within the session workspace or raise PolicyDenied.
+    def _confine(self, agent_id: str, branch: Optional[str], path: str) -> str:
+        """Resolve ``path`` within the ``(agent, branch)`` workspace, or raise.
 
-        ``realpath`` dereferences symlinks first, so a link planted inside the
-        workspace that points outside it resolves to an outside path and is
-        rejected — the harvest/escape hole the security review flagged.
+        Confined to the *agent's own* workspace (not the whole session), so a
+        traversal into a sibling agent's tree is refused. ``realpath``
+        dereferences symlinks first, so a link planted inside the workspace that
+        points outside it resolves to an outside path and is rejected — the
+        harvest/escape hole the security review flagged.
         """
-        root = os.path.realpath(self._session_root)
+        root = os.path.realpath(self._agent_root(agent_id, branch))
         candidate = path if os.path.isabs(path) else os.path.join(root, path)
         resolved = os.path.realpath(candidate)
         if resolved != root and not resolved.startswith(root + os.sep):

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -323,17 +323,27 @@ class Sandbox(ABC):
         """Absolute working directory for this ``(agent, branch)``; created."""
 
     @abstractmethod
-    def put_file(self, path: str, content: bytes) -> None:
-        """Write ``content`` to ``path`` inside the workspace (confined)."""
+    def put_file(
+        self, agent_id: str, branch: Optional[str], path: str, content: bytes
+    ) -> None:
+        """Write ``content`` to ``path`` in the ``(agent, branch)`` workspace.
+
+        ``path`` is confined to *that agent's own* workspace, the same scope as
+        ``exec``'s cwd — so a traversal out of it, including into a sibling
+        agent's workspace under the same session, is refused.
+        """
 
     @abstractmethod
-    def get_file(self, path: str) -> bytes:
-        """Read ``path`` from the workspace.
+    def get_file(
+        self, agent_id: str, branch: Optional[str], path: str
+    ) -> bytes:
+        """Read ``path`` from the ``(agent, branch)`` workspace.
 
-        Confined to the workspace. The *strength* of that confinement is
-        backend-dependent: the local backend resolves the real path (symlink
-        escapes blocked), while the ssh backend confines lexically (a remote
-        symlink escape is out of scope on a disposable box — see its docstring).
+        Confined to that agent's own workspace. The *strength* of that
+        confinement is backend-dependent: the local/docker backends resolve the
+        real path (symlink escapes blocked), while the ssh backend confines
+        lexically (a remote symlink escape is out of scope on a disposable box —
+        see its docstring).
         """
 
     @abstractmethod

--- a/src/gimle/hugin/sandbox/ssh.py
+++ b/src/gimle/hugin/sandbox/ssh.py
@@ -358,14 +358,14 @@ class SSHSandbox(Sandbox):
 
     # -- workspaces --
 
-    def workspace_for(self, agent_id: str, branch: Optional[str]) -> str:
-        """Return the remote ``(agent, branch)`` path, creating it once.
+    def _agent_root(self, agent_id: str, branch: Optional[str]) -> str:
+        """Compute the remote ``(agent, branch)`` path (pure, no remote I/O).
 
         ``agent_id`` and ``branch`` can carry LLM-chosen text (e.g. a
         ``create_branch`` name), so both are reduced to a single safe path
         component — :func:`_safe_component` maps ``/`` to ``-``, which alone
         defeats traversal — and the joined path is re-checked to be strictly
-        under the session root before it is ever used in a remote ``mkdir``.
+        under the session root.
         """
         if self._remote_root is None:
             raise RuntimeError("sandbox not started")
@@ -378,6 +378,11 @@ class SSHSandbox(Sandbox):
             raise PolicyDenied(
                 f"invalid agent/branch workspace: {agent_id!r}/{branch!r}"
             )
+        return path
+
+    def workspace_for(self, agent_id: str, branch: Optional[str]) -> str:
+        """Return the remote ``(agent, branch)`` path, creating it once."""
+        path = self._agent_root(agent_id, branch)
         if path not in self._created:
             self._safe_run(self._ssh_argv(f"mkdir -p {shlex.quote(path)}"))
             self._created.add(path)
@@ -531,9 +536,11 @@ class SSHSandbox(Sandbox):
 
     # -- files --
 
-    def put_file(self, path: str, content: bytes) -> None:
-        """Write ``content`` into the remote workspace (confined)."""
-        remote = self._confine(path)
+    def put_file(
+        self, agent_id: str, branch: Optional[str], path: str, content: bytes
+    ) -> None:
+        """Write ``content`` into the agent's remote workspace (confined)."""
+        remote = self._confine(agent_id, branch, path)
         parent = posixpath.dirname(remote)
         rc, _out, err, _capped, hung = self._run(
             self._ssh_argv(
@@ -547,15 +554,17 @@ class SSHSandbox(Sandbox):
                 f"put_file failed for {path!r}: {err.decode('utf-8', 'replace')}"
             )
 
-    def get_file(self, path: str) -> bytes:
-        """Read ``path`` from the remote workspace (confined).
+    def get_file(
+        self, agent_id: str, branch: Optional[str], path: str
+    ) -> bytes:
+        """Read ``path`` from the agent's remote workspace (confined).
 
         Raises rather than return a truncated file: the read goes through the
         byte-capped ``_run`` seam, so a file larger than
         :data:`_MAX_CAPTURE_BYTES` (or a stalled read) must surface as an error,
         never as silently short bytes a caller would mistake for the whole file.
         """
-        remote = self._confine(path)
+        remote = self._confine(agent_id, branch, path)
         rc, out, err, capped, hung = self._run(
             self._ssh_argv(f"cat {shlex.quote(remote)}"),
             deadline_s=_CONTROL_DEADLINE_S,
@@ -571,16 +580,16 @@ class SSHSandbox(Sandbox):
             )
         return bytes(out)
 
-    def _confine(self, path: str) -> str:
-        """Resolve ``path`` within the remote workspace root or raise.
+    def _confine(self, agent_id: str, branch: Optional[str], path: str) -> str:
+        """Resolve ``path`` within the ``(agent, branch)`` remote workspace, or raise.
 
-        Lexical (posix) confinement only — a remote ``realpath`` per call is a
-        round-trip we skip on a disposable box; a remote symlink escape is out of
-        scope for v1 (documented). ``..`` traversal is rejected.
+        Confined to the *agent's own* workspace (not the whole session), so a
+        traversal into a sibling agent's tree is refused. Lexical (posix)
+        confinement only — a remote ``realpath`` per call is a round-trip we skip
+        on a disposable box; a remote symlink escape is out of scope for v1
+        (documented). ``..`` traversal is rejected.
         """
-        if self._remote_root is None:
-            raise RuntimeError("sandbox not started")
-        root = self._remote_root
+        root = self._agent_root(agent_id, branch)
         candidate = (
             path if posixpath.isabs(path) else posixpath.join(root, path)
         )

--- a/tests/test_sandbox_contract.py
+++ b/tests/test_sandbox_contract.py
@@ -193,12 +193,23 @@ class TestBackendContract:
         assert "uid=" in result.stdout
 
     def test_put_get_roundtrip_and_confinement(self, backend):
-        """put_file/get_file round-trip bytes; a traversal path is refused."""
-        backend.box.workspace_for("a", None)  # ensure the root exists
-        backend.box.put_file("note.txt", b"payload-bytes")
-        assert backend.box.get_file("note.txt") == b"payload-bytes"
+        """put_file/get_file round-trip bytes in the agent workspace; traversal refused."""
+        backend.box.put_file("a", None, "note.txt", b"payload-bytes")
+        assert backend.box.get_file("a", None, "note.txt") == b"payload-bytes"
         with pytest.raises(PolicyDenied):
-            backend.box.get_file("../../../etc/passwd")
+            backend.box.get_file("a", None, "../../../etc/passwd")
+
+    def test_file_ops_are_confined_to_the_agent_workspace(self, backend):
+        """One agent cannot read another agent's file via put/get_file.
+
+        The file ops confine to ``(agent, branch)`` like ``exec``'s cwd, so a
+        path that reaches out of the agent's own workspace is refused — even
+        though a sibling agent's workspace exists under the same session root.
+        """
+        backend.box.put_file("owner", None, "secret.txt", b"top-secret")
+        backend.box.workspace_for("intruder", None)  # sibling exists
+        with pytest.raises(PolicyDenied):
+            backend.box.get_file("intruder", None, "../owner/secret.txt")
 
 
 class TestContainmentContract:

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -436,25 +436,28 @@ class TestFileConfinement:
     def test_put_then_get_roundtrips(self, tmp_path):
         """A file written through put_file reads back through get_file."""
         sandbox = _sandbox(tmp_path)
-        sandbox.put_file("notes.txt", b"hello")
-        assert sandbox.get_file("notes.txt") == b"hello"
+        sandbox.put_file("a", None, "notes.txt", b"hello")
+        assert sandbox.get_file("a", None, "notes.txt") == b"hello"
 
-    def test_container_path_is_accepted(self, tmp_path):
-        """A /workspace-absolute path is mapped to the host side, not rejected."""
+    def test_container_path_under_the_agent_workspace_is_accepted(
+        self, tmp_path
+    ):
+        """A /workspace-absolute path in the agent's own tree maps host-side."""
         sandbox = _sandbox(tmp_path)
-        sandbox.put_file(f"{CONTAINER_WORKSPACE}/a.txt", b"x")
-        assert sandbox.get_file("a.txt") == b"x"
+        container = f"{sandbox.workspace_for('a', None)}/a.txt"
+        sandbox.put_file("a", None, container, b"x")
+        assert sandbox.get_file("a", None, "a.txt") == b"x"
 
     def test_symlink_escape_is_refused(self, tmp_path):
         """A symlink pointing outside the workspace cannot be read through."""
         sandbox = _sandbox(tmp_path)
-        host_root = sandbox._host_root
-        os.makedirs(host_root, exist_ok=True)
+        agent_host = sandbox._host_path(sandbox.workspace_for("a", None))
+        os.makedirs(agent_host, exist_ok=True)
         secret = tmp_path / "outside.txt"
         secret.write_text("secret")
-        os.symlink(str(secret), os.path.join(host_root, "link"))
+        os.symlink(str(secret), os.path.join(agent_host, "link"))
         with pytest.raises(PolicyDenied):
-            sandbox.get_file("link")
+            sandbox.get_file("a", None, "link")
 
 
 class TestBackendRegistration:

--- a/tests/test_sandbox_local.py
+++ b/tests/test_sandbox_local.py
@@ -245,9 +245,9 @@ class TestFileAccess:
     """put_file/get_file and workspace confinement."""
 
     def test_put_and_get_file_round_trip(self, sandbox):
-        """A file written into the workspace reads back byte-for-byte."""
-        sandbox.put_file("notes/todo.txt", b"remember milk")
-        assert sandbox.get_file("notes/todo.txt") == b"remember milk"
+        """A file written into the agent workspace reads back byte-for-byte."""
+        sandbox.put_file("a", None, "notes/todo.txt", b"remember milk")
+        assert sandbox.get_file("a", None, "notes/todo.txt") == b"remember milk"
 
     def test_get_file_rejects_symlink_escape(self, sandbox, tmp_path):
         """A symlink pointing outside the workspace cannot be read."""
@@ -257,9 +257,14 @@ class TestFileAccess:
         link = os.path.join(root, "escape")
         os.symlink(str(secret), link)
         with pytest.raises(PolicyDenied):
-            sandbox.get_file(
-                os.path.join("agents", "agent-a", "main", "escape")
-            )
+            sandbox.get_file("agent-a", "main", "escape")
+
+    def test_file_ops_are_confined_to_the_agent(self, sandbox):
+        """A path that climbs into a sibling agent's workspace is refused."""
+        sandbox.put_file("owner", None, "secret.txt", b"mine")
+        sandbox.workspace_for("intruder", None)
+        with pytest.raises(PolicyDenied):
+            sandbox.get_file("intruder", None, "../owner/secret.txt")
 
 
 def test_stop_is_idempotent(tmp_path):

--- a/tests/test_sandbox_ssh.py
+++ b/tests/test_sandbox_ssh.py
@@ -9,7 +9,6 @@ real disposable box: the command executes on the remote machine, not locally.
 """
 
 import os
-import posixpath
 from types import SimpleNamespace
 
 import pytest
@@ -140,24 +139,30 @@ class TestCommandConstruction:
 class TestConfinement:
     """put_file/get_file resolve within the remote workspace only."""
 
-    def test_relative_path_joins_the_root(self):
-        """A relative path resolves under the remote root."""
+    def test_relative_path_joins_the_agent_root(self):
+        """A relative path resolves under the agent's own remote workspace."""
         sandbox = _started(_sandbox())
-        assert sandbox._confine("notes.txt") == (
-            "/home/u/.hugin-sandbox/sess-1/notes.txt"
+        assert sandbox._confine("a", None, "notes.txt") == (
+            "/home/u/.hugin-sandbox/sess-1/agents/a/default/notes.txt"
         )
 
     def test_dotdot_escape_is_refused(self):
-        """A traversal outside the workspace is rejected."""
+        """A traversal outside the agent workspace is rejected."""
         sandbox = _started(_sandbox())
         with pytest.raises(PolicyDenied):
-            sandbox._confine("../../etc/passwd")
+            sandbox._confine("a", None, "../../etc/passwd")
 
     def test_absolute_outside_is_refused(self):
-        """An absolute path outside the root is rejected."""
+        """An absolute path outside the workspace is rejected."""
         sandbox = _started(_sandbox())
         with pytest.raises(PolicyDenied):
-            sandbox._confine("/etc/passwd")
+            sandbox._confine("a", None, "/etc/passwd")
+
+    def test_sibling_agent_is_refused(self):
+        """A path climbing into another agent's workspace is rejected."""
+        sandbox = _started(_sandbox())
+        with pytest.raises(PolicyDenied):
+            sandbox._confine("a", None, "../other/secret.txt")
 
 
 class TestExec:
@@ -361,24 +366,24 @@ class TestWorkspaceAndFiles:
             (0, b"", b"", False, False),  # put
             (0, b"stored", b"", False, False),  # get
         )
-        sandbox.put_file("out.txt", b"data")
-        assert sandbox.get_file("out.txt") == b"stored"
+        sandbox.put_file("a", None, "out.txt", b"data")
+        assert sandbox.get_file("a", None, "out.txt") == b"stored"
         put_argv = " ".join(sandbox._run.calls[0].argv)
-        assert "sess-1/out.txt" in put_argv
+        assert "agents/a/default/out.txt" in put_argv
 
     def test_get_file_failure_raises(self):
         """A non-zero remote cat (missing file) raises."""
         sandbox = _started(_sandbox())
         sandbox._run = _FakeRun((1, b"", b"No such file", False, False))
         with pytest.raises(RuntimeError, match="get_file failed"):
-            sandbox.get_file("missing.txt")
+            sandbox.get_file("a", None, "missing.txt")
 
     def test_get_file_over_cap_raises_not_truncates(self):
         """A file larger than the transfer cap raises, never returns short bytes."""
         sandbox = _started(_sandbox())
         sandbox._run = _FakeRun((0, b"x" * 2_000_000, b"", True, False))
         with pytest.raises(RuntimeError, match="transfer cap"):
-            sandbox.get_file("huge.bin")
+            sandbox.get_file("a", None, "huge.bin")
 
 
 class TestRunSeam:
@@ -523,13 +528,11 @@ class TestRealHostContainment:
         assert result.stdout.strip() != os.uname().nodename
 
     def test_files_roundtrip_on_the_remote(self, real_sandbox):
-        """put_file then a remote cat sees the same bytes."""
-        real_sandbox.workspace_for("a", None)
-        real_sandbox.put_file("marker.txt", b"remote-hello")
+        """put_file then a remote cat of the agent's own file sees the bytes."""
+        real_sandbox.put_file("a", None, "marker.txt", b"remote-hello")
         cwd = real_sandbox.workspace_for("a", None)
         result = real_sandbox.exec(
-            "cat ../../marker.txt || cat "
-            + posixpath.join(real_sandbox._remote_root, "marker.txt"),
+            "cat marker.txt",  # the file lives in the agent's own workspace
             policy=Policy(),
             cwd=cwd,
             timeout_s=20,


### PR DESCRIPTION
## Summary

Task 024 file-methods follow-up. `Sandbox.put_file`/`get_file` took only a
`path` and confined it to the whole **session** root, while `exec`'s cwd is
per-`(agent, branch)` — three confinement scopes under one "workspace" word, and
an agent could read or write a **sibling agent's** files by climbing into
`agents/<other>/...`. Per the decision to give the file methods agent context
(over dropping them), they now confine to the agent's own workspace, matching
`exec`.

## Changes

- File ops take `(agent_id, branch, path[, content])` and confine to that
  agent's workspace; a traversal out of it — including into a sibling agent's
  tree — is refused.
- Each backend gains a **pure** `_agent_root(agent_id, branch)` path helper,
  shared by `workspace_for` (which creates the dir) and a now **side-effect-free**
  `_confine` — so ssh confinement no longer does a remote round-trip, and the
  LLM-controlled `agent_id`/`branch` stay traversal-safe (ssh's `_safe_component`
  sanitisation is reused).
- docker maps the agent's container path to its host bind-mount before the
  realpath check. ABC + local/docker/ssh/fake all updated.

## Testing

- Test-first; the existing round-trip/confinement tests were rebased to the new
  signature and agent scope.
- New: a cross-backend **contract** test that one agent cannot read another's
  file via `../owner/secret.txt`, plus per-backend cross-agent cases. The
  contract test **passed for local and docker** (docker against the real
  backend); ssh skips without a host.
- Full suite: `uv run pytest` → 1084 passed, 39 skipped, 2 xfailed. Pre-commit
  clean.