### PR TITLE
Bash sandbox: cap single-file size via an fsize rlimit (task 030)

### DIFF
--- a/src/gimle/hugin/sandbox/docker.py
+++ b/src/gimle/hugin/sandbox/docker.py
@@ -62,6 +62,7 @@ from gimle.hugin.sandbox.local import (
 from gimle.hugin.sandbox.policy import Allow, Policy, evaluate
 from gimle.hugin.sandbox.sandbox import (
     DEFAULT_SANDBOX_ROOT,
+    MAX_FILE_BYTES,
     ExecResult,
     PolicyDenied,
     Sandbox,
@@ -669,6 +670,9 @@ class DockerSandbox(Sandbox):
             "ulimits": [
                 ("nofile", 1024, 4096),
                 ("nproc", self._spec.pids, self._spec.pids),
+                # Cap any single file so a runaway `yes > f` can't fill the host
+                # disk through the bind mount (RLIMIT_FSIZE is in bytes).
+                ("fsize", MAX_FILE_BYTES, MAX_FILE_BYTES),
             ],
             # Run as the host user so bind-mounted files stay host-readable and
             # the process is provably non-root inside the container.

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -28,6 +28,7 @@ from gimle.hugin.sandbox.sandbox import (
     PolicyDenied,
     Sandbox,
     SandboxSpec,
+    fsize_ulimit_blocks,
     new_spill_relpath,
     truncate_output,
 )
@@ -242,10 +243,14 @@ class LocalSandbox(Sandbox):
 
         effective_timeout = min(timeout_s, policy.max_timeout_s)
         env = self._scrubbed_env(cwd)
+        # Cap any single file the command writes (a runaway `yes > f` would
+        # otherwise fill the host disk — local has no container to bound it).
+        # `ulimit -f` sets soft+hard, so the command can't raise it back.
+        wrapped = f"ulimit -f {fsize_ulimit_blocks()}; {command}"
 
         started = time.monotonic()
         proc = subprocess.Popen(
-            [self._bash, "-c", command],
+            [self._bash, "-c", wrapped],
             cwd=cwd,
             env=env,
             stdout=subprocess.PIPE,

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -28,6 +28,19 @@ DEFAULT_STORAGE_BASE = "./storage"
 # backend joins it onto its own base and returns the absolute result.
 SPILL_DIR = ".hugin"
 
+# Hard cap on the size of any *single* file a sandbox command may create, enforced
+# as an ``fsize`` rlimit on every backend (docker container ulimit; ``ulimit -f``
+# in the local/ssh bash wrapper). Stops a runaway ``yes > f`` from filling the
+# host disk and taking down the orchestrator. Generous (2 GiB) so a legitimate
+# build artifact isn't broken. This bounds one file, NOT total workspace usage —
+# a size-limited workspace volume is the stronger, deferred control (task 030).
+MAX_FILE_BYTES = 2 * 1024**3
+
+
+def fsize_ulimit_blocks() -> int:
+    """Return :data:`MAX_FILE_BYTES` as ``ulimit -f`` 1024-byte blocks."""
+    return MAX_FILE_BYTES // 1024
+
 
 def new_spill_relpath() -> str:
     """Return a unique, workspace-relative spill filename for one command.

--- a/src/gimle/hugin/sandbox/ssh.py
+++ b/src/gimle/hugin/sandbox/ssh.py
@@ -62,6 +62,7 @@ from gimle.hugin.sandbox.sandbox import (
     Sandbox,
     SandboxSpec,
     classify_timeout_exit,
+    fsize_ulimit_blocks,
     new_spill_relpath,
     truncate_output,
 )
@@ -208,7 +209,12 @@ class SSHSandbox(Sandbox):
         touch = ""
         if self._remote_root:
             touch = f"touch {shlex.quote(self._remote_root)} 2>/dev/null; "
+        # Cap any single file the command writes (rlimits inherit across
+        # ``env -i`` and ``exec``, so this bounds the command even though the env
+        # is scrubbed) — a runaway ``yes > f`` can't fill the remote disk.
+        fsize = f"ulimit -f {fsize_ulimit_blocks()} 2>/dev/null; "
         return (
+            f"{fsize}"
             f"{touch}"
             f"cd {q_cwd} && "
             f"env -i HOME={q_cwd} PATH=/usr/local/bin:/usr/bin:/bin "

--- a/tasks/open/030-bash-sandbox-docker-followups.md
+++ b/tasks/open/030-bash-sandbox-docker-followups.md
@@ -55,11 +55,15 @@ task is picked up first.
   Default to a digest, verify digest/signature on pull (cosign), pin `FROM` by
   digest, replace `curl|sh` with a checksum-verified artifact, and add a
   Trivy/Grype scan + cosign sign step to the image build/publish pipeline.
-- [ ] **Workspace disk quota.** *(security, MEDIUM)* cpu/memory/pids are capped
-  but the bind-mounted `/workspace` is unquota'd host storage; `yes > f` (not on
-  the denylist) fills the host disk and takes down the orchestrator. Mount the
-  workspace on a size-limited volume or enforce a quota / `fsize` ulimit (chosen
-  generously so legit builds aren't broken).
+- [~] **Workspace disk quota.** *(security, MEDIUM)* **Per-file cap done:** an
+  `fsize` rlimit (2 GiB, `MAX_FILE_BYTES`) bounds any *single* file a command
+  writes, on all three backends — docker via the container ulimit, local/ssh via
+  `ulimit -f` in the bash wrapper (rlimits inherit across `env -i`/`exec`). A
+  runaway `yes > f` now hits SIGXFSZ (verified: docker caps at exactly 2 GiB;
+  local end-to-end test with a small cap). **Still open (stronger control):**
+  *total* workspace usage is still unbounded (`for i in …; do yes > f$i; done`) —
+  mount the workspace on a size-limited volume (loopback/xfs project quota) for a
+  real total quota. Deferred as heavier + platform-specific.
 - [ ] **`put_file`/`get_file` TOCTOU / `O_NOFOLLOW`.** *(security, MEDIUM,
   latent — no production caller yet)* `_confine` realpath-checks then does a
   plain `open`; because the container writes the same tree as the host uid, a

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -107,14 +107,14 @@ class TestHardeningContract:
         assert kwargs["pids_limit"] == 256
 
     def test_ulimits_present(self, tmp_path):
-        """nproc/nofile ulimits are set (as plain tuples, SDK-free)."""
+        """nproc/nofile/fsize ulimits are set (as plain tuples, SDK-free)."""
         names = {
             name
             for (name, _s, _h) in _sandbox(tmp_path)._container_kwargs()[
                 "ulimits"
             ]
         }
-        assert names == {"nofile", "nproc"}
+        assert names == {"nofile", "nproc", "fsize"}
 
     def test_init_reaps_children(self, tmp_path):
         """--init gives PID 1 that reaps double-forked children."""
@@ -166,6 +166,13 @@ class TestHardeningContract:
         """memswap_limit == mem_limit so the memory cap can't be doubled via swap."""
         kwargs = _sandbox(tmp_path, memory="1g")._container_kwargs()
         assert kwargs["memswap_limit"] == kwargs["mem_limit"] == "1g"
+
+    def test_single_file_size_is_capped(self, tmp_path):
+        """An fsize ulimit bounds any one file (a runaway `yes > f` can't fill disk)."""
+        from gimle.hugin.sandbox.sandbox import MAX_FILE_BYTES
+
+        ulimits = _sandbox(tmp_path)._container_kwargs()["ulimits"]
+        assert ("fsize", MAX_FILE_BYTES, MAX_FILE_BYTES) in ulimits
 
 
 class TestProxyHardeningContract:

--- a/tests/test_sandbox_local.py
+++ b/tests/test_sandbox_local.py
@@ -202,6 +202,26 @@ class TestOutputTruncation:
         with open(second.spill_path, encoding="utf-8") as handle:
             assert "beta-1000" in handle.read()
 
+    def test_runaway_file_write_is_size_capped(self, sandbox, monkeypatch):
+        """A single file a command writes is bounded by the fsize cap, not the disk.
+
+        `yes > f` would fill the host disk; the fsize rlimit kills it (SIGXFSZ)
+        with the file bounded near the cap — not a timeout, not a success.
+        """
+        import os
+
+        from gimle.hugin.sandbox import sandbox as sandbox_mod
+
+        monkeypatch.setattr(sandbox_mod, "MAX_FILE_BYTES", 1_048_576)  # 1 MiB
+        cwd = _cwd(sandbox)
+        result = sandbox.exec(
+            "yes > big.txt", policy=Policy(), cwd=cwd, timeout_s=10
+        )
+        assert result.exit_code != 0  # killed by the file-size cap
+        assert result.timed_out is False  # the cap stopped it, not the clock
+        size = os.path.getsize(os.path.join(cwd, "big.txt"))
+        assert size <= 1_048_576 + 65_536  # bounded near the cap, not unbounded
+
     def test_runaway_output_is_capped_without_hanging(self, sandbox):
         """Unbounded output is bounded in memory and the process is killed.
 

--- a/tests/test_sandbox_ssh.py
+++ b/tests/test_sandbox_ssh.py
@@ -103,9 +103,12 @@ class TestCommandConstruction:
         assert "-p" not in _sandbox()._ssh_opts()
 
     def test_remote_wrapper_scrubs_env_and_bounds_time(self):
-        """The wrapper cds, scrubs env (env -i), and runs under a remote timeout."""
+        """The wrapper caps file size, cds, scrubs env, and bounds time."""
         wrapper = _sandbox()._remote_wrapper("/home/u/ws", 15)
-        assert wrapper.startswith("cd /home/u/ws && ")
+        # A single file the command writes is size-capped (rlimit inherits
+        # across env -i / exec), so a runaway can't fill the remote disk.
+        assert wrapper.startswith("ulimit -f ")
+        assert "cd /home/u/ws && " in wrapper
         assert "env -i HOME=/home/u/ws" in wrapper
         assert "timeout -k 5 15 bash -c" in wrapper
         # The untrusted command travels over stdin, not the argv.
@@ -117,7 +120,7 @@ class TestCommandConstruction:
     def test_remote_wrapper_touches_root_when_started(self):
         """A started sandbox's wrapper touches the session root (TTL heartbeat)."""
         wrapper = _started(_sandbox())._remote_wrapper("/home/u/ws", 15)
-        assert wrapper.startswith("touch /home/u/.hugin-sandbox/sess-1 ")
+        assert "touch /home/u/.hugin-sandbox/sess-1 " in wrapper
 
     def test_ssh_argv_targets_the_host(self):
         """The argv is ssh <opts> <host> <remote-command>."""


### PR DESCRIPTION
## Summary

Second **task 030** slice. cpu/memory/pids were capped, but a command could write
an **unbounded file** to the bind-mounted workspace — a `yes > f` (not on the
denylist) fills the host disk and takes down the orchestrator. Now any *single*
file is bounded by an `fsize` rlimit (`MAX_FILE_BYTES` = 2 GiB, generous so a
legit build artifact isn't broken) on every backend.

## Changes

- **docker**: an `("fsize", N, N)` container ulimit (bytes) in `_container_kwargs`.
- **local**: `ulimit -f <blocks>` prepended to the `bash -c` wrapper (sets
  soft+hard, so the command can't raise it back).
- **ssh**: `ulimit -f <blocks>` at the top of the remote wrapper — rlimits inherit
  across `env -i` and `exec`, so it bounds the command even with the scrubbed env.
- Shared `MAX_FILE_BYTES` + `fsize_ulimit_blocks()` in `sandbox.py`.

A runaway write hits SIGXFSZ with the file bounded at the cap. **This bounds one
file, not total workspace usage** — a size-limited workspace volume (for the
`for i…; do yes > f$i` case) stays the deferred stronger control.

## Testing

- Test-first. `test_single_file_size_is_capped` / `test_ulimits_present` pin the
  docker ulimit; a **local end-to-end** test (small monkeypatched cap) proves
  `yes > f` is killed by the size cap — not a success, not a timeout, file bounded
  near the cap; the ssh wrapper test asserts the `ulimit -f` prefix.
- **Verified against a real docker daemon**: a container's runaway file was capped
  at exactly 2 GiB and `yes` got SIGXFSZ (153). (Not committed as a test — writing
  2 GiB is too slow.)
- Full suite: `uv run pytest` → 1092 passed, 39 skipped, 2 xfailed. Pre-commit
  clean.