### PR TITLE
Docker reaper: scope the owner-PID test to the container's host + boot (task 030)

### DIFF
--- a/src/gimle/hugin/sandbox/docker.py
+++ b/src/gimle/hugin/sandbox/docker.py
@@ -55,6 +55,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from gimle.hugin.sandbox import egress_proxy
 from gimle.hugin.sandbox.local import (
     OWNER_FILE,
+    boot_id,
+    current_hostname,
     process_start_time,
 )
 from gimle.hugin.sandbox.policy import Allow, Policy, evaluate
@@ -103,6 +105,11 @@ LABEL_OWNER_PID = "hugin.owner_pid"
 LABEL_OWNER_START = "hugin.owner_start"
 LABEL_CREATED = "hugin.created"
 LABEL_TTL = "hugin.ttl"
+# Which host + boot created the container, so the reaper only judges an owner
+# PID against the process table it actually belongs to: never another host's
+# container (a shared daemon), and a prior boot's owner PID (recycled) is dead.
+LABEL_HOST = "hugin.host"
+LABEL_BOOT = "hugin.boot"
 
 # Backstop lifetime for a container whose owner we can no longer positively
 # identify (PID reused, start-time unreadable). Owner-liveness is the primary
@@ -696,6 +703,8 @@ class DockerSandbox(Sandbox):
             LABEL_OWNER_START: process_start_time(pid) or "",
             LABEL_CREATED: str(int(time.time())),
             LABEL_TTL: str(DEFAULT_TTL_S),
+            LABEL_HOST: current_hostname(),
+            LABEL_BOOT: boot_id(),
         }
 
     def _write_owner_stamp(self) -> None:

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -15,6 +15,7 @@ import logging
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import threading
 import time
@@ -68,6 +69,53 @@ def process_start_time(pid: int) -> Optional[str]:
         return result.stdout.strip() or None
     except (OSError, ValueError, IndexError, subprocess.SubprocessError):
         return None
+
+
+# Sentinel boot token when a host's boot id cannot be determined; callers treat
+# it as "unknown" and fall back to the PID/TTL judgment (pre-scoping behaviour).
+UNKNOWN_BOOT = "unknown"
+
+
+def current_hostname() -> str:
+    """Return this host's name — labels a container so the reaper scopes to it."""
+    try:
+        return socket.gethostname() or "unknown-host"
+    except OSError:
+        return "unknown-host"
+
+
+def boot_id() -> str:
+    """Return an opaque per-boot token for this host, or :data:`UNKNOWN_BOOT`.
+
+    Lets the reaper tell one boot from another: a container's owner PID is only
+    meaningful within the boot that created it (PIDs recycle across reboots), so
+    a container labelled with a *different* boot has a definitely-dead owner.
+    Best-effort and dependency-free — Linux reads the kernel boot UUID; macOS/BSD
+    read ``kern.boottime``; otherwise ``UNKNOWN_BOOT`` (callers then fall back to
+    the PID/TTL judgment rather than risk a false reap).
+    """
+    try:
+        with open(
+            "/proc/sys/kernel/random/boot_id", encoding="utf-8"
+        ) as handle:
+            token = handle.read().strip()
+        if token:
+            return token
+    except OSError:
+        pass
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "kern.boottime"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        token = result.stdout.strip()
+        if token:
+            return token
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return UNKNOWN_BOOT
 
 
 # Hard ceiling on output *buffered in this process* per command, across stdout

--- a/src/gimle/hugin/sandbox/reaper.py
+++ b/src/gimle/hugin/sandbox/reaper.py
@@ -27,9 +27,17 @@ import shutil
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Tuple
 
-from gimle.hugin.sandbox.local import OWNER_FILE, process_start_time
+from gimle.hugin.sandbox.local import (
+    OWNER_FILE,
+    UNKNOWN_BOOT,
+    boot_id,
+    current_hostname,
+    process_start_time,
+)
 
 logger = logging.getLogger(__name__)
+
+_BOOT_UNKNOWN = UNKNOWN_BOOT
 
 
 @dataclass(frozen=True)
@@ -170,7 +178,9 @@ def reap_abandoned_containers(
         The names of the containers that were removed.
     """
     from gimle.hugin.sandbox.docker import (
+        LABEL_BOOT,
         LABEL_CREATED,
+        LABEL_HOST,
         LABEL_OWNER_PID,
         LABEL_OWNER_START,
         LABEL_SESSION,
@@ -190,6 +200,7 @@ def reap_abandoned_containers(
         logger.debug("container reap skipped (docker unavailable): %s", error)
         return []
 
+    this_host, this_boot = current_hostname(), boot_id()
     reaped: List[str] = []
     for container in containers:
         try:
@@ -203,6 +214,10 @@ def reap_abandoned_containers(
                 pid_key=LABEL_OWNER_PID,
                 start_key=LABEL_OWNER_START,
                 ttl_key=LABEL_TTL,
+                host_key=LABEL_HOST,
+                boot_key=LABEL_BOOT,
+                current_host=this_host,
+                current_boot=this_boot,
             ):
                 # force=True SIGKILLs and removes in one step (the owner is
                 # already dead — no graceful stop to wait on).
@@ -239,7 +254,9 @@ def reap_abandoned_networks(
         The names of the networks that were removed.
     """
     from gimle.hugin.sandbox.docker import (
+        LABEL_BOOT,
         LABEL_CREATED,
+        LABEL_HOST,
         LABEL_OWNER_PID,
         LABEL_OWNER_START,
         LABEL_SESSION,
@@ -255,6 +272,7 @@ def reap_abandoned_networks(
         logger.debug("network reap skipped (docker unavailable): %s", error)
         return []
 
+    this_host, this_boot = current_hostname(), boot_id()
     reaped: List[str] = []
     for network in networks:
         try:
@@ -268,6 +286,10 @@ def reap_abandoned_networks(
                 pid_key=LABEL_OWNER_PID,
                 start_key=LABEL_OWNER_START,
                 ttl_key=LABEL_TTL,
+                host_key=LABEL_HOST,
+                boot_key=LABEL_BOOT,
+                current_host=this_host,
+                current_boot=this_boot,
             ):
                 # Refuses (raises) if a live peer container is still attached —
                 # caught below, so a live session's network is never pulled.
@@ -293,6 +315,10 @@ def _container_is_abandoned(
     pid_key: str,
     start_key: str,
     ttl_key: str,
+    host_key: Optional[str] = None,
+    boot_key: Optional[str] = None,
+    current_host: Optional[str] = None,
+    current_boot: Optional[str] = None,
 ) -> bool:
     """Decide whether a labelled container is abandoned (dead owner, or past TTL).
 
@@ -302,7 +328,28 @@ def _container_is_abandoned(
     container whose owner cannot be identified at all (missing/garbled PID
     label) is kept until its TTL elapses, never removed while its owner is
     provably alive.
+
+    Host/boot scoping (when the container carries a host label — older ones
+    predate it and fall through to the PID/TTL judgment) keeps the owner-PID test
+    sound: a container created by a *different host* (a shared daemon) is never
+    judged or reaped here — the local process table says nothing about its owner,
+    so that host's own reaper owns it (cross-host reaping is out of scope). A
+    container from *this host but a prior boot* is abandoned outright: PIDs
+    recycle across reboots, so its owner PID is meaningless.
     """
+    label_host = labels.get(host_key) if host_key else None
+    if label_host is not None and current_host is not None:
+        if label_host != current_host:
+            return False  # another host's container — not ours to judge or reap
+        label_boot = labels.get(boot_key) if boot_key else None
+        if (
+            label_boot
+            and current_boot
+            and _BOOT_UNKNOWN not in (label_boot, current_boot)
+            and label_boot != current_boot
+        ):
+            return True  # this host rebooted since — the owner PID is dead
+
     try:
         pid = int(labels[pid_key])
     except (KeyError, ValueError, TypeError):

--- a/tasks/open/030-bash-sandbox-docker-followups.md
+++ b/tasks/open/030-bash-sandbox-docker-followups.md
@@ -69,15 +69,17 @@ task is picked up first.
 
 ## Architecture / ops
 
-- [ ] **Reaper generalization + scoping.** *(architect/SRE, MEDIUM)* Backend
-  reap logic (`reap_abandoned_containers`) is a bespoke free function in
-  `reaper.py`; SSH will add a third. Give the backend registry a reap seam so the
-  CLI iterates it. Also the container sweep is daemon-global: it lists *every*
-  `hugin.session` container and judges the owner PID against the *local* process
-  table — wrong for a remote/shared daemon, and it can reap another
-  `--storage-path`'s containers. Label the container with a host/boot-id and its
-  workspace-root and filter on both; document the local-daemon assumption.
-  Overlaps task 024's reaper-generalization item.
+- [~] **Reaper generalization + scoping.** *(architect/SRE, MEDIUM)* **Scoping
+  done:** containers/networks are now labelled with `hugin.host` + `hugin.boot`,
+  and the reaper only judges an owner PID against the process table it belongs
+  to — a *different host*'s container (shared daemon) is never reaped here (its
+  own host owns it), and a *prior boot*'s container is abandoned outright (PIDs
+  recycle across reboots). Older unlabelled containers fall through to the
+  pre-scoping PID/TTL judgment. `boot_id()`/`current_hostname()` in `local.py`.
+  **Still open:** the *generalization* — `reap_abandoned_containers` is still a
+  bespoke free function; give the backend registry a reap seam so the CLI
+  iterates backends (SSH will add a third). Cross-host reaping of a genuinely
+  dead host's containers stays out of scope (documented). Overlaps task 024.
 - [ ] **Capped / backgrounded exec: explicit state + kill.** *(SRE/architect/
   usability, MEDIUM)* On the output cap or a host-side abandonment the exec'd
   process keeps running in-container until its `timeout` fires, and the next

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -147,10 +147,14 @@ class TestHardeningContract:
         assert mapping == {"bind": CONTAINER_WORKSPACE, "mode": "rw"}
 
     def test_labels_identify_the_owner_for_the_reaper(self, tmp_path):
-        """Labels carry owner PID + created + ttl so the reaper can judge it."""
+        """Labels carry owner PID + created + ttl + host/boot so it can judge it."""
+        from gimle.hugin.sandbox.docker import LABEL_BOOT, LABEL_HOST
+
         labels = _sandbox(tmp_path)._container_kwargs()["labels"]
         assert labels[LABEL_OWNER_PID] == str(os.getpid())
         assert LABEL_CREATED in labels and LABEL_TTL in labels
+        # Host + boot scope the owner-PID test to this host+boot (task 030).
+        assert labels[LABEL_HOST] and labels[LABEL_BOOT]
 
     def test_dev_shm_is_hardened_too(self, tmp_path):
         """/dev/shm is a noexec,nosuid tmpfs (docker mounts it rw+exec by default)."""

--- a/tests/test_sandbox_reaper.py
+++ b/tests/test_sandbox_reaper.py
@@ -10,13 +10,15 @@ import os
 import time
 
 from gimle.hugin.sandbox.docker import (
+    LABEL_BOOT,
     LABEL_CREATED,
+    LABEL_HOST,
     LABEL_OWNER_PID,
     LABEL_OWNER_START,
     LABEL_SESSION,
     LABEL_TTL,
 )
-from gimle.hugin.sandbox.local import OWNER_FILE
+from gimle.hugin.sandbox.local import OWNER_FILE, UNKNOWN_BOOT, boot_id
 from gimle.hugin.sandbox.reaper import (
     _container_is_abandoned,
     list_local_workspaces,
@@ -163,15 +165,20 @@ class TestPidReuseDisambiguation:
         assert reaped == []
 
 
-def _labels(pid, start="SAME", created=NOW, ttl=3600):
+def _labels(pid, start="SAME", created=NOW, ttl=3600, host=None, boot=None):
     """Build the container labels a DockerSandbox would stamp."""
-    return {
+    labels = {
         LABEL_SESSION: "sess",
         LABEL_OWNER_PID: str(pid),
         LABEL_OWNER_START: start,
         LABEL_CREATED: str(created),
         LABEL_TTL: str(ttl),
     }
+    if host is not None:
+        labels[LABEL_HOST] = host
+    if boot is not None:
+        labels[LABEL_BOOT] = boot
+    return labels
 
 
 def _abandoned(labels, *, now=NOW, pid_alive=_dead, start_time_of=None):
@@ -185,6 +192,26 @@ def _abandoned(labels, *, now=NOW, pid_alive=_dead, start_time_of=None):
         pid_key=LABEL_OWNER_PID,
         start_key=LABEL_OWNER_START,
         ttl_key=LABEL_TTL,
+    )
+
+
+def _abandoned_scoped(
+    labels, *, current_host, current_boot, pid_alive=_dead, start_time_of=None
+):
+    """Call _container_is_abandoned with host/boot scoping enabled."""
+    return _container_is_abandoned(
+        labels,
+        now=NOW,
+        pid_alive=pid_alive,
+        start_time_of=start_time_of or (lambda pid: "SAME"),
+        created_key=LABEL_CREATED,
+        pid_key=LABEL_OWNER_PID,
+        start_key=LABEL_OWNER_START,
+        ttl_key=LABEL_TTL,
+        host_key=LABEL_HOST,
+        boot_key=LABEL_BOOT,
+        current_host=current_host,
+        current_boot=current_boot,
     )
 
 
@@ -223,6 +250,82 @@ class TestContainerReaping:
         stale = _labels("not-an-int", created=NOW - 7200, ttl=3600)
         assert _abandoned(fresh) is False
         assert _abandoned(stale) is True
+
+
+class TestHostBootScoping:
+    """The owner-PID test is only applied to *this* host+boot's containers."""
+
+    def test_same_host_and_boot_still_judges_by_pid(self):
+        """Own host+boot: a dead owner is reaped, a live one kept (as before)."""
+        dead = _labels(4242, host="h1", boot="b1")
+        live = _labels(222, start="SAME", host="h1", boot="b1")
+        assert (
+            _abandoned_scoped(dead, current_host="h1", current_boot="b1")
+            is True
+        )
+        assert (
+            _abandoned_scoped(
+                live,
+                current_host="h1",
+                current_boot="b1",
+                pid_alive=_only(222),
+            )
+            is False
+        )
+
+    def test_a_different_hosts_container_is_never_reaped(self):
+        """A shared daemon: another host's container is left to that host.
+
+        Its owner PID is dead *here* (our table), which without scoping would
+        reap it — but it may be a live session on the other host, so we must not.
+        """
+        other = _labels(4242, host="h2", boot="b1")  # dead PID locally
+        assert (
+            _abandoned_scoped(other, current_host="h1", current_boot="b1")
+            is False
+        )
+
+    def test_a_prior_boot_on_this_host_is_reaped(self):
+        """Same host, earlier boot: the owner PID is meaningless (recycled)."""
+        stale = _labels(222, host="h1", boot="b0")
+        # Even if that PID looks alive now, a reboot means the owner is gone.
+        assert (
+            _abandoned_scoped(
+                stale,
+                current_host="h1",
+                current_boot="b1",
+                pid_alive=_only(222),
+                start_time_of=lambda pid: "SAME",
+            )
+            is True
+        )
+
+    def test_unknown_boot_falls_back_to_pid(self):
+        """When boot can't be determined, don't reap on it — judge by PID."""
+        dead = _labels(4242, host="h1", boot=UNKNOWN_BOOT)
+        assert (
+            _abandoned_scoped(
+                dead, current_host="h1", current_boot=UNKNOWN_BOOT
+            )
+            is True  # PID dead, so still reaped — but on PID, not boot
+        )
+
+    def test_container_without_host_label_is_pid_judged(self):
+        """An older container (no host label) keeps the pre-scoping behaviour."""
+        old = _labels(4242)  # no host/boot labels
+        assert (
+            _abandoned_scoped(old, current_host="h1", current_boot="b1") is True
+        )
+
+
+class TestHostBootHelpers:
+    """The host/boot identity used to stamp and scope containers."""
+
+    def test_boot_id_is_a_nonempty_string(self):
+        """boot_id() returns a stable token (or the 'unknown' sentinel)."""
+        token = boot_id()
+        assert isinstance(token, str) and token
+        assert token == boot_id()  # stable within a boot
 
     def test_reap_is_a_noop_without_docker(self, monkeypatch):
         """Without the docker SDK / a daemon, reaping is a silent no-op."""


### PR DESCRIPTION
## Summary

First **task 030** slice — a reaper correctness/safety fix with real teeth. The
container/network reaper listed every `hugin.session` resource on the daemon and
judged each one's `hugin.owner_pid` against the **local** process table. That's
wrong two ways:

- **Shared/remote daemon:** another host's *live* session has a PID that may look
  dead here, so the reaper could **kill a live peer**.
- **Across a reboot:** PIDs recycle, so a pre-reboot container's owner PID can
  match an unrelated live process — leaking it forever.

Containers and networks are now stamped with `hugin.host` + `hugin.boot`, and the
abandonment test is scoped to the process table the PID actually belongs to.

## Changes

- **Different host** (shared daemon) → never judged or reaped here; that host's
  own reaper owns it. (Cross-host reaping of a genuinely dead host stays out of
  scope — documented.)
- **This host, a prior boot** → abandoned outright (owner PID is meaningless
  after a reboot).
- **This host + boot** → the existing PID/start-time judgment, unchanged.
- **Older unlabelled containers** → fall through to the pre-scoping judgment
  (backward compatible).
- `boot_id()` (Linux boot UUID / macOS `kern.boottime` / `UNKNOWN_BOOT` fallback)
  + `current_hostname()` in `local.py`, beside `process_start_time`. When boot id
  is undeterminable, the reaper falls back to PID/TTL rather than risk a false
  reap.

Safe-by-construction in the dangerous direction: it only makes the reaper *more*
conservative about killing a live peer.

## Testing

- Test-first: `TestHostBootScoping` pins all cases (same host+boot judged by PID;
  different host never reaped; prior boot reaped even if the PID looks alive;
  unknown boot → PID fallback; unlabelled container → pre-scoping behaviour), plus
  a `boot_id()` stability check.
- The docker labels contract test asserts `hugin.host`/`hugin.boot` are stamped;
  the daemon-gated container-lifecycle/reaping tests still pass against a real
  daemon.
- Full suite: `uv run pytest` → 1090 passed, 39 skipped, 2 xfailed. Pre-commit
  clean.