### PR TITLE
Warn on unknown template references

### DIFF
--- a/src/gimle/hugin/agent/environment.py
+++ b/src/gimle/hugin/agent/environment.py
@@ -3,7 +3,9 @@
 import importlib.util
 import logging
 import os
+import re
 import sys
+from difflib import get_close_matches
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Set
 
@@ -20,6 +22,8 @@ if TYPE_CHECKING:
     from gimle.hugin.storage.storage import Storage
 
 logger = logging.getLogger(__name__)
+
+_BARE_TEMPLATE_REFERENCE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
 
 
 def _env_truthy(name: str) -> bool:
@@ -273,7 +277,72 @@ class Environment:
         # Load builtin agents
         Environment._load_builtin_agents()
 
+        # Configs and tasks are loaded before templates, so validate references
+        # only after the complete environment has been registered.
+        env._warn_on_unknown_template_references()
+
         return env
+
+    def _warn_on_unknown_template_references(self) -> None:
+        """Warn about identifier-like prompt values with no matching template.
+
+        Bare registered template names are supported by ``PromptRenderer``.
+        This catches the likely typo case without treating inline prose,
+        multiline prompts, or explicit Jinja expressions as references.
+        """
+        template_names = sorted(self.template_registry.registered())
+        sources = (
+            (
+                "Config",
+                self.config_registry.registered(),
+                ("system_template",),
+            ),
+            (
+                "Task",
+                self.task_registry.registered(),
+                ("system_template", "prompt"),
+            ),
+        )
+
+        for source_type, instances, field_names in sources:
+            for instance_name, instance in instances.items():
+                for field_name in field_names:
+                    reference = getattr(instance, field_name)
+                    if not isinstance(reference, str):
+                        continue
+                    if not _BARE_TEMPLATE_REFERENCE.fullmatch(reference):
+                        continue
+                    if reference in template_names:
+                        continue
+
+                    matches = get_close_matches(
+                        reference,
+                        template_names,
+                        n=1,
+                        cutoff=0.6,
+                    )
+                    if matches:
+                        suggestion = matches[0]
+                        hint = (
+                            f" Did you mean '{suggestion}'? The explicit form "
+                            f"is '{{{{ {suggestion}.template }}}}'."
+                        )
+                    else:
+                        hint = (
+                            " If this is intended as a template, register it; "
+                            "explicit references use "
+                            "'{{ template_name.template }}'."
+                        )
+
+                    logger.warning(
+                        "%s '%s' field '%s' looks like a bare template "
+                        "reference, but '%s' is not a registered template.%s",
+                        source_type,
+                        instance_name,
+                        field_name,
+                        reference,
+                        hint,
+                    )
 
     @classmethod
     def _load_builtin_agents(cls) -> None:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,9 +1,15 @@
 """Tests for Environment functionality."""
 
+import logging
+from pathlib import Path
+
 import pytest
 import yaml
 
+from gimle.hugin.agent.config import Config
 from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.task import Task
+from gimle.hugin.llm.prompt.template import Template
 from gimle.hugin.tools.tool import Tool
 
 
@@ -175,6 +181,148 @@ class TestEnvironment:
         template = env.template_registry.get("test_template")
         assert template.name == "test_template"
         assert template.template == "Hello {{ name }}"
+
+    def test_environment_warns_on_unknown_bare_template_references(
+        self, tmp_path, caplog
+    ):
+        """Likely template-name typos identify their owner and suggestion."""
+        configs_dir = tmp_path / "configs"
+        tasks_dir = tmp_path / "tasks"
+        templates_dir = tmp_path / "templates"
+        configs_dir.mkdir()
+        tasks_dir.mkdir()
+        templates_dir.mkdir()
+
+        with open(configs_dir / "researcher.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "name": "researcher",
+                    "description": "Research agent",
+                    "system_template": "basci_system",
+                },
+                f,
+            )
+        with open(tasks_dir / "research.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "name": "research",
+                    "description": "Research task",
+                    "prompt": "research_promt",
+                    "system_template": "researh_system",
+                },
+                f,
+            )
+        for name in ("basic_system", "research_prompt", "research_system"):
+            with open(templates_dir / f"{name}.yaml", "w") as f:
+                yaml.dump({"name": name, "template": "Template body"}, f)
+
+        with caplog.at_level(
+            logging.WARNING, logger="gimle.hugin.agent.environment"
+        ):
+            Environment.load(str(tmp_path))
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert len(messages) == 3
+        assert any(
+            "Config 'researcher' field 'system_template'" in message
+            and "'basci_system' is not a registered template" in message
+            and "Did you mean 'basic_system'?" in message
+            and "{{ basic_system.template }}" in message
+            for message in messages
+        )
+        assert any(
+            "Task 'research' field 'prompt'" in message
+            and "Did you mean 'research_prompt'?" in message
+            for message in messages
+        )
+        assert any(
+            "Task 'research' field 'system_template'" in message
+            and "Did you mean 'research_system'?" in message
+            for message in messages
+        )
+
+    def test_environment_template_warning_ignores_valid_and_inline_values(
+        self, tmp_path, caplog
+    ):
+        """Registered names, explicit Jinja, and inline prose stay quiet."""
+        configs_dir = tmp_path / "configs"
+        tasks_dir = tmp_path / "tasks"
+        templates_dir = tmp_path / "templates"
+        configs_dir.mkdir()
+        tasks_dir.mkdir()
+        templates_dir.mkdir()
+
+        with open(configs_dir / "researcher.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "name": "researcher",
+                    "description": "Research agent",
+                    "system_template": "basic_system",
+                },
+                f,
+            )
+        with open(tasks_dir / "research.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "name": "research",
+                    "description": "Research task",
+                    "prompt": "Summarize this.",
+                    "system_template": "{{ basic_system.template }}",
+                },
+                f,
+            )
+        with open(templates_dir / "basic_system.yaml", "w") as f:
+            yaml.dump({"name": "basic_system", "template": "Template body"}, f)
+
+        with caplog.at_level(
+            logging.WARNING, logger="gimle.hugin.agent.environment"
+        ):
+            Environment.load(str(tmp_path))
+
+        assert not caplog.records
+
+    def test_bundled_apps_and_examples_have_no_unknown_template_warnings(
+        self, caplog
+    ):
+        """The template-reference heuristic stays quiet for shipped YAML."""
+        repository_root = Path(__file__).resolve().parents[1]
+        source_roots = (
+            repository_root / "apps",
+            repository_root / "examples",
+            repository_root / "src" / "gimle" / "hugin" / "apps",
+        )
+        package_paths = set()
+        for source_root in source_roots:
+            for folder_name in ("configs", "tasks", "templates"):
+                package_paths.update(
+                    folder.parent
+                    for folder in source_root.rglob(folder_name)
+                    if folder.is_dir()
+                )
+
+        with caplog.at_level(
+            logging.WARNING, logger="gimle.hugin.agent.environment"
+        ):
+            for package_path in sorted(package_paths):
+                env = Environment()
+                for yaml_path in (package_path / "configs").glob("*.yaml"):
+                    with open(yaml_path, "r") as f:
+                        env.config_registry.register(
+                            Config.from_dict(yaml.safe_load(f))
+                        )
+                for yaml_path in (package_path / "tasks").glob("*.yaml"):
+                    with open(yaml_path, "r") as f:
+                        env.task_registry.register(
+                            Task.from_dict(yaml.safe_load(f))
+                        )
+                for yaml_path in (package_path / "templates").glob("*.yaml"):
+                    with open(yaml_path, "r") as f:
+                        env.template_registry.register(
+                            Template.from_dict(yaml.safe_load(f))
+                        )
+                env._warn_on_unknown_template_references()
+
+        assert not caplog.records
 
     def test_environment_load_all_types(self, tmp_path):
         """Test loading configs, tasks, and templates together."""


### PR DESCRIPTION
## Summary

- warn after `Environment.load()` when config or task fields look like bare template references but match no registered template
- suggest the closest registered template and show the explicit Jinja reference form
- keep inline prose, multiline prompts, explicit Jinja, and valid registered names warning-free
- cover all bundled app and example YAML against false positives

## Why

A misspelled bare reference such as `system_template: basci_system` currently does not match a registered template, so the renderer silently sends the typo itself to the model. Validation must happen after the complete environment is loaded because configs and tasks may be registered before their templates.

## Impact

This adds a conservative load-time warning without changing rendering or rejecting existing configurations.

## Testing

- `pytest -q tests/test_environment.py` — 35 passed
- full test suite — 1,075 passed, 53 skipped
- isort, Black, Flake8, mypy, and `git diff --check`
