### PR TITLE
Bash sandbox: three robustness hardening fixes (task 030)

### DIFF
--- a/src/gimle/hugin/sandbox/background.py
+++ b/src/gimle/hugin/sandbox/background.py
@@ -68,6 +68,7 @@ def result_content(command: str, result: ExecResult) -> Dict[str, Any]:
         "truncated": result.truncated,
         "timed_out": result.timed_out,
         "oom_killed": result.oom_killed,
+        "output_capped": result.output_capped,
     }
     if result.truncated and result.spill_path:
         content["full_output"] = result.spill_path
@@ -236,7 +237,9 @@ class BackgroundExecutor:
             )
         else:
             content = result_content(job.command, result)
-            is_error = result.timed_out or result.oom_killed
+            is_error = (
+                result.timed_out or result.oom_killed or result.output_capped
+            )
         job.collected = True
         # Evict a collected job so a long session doesn't accumulate one entry
         # per command (every bash call routes through the registry, including

--- a/src/gimle/hugin/sandbox/docker.py
+++ b/src/gimle/hugin/sandbox/docker.py
@@ -69,7 +69,10 @@ from gimle.hugin.sandbox.sandbox import (
     SandboxSpec,
     classify_timeout_exit,
     new_spill_relpath,
+    read_file_nofollow,
+    reject_symlink_swap,
     truncate_output,
+    write_file_nofollow,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - typing only, never imported at runtime
@@ -284,6 +287,8 @@ class DockerSandbox(Sandbox):
         # with the proxy already reachable. If anything from here on fails, tear
         # down the infra we just created — otherwise a per-session network +
         # proxy leak (and the network subnet pool is small).
+        container: Optional["Container"] = None
+        created = False
         try:
             if self._egress_filtered():
                 self._ensure_egress_infra(docker)
@@ -296,16 +301,40 @@ class DockerSandbox(Sandbox):
                 self._remove_container(container)
                 container = None
             if container is None:
+                created = True
                 container = self._create_container(docker)
             elif container.status != "running":
                 container.start()
+            # Publish the handle only once the container is up, so a failure
+            # can't leave a half-brought-up sandbox that stop() can't reach.
+            self._container = container
+            self._started = True
         except Exception:
-            # _remove_proxy_and_network never raises (guarded), so it can't mask
-            # the original failure we re-raise.
-            self._remove_proxy_and_network()
+            self._rollback_failed_start(created, container)
             raise
-        self._container = container
-        self._started = True
+
+    def _rollback_failed_start(
+        self, created: bool, container: Optional["Container"]
+    ) -> None:
+        """Undo a failed ``start`` so it leaves nothing orphaned. Never raises.
+
+        A container this call created (including one a failed ``containers.run``
+        left behind under our name) is removed — a *pre-existing* one is not ours
+        to remove. Then the egress infra. Best-effort throughout so it can't mask
+        the original failure being re-raised.
+        """
+        self._started = False
+        self._container = None
+        if created:
+            leftover = container
+            if leftover is None:
+                try:  # a failed containers.run may have left one under our name
+                    leftover = self._existing_container()
+                except Exception:  # daemon unreachable — nothing more to do
+                    leftover = None
+            if leftover is not None:
+                self._remove_container(leftover)
+        self._remove_proxy_and_network()
 
     def _assert_not_unsafe_root(self) -> None:
         """Fail closed if running as root without daemon userns-remap.
@@ -869,6 +898,7 @@ class DockerSandbox(Sandbox):
             truncated=truncated,
             timed_out=timed_out,
             oom_killed=oom_killed,
+            output_capped=capped,
             spill_path=spill_path,
         )
 
@@ -1015,16 +1045,20 @@ class DockerSandbox(Sandbox):
         """Write ``content`` into the agent's workspace (host-side, confined)."""
         target = self._confine(agent_id, branch, path)
         os.makedirs(os.path.dirname(target), exist_ok=True)
-        with open(target, "wb") as handle:
-            handle.write(content)
+        try:
+            write_file_nofollow(target, content)
+        except OSError as error:
+            reject_symlink_swap(path, error)
 
     def get_file(
         self, agent_id: str, branch: Optional[str], path: str
     ) -> bytes:
         """Read ``path`` from the agent's workspace, refusing a symlink escape."""
         target = self._confine(agent_id, branch, path)
-        with open(target, "rb") as handle:
-            return handle.read()
+        try:
+            return read_file_nofollow(target)
+        except OSError as error:
+            reject_symlink_swap(path, error)
 
     def _confine(self, agent_id: str, branch: Optional[str], path: str) -> str:
         """Resolve ``path`` within the ``(agent, branch)`` host workspace, or raise.

--- a/src/gimle/hugin/sandbox/local.py
+++ b/src/gimle/hugin/sandbox/local.py
@@ -30,7 +30,10 @@ from gimle.hugin.sandbox.sandbox import (
     SandboxSpec,
     fsize_ulimit_blocks,
     new_spill_relpath,
+    read_file_nofollow,
+    reject_symlink_swap,
     truncate_output,
+    write_file_nofollow,
 )
 
 logger = logging.getLogger(__name__)
@@ -289,6 +292,7 @@ class LocalSandbox(Sandbox):
             truncated=truncated,
             timed_out=timed_out,
             oom_killed=False,  # a bare subprocess cannot bound or detect OOM
+            output_capped=capped,
             spill_path=spill_path,
         )
 
@@ -413,16 +417,20 @@ class LocalSandbox(Sandbox):
         """Write ``content`` to ``path`` inside the agent's workspace."""
         target = self._confine(agent_id, branch, path)
         os.makedirs(os.path.dirname(target), exist_ok=True)
-        with open(target, "wb") as handle:
-            handle.write(content)
+        try:
+            write_file_nofollow(target, content)
+        except OSError as error:
+            reject_symlink_swap(path, error)
 
     def get_file(
         self, agent_id: str, branch: Optional[str], path: str
     ) -> bytes:
         """Read ``path`` from the agent's workspace, refusing a symlink escape."""
         target = self._confine(agent_id, branch, path)
-        with open(target, "rb") as handle:
-            return handle.read()
+        try:
+            return read_file_nofollow(target)
+        except OSError as error:
+            reject_symlink_swap(path, error)
 
     def _confine(self, agent_id: str, branch: Optional[str], path: str) -> str:
         """Resolve ``path`` within the ``(agent, branch)`` workspace, or raise.

--- a/src/gimle/hugin/sandbox/sandbox.py
+++ b/src/gimle/hugin/sandbox/sandbox.py
@@ -11,11 +11,12 @@ shared types so the tool and the policy engine can be built and tested against
 a fake backend first.
 """
 
+import errno
 import os
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields
-from typing import Any, Callable, Dict, Optional, Tuple, Type, cast
+from typing import Any, Callable, Dict, NoReturn, Optional, Tuple, Type, cast
 
 from gimle.hugin.sandbox.policy import Policy
 
@@ -40,6 +41,47 @@ MAX_FILE_BYTES = 2 * 1024**3
 def fsize_ulimit_blocks() -> int:
     """Return :data:`MAX_FILE_BYTES` as ``ulimit -f`` 1024-byte blocks."""
     return MAX_FILE_BYTES // 1024
+
+
+def read_file_nofollow(path: str) -> bytes:
+    """Read ``path`` without following a symlink at its final component.
+
+    Closes the TOCTOU between a confinement check (which resolved the real path)
+    and this read: if the final component was swapped to a symlink afterwards,
+    ``O_NOFOLLOW`` fails the open (``ELOOP``) instead of reading through it. The
+    caller has already realpath-confined the path, so intermediate components are
+    covered at check time; only the last hop needs guarding here.
+    """
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    with os.fdopen(fd, "rb") as handle:
+        return handle.read()
+
+
+def write_file_nofollow(path: str, content: bytes) -> None:
+    """Write ``content`` to ``path`` without following a final-component symlink.
+
+    The write counterpart of :func:`read_file_nofollow`: ``O_NOFOLLOW`` refuses
+    to write *through* a symlink swapped in after the confinement check.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o600)
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(content)
+
+
+def reject_symlink_swap(path: str, error: OSError) -> NoReturn:
+    """Raise :class:`PolicyDenied` for an ``O_NOFOLLOW`` ``ELOOP``, else re-raise.
+
+    A symlink swapped into the final path component after the confinement check
+    makes the ``O_NOFOLLOW`` open fail with ``ELOOP`` — surface that as a
+    workspace escape (a denial), not a raw ``OSError``. Any other error (missing
+    file, permission) propagates unchanged.
+    """
+    if error.errno == errno.ELOOP:
+        raise PolicyDenied(
+            f"path escapes the workspace via a symlink: {path}"
+        ) from error
+    raise error
 
 
 def new_spill_relpath() -> str:
@@ -189,6 +231,11 @@ class ExecResult:
     truncated: bool = False
     timed_out: bool = False
     oom_killed: bool = False
+    # The output byte-ceiling was hit and the command was cut off mid-stream
+    # (not the ordinary tail-truncation of a finished command). It is a failure
+    # the model must react to — a runaway that read as "success" otherwise — so
+    # the tool maps it to ``is_error``.
+    output_capped: bool = False
     # When ``truncated``, the absolute path (in the command's own namespace —
     # host / container / remote) of the file the full output was spilled to, so
     # a follow-up can read past the cap. Unique per command (so a later

--- a/src/gimle/hugin/sandbox/ssh.py
+++ b/src/gimle/hugin/sandbox/ssh.py
@@ -493,6 +493,7 @@ class SSHSandbox(Sandbox):
             truncated=truncated,
             timed_out=timed_out,
             oom_killed=oom_killed,
+            output_capped=capped,
             spill_path=spill_path,
         )
 

--- a/src/gimle/hugin/tools/builtins/bash.py
+++ b/src/gimle/hugin/tools/builtins/bash.py
@@ -555,7 +555,7 @@ def _to_response(command: str, result: ExecResult) -> ToolResponse:
     finish — an error the model must react to, unlike a plain non-zero exit.
     """
     return ToolResponse(
-        is_error=result.timed_out or result.oom_killed,
+        is_error=result.timed_out or result.oom_killed or result.output_capped,
         content=result_content(command, result),
     )
 

--- a/tasks/open/030-bash-sandbox-docker-followups.md
+++ b/tasks/open/030-bash-sandbox-docker-followups.md
@@ -64,12 +64,15 @@ task is picked up first.
   *total* workspace usage is still unbounded (`for i in …; do yes > f$i; done`) —
   mount the workspace on a size-limited volume (loopback/xfs project quota) for a
   real total quota. Deferred as heavier + platform-specific.
-- [ ] **`put_file`/`get_file` TOCTOU / `O_NOFOLLOW`.** *(security, MEDIUM,
-  latent — no production caller yet)* `_confine` realpath-checks then does a
-  plain `open`; because the container writes the same tree as the host uid, a
-  symlink swap between check and open escapes. Open with `O_NOFOLLOW` /
-  `openat2(RESOLVE_NO_SYMLINKS)` walking from a dirfd. Overlaps task 024's
-  `put_file`/`get_file` item.
+- [~] **`put_file`/`get_file` TOCTOU / `O_NOFOLLOW`.** *(security, MEDIUM)*
+  **Final-component done:** local/docker put/get now open through
+  `read_file_nofollow`/`write_file_nofollow` (`O_NOFOLLOW`), so a symlink swapped
+  into the *last* path component after the realpath check is refused (`ELOOP` →
+  `PolicyDenied` via `reject_symlink_swap`) instead of read/written through.
+  **Still open:** an *intermediate*-directory swap between check and open — the
+  full guard is `openat2(RESOLVE_NO_SYMLINKS)` (Linux-only) walking from a dirfd;
+  deferred as platform-specific. (ssh confines lexically — remote symlink escape
+  is out of scope on a disposable box, documented.)
 
 ## Architecture / ops
 
@@ -84,17 +87,20 @@ task is picked up first.
   bespoke free function; give the backend registry a reap seam so the CLI
   iterates backends (SSH will add a third). Cross-host reaping of a genuinely
   dead host's containers stays out of scope (documented). Overlaps task 024.
-- [ ] **Capped / backgrounded exec: explicit state + kill.** *(SRE/architect/
-  usability, MEDIUM)* On the output cap or a host-side abandonment the exec'd
-  process keeps running in-container until its `timeout` fires, and the next
-  command runs as a second concurrent exec competing for pids/cpu. `exit_code`
-  is `-1` and `is_error` is `False`, so a capped runaway reads as success. Add an
-  explicit `output_capped`/`abandoned` field to `ExecResult` (treat as
-  `is_error`) and proactively terminate the lingering exec before returning.
-- [ ] **`start()` atomicity.** *(architect/SRE, MEDIUM)* Assign `self._container`
-  immediately after `containers.run` and wrap the post-create steps so a failure
-  after create stops the container instead of orphaning a live one the manager
-  never learned about.
+- [~] **Capped / backgrounded exec: explicit state + kill.** *(SRE/architect/
+  usability, MEDIUM)* **Explicit state done:** `ExecResult.output_capped` is set
+  by every backend when the byte-ceiling cuts a command off mid-stream, and the
+  tool maps it to `is_error` (+ an `output_capped` field in the result) — a
+  capped runaway no longer reads as success. **Still open:** proactively *kill*
+  the lingering docker exec on cap (local already terminates the process group;
+  docker relies on the in-container `timeout` to bound it, so it's not
+  immediately reaped).
+- [x] **`start()` atomicity.** *(architect/SRE, MEDIUM)* **Done:** `start()`
+  publishes `self._container` only once the container is up, and a failure rolls
+  back via `_rollback_failed_start` — a container *this call* created (including
+  one a failed `containers.run` left under our name) is removed; a *pre-existing*
+  one is left as-is; then the egress infra. Best-effort so it can't mask the
+  original error.
 - [ ] **Observability.** *(SRE, MEDIUM)* Differentiate `sandbox_start_failures`
   by exception class (daemon-down vs image-missing vs create-rejected); add
   `sandbox_containers_reaped`, start/pull duration, and a live labelled-container

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -130,6 +130,22 @@ class TestResultMapping:
         assert response.is_error is True
         assert response.content["oom_killed"] is True
 
+    def test_capped_output_is_an_error_not_a_silent_success(self):
+        """A command cut off at the byte ceiling is an error, not a success."""
+        fake = FakeSandbox(
+            ExecResult(
+                exit_code=-1,
+                stdout="floods",
+                stderr="[hugin: output exceeded ...]",
+                duration_s=0.3,
+                truncated=True,
+                output_capped=True,
+            )
+        )
+        response = bash("yes", stack=_stack_with_fake(fake))
+        assert response.is_error is True
+        assert response.content["output_capped"] is True
+
     def test_truncated_output_carries_the_spill_path(self):
         """A truncated result reports the exact spill path the backend wrote."""
         fake = FakeSandbox(

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -300,6 +300,55 @@ class TestTeardownSafety:
         sandbox._remove_proxy_and_network()  # must not raise
 
 
+class TestStartAtomicity:
+    """A failed start() rolls back what it created — nothing is orphaned."""
+
+    def test_rollback_removes_a_container_we_created(
+        self, tmp_path, monkeypatch
+    ):
+        """A container created this call is removed, and the state is reset."""
+        sandbox = _sandbox(tmp_path)
+        removed: list = []
+        monkeypatch.setattr(
+            sandbox, "_remove_container", lambda c: removed.append(c)
+        )
+        monkeypatch.setattr(sandbox, "_remove_proxy_and_network", lambda: None)
+        handle = object()
+        sandbox._rollback_failed_start(created=True, container=handle)
+        assert removed == [handle]
+        assert sandbox._container is None
+        assert sandbox._started is False
+
+    def test_rollback_finds_a_partial_container_by_name(
+        self, tmp_path, monkeypatch
+    ):
+        """A failed containers.run leaves no handle — the leftover is found by name."""
+        sandbox = _sandbox(tmp_path)
+        removed: list = []
+        partial = object()
+        monkeypatch.setattr(sandbox, "_existing_container", lambda: partial)
+        monkeypatch.setattr(
+            sandbox, "_remove_container", lambda c: removed.append(c)
+        )
+        monkeypatch.setattr(sandbox, "_remove_proxy_and_network", lambda: None)
+        sandbox._rollback_failed_start(created=True, container=None)
+        assert removed == [partial]
+
+    def test_rollback_leaves_a_preexisting_container(
+        self, tmp_path, monkeypatch
+    ):
+        """A pre-existing container (not created this call) is never removed."""
+        sandbox = _sandbox(tmp_path)
+        removed: list = []
+        monkeypatch.setattr(
+            sandbox, "_remove_container", lambda c: removed.append(c)
+        )
+        monkeypatch.setattr(sandbox, "_remove_proxy_and_network", lambda: None)
+        sandbox._rollback_failed_start(created=False, container=object())
+        assert removed == []
+        assert sandbox._container is None and sandbox._started is False
+
+
 class TestExitClassification:
     """124/137/hung map to the right (timed_out, oom_killed) signals."""
 

--- a/tests/test_sandbox_fileio.py
+++ b/tests/test_sandbox_fileio.py
@@ -1,0 +1,66 @@
+"""The O_NOFOLLOW confined file IO helpers that guard the put/get TOCTOU.
+
+``put_file``/``get_file`` realpath-confine a path, then open it — a symlink
+swapped into the final component between check and open would escape. These pin
+that ``O_NOFOLLOW`` refuses to follow such a swap and that the failure surfaces
+as a workspace-escape denial, not a raw OSError.
+"""
+
+import errno
+import os
+
+import pytest
+
+from gimle.hugin.sandbox.sandbox import (
+    PolicyDenied,
+    read_file_nofollow,
+    reject_symlink_swap,
+    write_file_nofollow,
+)
+
+
+class TestNoFollowIO:
+    """Reading/writing refuses to follow a final-component symlink."""
+
+    def test_roundtrip_on_a_regular_file(self, tmp_path):
+        """A regular file reads back exactly what was written."""
+        path = str(tmp_path / "f.bin")
+        write_file_nofollow(path, b"hello-bytes")
+        assert read_file_nofollow(path) == b"hello-bytes"
+
+    def test_read_refuses_a_symlink(self, tmp_path):
+        """Reading through a symlink fails with ELOOP, not the target's bytes."""
+        outside = tmp_path / "secret.txt"
+        outside.write_text("classified")
+        link = str(tmp_path / "link")
+        os.symlink(str(outside), link)
+        with pytest.raises(OSError) as excinfo:
+            read_file_nofollow(link)
+        assert excinfo.value.errno == errno.ELOOP
+
+    def test_write_refuses_a_symlink_and_leaves_the_target(self, tmp_path):
+        """Writing through a symlink fails and does not touch the target."""
+        outside = tmp_path / "target.txt"
+        outside.write_text("original")
+        link = str(tmp_path / "link")
+        os.symlink(str(outside), link)
+        with pytest.raises(OSError) as excinfo:
+            write_file_nofollow(link, b"evil")
+        assert excinfo.value.errno == errno.ELOOP
+        assert outside.read_text() == "original"  # never written through
+
+
+class TestRejectSymlinkSwap:
+    """ELOOP becomes a denial; every other error propagates unchanged."""
+
+    def test_eloop_becomes_policy_denied(self):
+        """A symlink swap (ELOOP) is surfaced as a workspace escape."""
+        error = OSError(errno.ELOOP, "too many symbolic links")
+        with pytest.raises(PolicyDenied, match="symlink"):
+            reject_symlink_swap("notes.txt", error)
+
+    def test_other_errors_propagate(self):
+        """A missing file (ENOENT) is not masked as a denial."""
+        error = FileNotFoundError(errno.ENOENT, "no such file")
+        with pytest.raises(FileNotFoundError):
+            reject_symlink_swap("notes.txt", error)

--- a/tests/test_sandbox_local.py
+++ b/tests/test_sandbox_local.py
@@ -241,6 +241,7 @@ class TestOutputTruncation:
         )
         elapsed = time.monotonic() - start
         assert result.truncated
+        assert result.output_capped is True  # cut off mid-stream, not a success
         assert not result.timed_out  # killed for output, not for wall-clock
         assert elapsed < 8
         assert len(result.stdout.encode()) <= 600  # cap + marker slack
@@ -285,6 +286,24 @@ class TestFileAccess:
         sandbox.workspace_for("intruder", None)
         with pytest.raises(PolicyDenied):
             sandbox.get_file("intruder", None, "../owner/secret.txt")
+
+    def test_get_file_refuses_a_symlink_swapped_after_the_check(
+        self, sandbox, tmp_path, monkeypatch
+    ):
+        """O_NOFOLLOW closes the TOCTOU a plain realpath-then-open would leave.
+
+        A symlink appearing at the final component *after* the confinement check
+        (simulated by returning it straight from ``_confine``) is refused at the
+        open, not read through.
+        """
+        secret = tmp_path / "outside.txt"
+        secret.write_text("classified")
+        root = sandbox.workspace_for("a", None)
+        swapped = os.path.join(root, "swapped")
+        os.symlink(str(secret), swapped)
+        monkeypatch.setattr(sandbox, "_confine", lambda *a, **k: swapped)
+        with pytest.raises(PolicyDenied):
+            sandbox.get_file("a", None, "swapped")
 
 
 def test_stop_is_idempotent(tmp_path):


### PR DESCRIPTION
## Summary

The **small-wins cluster** from task 030 — three tight, well-scoped backend
robustness fixes.

## Changes

**1. `put_file`/`get_file` O_NOFOLLOW (TOCTOU).** `_confine` realpath-checks a
path, then opens it — a symlink swapped into the **final component** in between
would escape. local/docker now open through `read_file_nofollow` /
`write_file_nofollow` (`O_NOFOLLOW`); an `ELOOP` is surfaced as a workspace
escape (`PolicyDenied` via `reject_symlink_swap`), not read/written through. (An
*intermediate*-directory swap still needs `openat2(RESOLVE_NO_SYMLINKS)`,
Linux-only — deferred. ssh confines lexically, remote symlink escape out of
scope.)

**2. `start()` atomicity.** `start()` publishes `self._container` only once the
container is up, and a failure rolls back via `_rollback_failed_start`: a
container *this call* created (including one a failed `containers.run` left under
our name) is removed; a *pre-existing* one is left as-is; then the egress infra.
Nothing is orphaned, and the rollback can't mask the original error.

**3. Capped-exec explicit state.** A command cut off at the output byte-ceiling
had `is_error` False, so a runaway read as **success**. `ExecResult.output_capped`
is now set by every backend and mapped to `is_error` (+ an `output_capped` result
field). (Proactively killing the lingering *docker* exec is a follow-up; the
in-container `timeout` already bounds it — local already terminates the group.)

## Testing

- Test-first throughout. New: O_NOFOLLOW read/write-refuse-symlink + ELOOP→denial
  helpers, a backend "symlink swapped after the check" test; `start()` rollback
  (created vs pre-existing vs found-by-name); capped→`is_error` at both the
  backend (`output_capped` on a real `yes`) and tool layers.
- Full suite: `uv run pytest` → 1102 passed, 39 skipped, 2 xfailed. Pre-commit
  clean; daemon-gated docker suite still green.