### PR TITLE
Agent builder: make file writes safe and confined (task 034, PR 1.1)

### DIFF
--- a/src/gimle/hugin/apps/agent_builder/tools/agent_paths.py
+++ b/src/gimle/hugin/apps/agent_builder/tools/agent_paths.py
@@ -18,9 +18,20 @@ import re
 from pathlib import Path
 from typing import Dict, List, Optional
 
-# A generated key is always "<dir>/<stem>.<ext>" with snake_case components.
-# Anchored, so a traversal or an absolute path cannot match in the first place.
-GENERATED_KEY = re.compile(r"^[a-z][a-z0-9_]*/[a-z][a-z0-9_]*\.(?:yaml|py)$")
+# A generated key is "<dir>/<file>.<yaml|py>", one level deep, relative.
+#
+# Deliberately permissive about *style* and strict about *shape*. An earlier
+# version required snake_case throughout, which conflated two unrelated jobs:
+# confinement (a security property -- reject traversal, absolute paths and
+# anything that leaves the output directory) and naming taste. Because a
+# rejected key aborts the whole write, an LLM naming one tool `getWeather`
+# discarded an otherwise complete agent, and `hugin validate` rejected
+# hand-written agents containing a perfectly loadable `tools/my-tool.py`.
+# Every character allowed here is still safe: no separator, no traversal, no
+# absolute path.
+GENERATED_KEY = re.compile(
+    r"^[A-Za-z0-9_]+/[A-Za-z0-9_][A-Za-z0-9_.\-]*\.(?:yaml|py)$"
+)
 
 # Written by the builder itself rather than generated, so exempt from the
 # snake_case key rule (dunder names would never match it).
@@ -55,16 +66,26 @@ def validate_generated_key(key: str) -> Optional[str]:
     if not GENERATED_KEY.match(key):
         return (
             f"file key {key!r} must be '<dir>/<name>.yaml' or "
-            "'<dir>/<name>.py' in snake_case"
+            "'<dir>/<name>.py', one directory deep"
         )
     return None
+
+
+def is_exempt(key: str) -> bool:
+    """Return True for files the builder writes rather than generates.
+
+    Single source for the exemption, which was previously spelled out twice --
+    in opposite orders -- in :func:`validate_generated_keys` and
+    :func:`confine`, so the two could disagree about the same key.
+    """
+    return key in FRAMEWORK_FILES
 
 
 def validate_generated_keys(keys: List[str]) -> List[str]:
     """Return every error across ``keys``, empty when all are usable."""
     errors = []
     for key in keys:
-        if key in FRAMEWORK_FILES:
+        if is_exempt(key):
             continue
         error = validate_generated_key(key)
         if error:
@@ -79,9 +100,10 @@ def confine(root: Path, key: str) -> Path:
     dereferenced paths; a symlink planted inside the tree that points outside it
     therefore resolves to an outside path and is rejected.
     """
-    error = validate_generated_key(key)
-    if error and key not in FRAMEWORK_FILES:
-        raise PathConfinementError(error)
+    if not is_exempt(key):
+        error = validate_generated_key(key)
+        if error:
+            raise PathConfinementError(error)
 
     real_root = Path(os.path.realpath(root))
     resolved = Path(os.path.realpath(real_root / key))
@@ -104,7 +126,14 @@ def check_output_path(output_path: str) -> Optional[str]:
     if not output_path or not output_path.strip():
         return "no output path specified"
 
-    resolved = Path(os.path.realpath(output_path))
+    # expanduser() first, and everywhere. Without it realpath("~") yields
+    # "<cwd>/~" rather than $HOME, so the home-directory and .git guards below
+    # silently passed every ~-prefixed path -- while the symlink probe further
+    # down *did* expand it, leaving the two halves of this function checking
+    # different directories. "~/agents/demo" is exactly what a model passes
+    # when the user says "put it in ~/agents/demo".
+    expanded = Path(output_path).expanduser()
+    resolved = Path(os.path.realpath(expanded))
 
     if resolved == Path(resolved.anchor):
         return f"refusing to write an agent to the filesystem root: {resolved}"
@@ -121,8 +150,7 @@ def check_output_path(output_path: str) -> Optional[str]:
 
     # A symlinked component means the final location is not the one the user
     # named, which defeats every other check here.
-    probe = Path(output_path).expanduser()
-    for parent in [probe, *probe.parents]:
+    for parent in [expanded, *expanded.parents]:
         if parent.is_symlink():
             return (
                 f"refusing to write through a symlinked path component: "

--- a/src/gimle/hugin/apps/agent_builder/tools/agent_paths.py
+++ b/src/gimle/hugin/apps/agent_builder/tools/agent_paths.py
@@ -1,0 +1,197 @@
+"""Path confinement and name validation for generated agent files.
+
+The builder assembles a ``{relative_path: content}`` dict whose keys come from
+LLM-chosen names, then writes it to a user-supplied directory. Both halves are
+untrusted input to a filesystem write, so both are checked here rather than at
+each call site.
+
+``pathlib`` does not normalise ``..`` and an absolute operand *replaces* the
+left-hand side entirely -- ``Path("/a/b") / "/etc/passwd"`` is ``/etc/passwd`` --
+so a naive ``output_dir / key`` join writes anywhere the process can reach. The
+confinement below mirrors ``sandbox.local.LocalSandbox._confine``: realpath
+first so a planted symlink resolves to its target, then verify the result is
+still under the root.
+"""
+
+import os
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# A generated key is always "<dir>/<stem>.<ext>" with snake_case components.
+# Anchored, so a traversal or an absolute path cannot match in the first place.
+GENERATED_KEY = re.compile(
+    r"^[a-z][a-z0-9_]*/[a-z][a-z0-9_]*\.(?:yaml|py)$"
+)
+
+# Written by the builder itself rather than generated, so exempt from the
+# snake_case key rule (dunder names would never match it).
+FRAMEWORK_FILES = ("__init__.py", "tools/__init__.py", "README.md")
+
+
+class PathConfinementError(Exception):
+    """A generated path escapes, or would escape, its output directory."""
+
+
+def validate_generated_key(key: str) -> Optional[str]:
+    """Return an error message for an unusable generated-file key, else None.
+
+    Rejects absolute keys, traversal, and anything outside the snake_case
+    ``<dir>/<name>.<yaml|py>`` shape the generators are supposed to emit.
+    """
+    if not key or key != key.strip():
+        return f"empty or padded file key: {key!r}"
+    if os.path.isabs(key) or key.startswith("~"):
+        return (
+            f"absolute file key {key!r}: an absolute path replaces the "
+            "output directory instead of nesting under it"
+        )
+    if "\\" in key:
+        return f"backslash in file key {key!r}: use forward slashes"
+    normalised = os.path.normpath(key)
+    if normalised.startswith("..") or normalised != key:
+        return (
+            f"file key {key!r} does not normalise to itself "
+            f"(got {normalised!r}): traversal is not allowed"
+        )
+    if not GENERATED_KEY.match(key):
+        return (
+            f"file key {key!r} must be '<dir>/<name>.yaml' or "
+            "'<dir>/<name>.py' in snake_case"
+        )
+    return None
+
+
+def validate_generated_keys(keys: List[str]) -> List[str]:
+    """Return every error across ``keys``, empty when all are usable."""
+    errors = []
+    for key in keys:
+        if key in FRAMEWORK_FILES:
+            continue
+        error = validate_generated_key(key)
+        if error:
+            errors.append(error)
+    return errors
+
+
+def confine(root: Path, key: str) -> Path:
+    """Resolve ``key`` under ``root``, or raise :class:`PathConfinementError`.
+
+    ``root`` is realpath'd first so the comparison is between two fully
+    dereferenced paths; a symlink planted inside the tree that points outside it
+    therefore resolves to an outside path and is rejected.
+    """
+    error = validate_generated_key(key)
+    if error and key not in FRAMEWORK_FILES:
+        raise PathConfinementError(error)
+
+    real_root = Path(os.path.realpath(root))
+    resolved = Path(os.path.realpath(real_root / key))
+    if resolved != real_root and not str(resolved).startswith(
+        str(real_root) + os.sep
+    ):
+        raise PathConfinementError(
+            f"generated file {key!r} escapes the output directory"
+        )
+    return resolved
+
+
+def check_output_path(output_path: str) -> Optional[str]:
+    """Return an error message for an unsafe output directory, else None.
+
+    ``output_path`` reaches the tool as a plain task parameter, so it may name
+    any directory on the machine. Refuse the handful that are never a legitimate
+    target for a generated agent and are catastrophic to write into.
+    """
+    if not output_path or not output_path.strip():
+        return "no output path specified"
+
+    resolved = Path(os.path.realpath(output_path))
+
+    if resolved == Path(resolved.anchor):
+        return f"refusing to write an agent to the filesystem root: {resolved}"
+
+    home = Path(os.path.realpath(Path.home()))
+    if resolved == home:
+        return f"refusing to write an agent directly to the home dir: {home}"
+
+    if (resolved / ".git").exists():
+        return (
+            f"refusing to write an agent into a repository root: {resolved} "
+            "contains .git -- point at a subdirectory instead"
+        )
+
+    # A symlinked component means the final location is not the one the user
+    # named, which defeats every other check here.
+    probe = Path(output_path).expanduser()
+    for parent in [probe, *probe.parents]:
+        if parent.is_symlink():
+            return (
+                f"refusing to write through a symlinked path component: "
+                f"{parent}"
+            )
+    return None
+
+
+def materialise(
+    generated_files: Dict[str, str],
+    agent_name: str,
+    description: str,
+    output_path: str,
+    task_name: Optional[str] = None,
+) -> Dict[str, str]:
+    """Return the complete file set for an agent, framework files included.
+
+    Shared by the writer and (from PR 1.3) the validator so the tree that gets
+    checked is byte-for-byte the tree that gets written -- they cannot drift
+    into disagreeing about what an agent directory contains.
+    """
+    files = dict(generated_files)
+    files["__init__.py"] = f'"""Generated Hugin agent: {agent_name}."""\n'
+    files["tools/__init__.py"] = '"""Agent tools."""\n'
+    files["README.md"] = _readme(
+        agent_name, description, output_path, task_name
+    )
+    return files
+
+
+def run_command(output_path: str, task_name: Optional[str]) -> str:
+    """Return the one true command for running a generated agent.
+
+    Single source for a string that was previously spelled four different ways
+    across the writer, the CLI success screen and two docs pages -- one of which
+    named a ``run-agent`` entrypoint that does not exist.
+    """
+    if task_name:
+        return (
+            f"uv run hugin run --task {task_name} --task-path {output_path}"
+        )
+    return f"uv run hugin run --task-path {output_path}"
+
+
+def _readme(
+    agent_name: str,
+    description: str,
+    output_path: str,
+    task_name: Optional[str],
+) -> str:
+    """Build the generated agent's README."""
+    return f"""# {agent_name}
+
+{description}
+
+## Running the Agent
+
+```bash
+{run_command(output_path, task_name)}
+```
+
+## Structure
+
+- `configs/` - Agent configuration
+- `tasks/` - Task definitions
+- `templates/` - System prompts
+- `tools/` - Custom tools
+
+Generated by Hugin Agent Builder.
+"""

--- a/src/gimle/hugin/apps/agent_builder/tools/agent_paths.py
+++ b/src/gimle/hugin/apps/agent_builder/tools/agent_paths.py
@@ -15,6 +15,7 @@ still under the root.
 
 import os
 import re
+import shlex
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -188,9 +189,11 @@ def run_command(output_path: str, task_name: Optional[str]) -> str:
     across the writer, the CLI success screen and two docs pages -- one of which
     named a ``run-agent`` entrypoint that does not exist.
     """
+    command = ["uv", "run", "hugin", "run"]
     if task_name:
-        return f"uv run hugin run --task {task_name} --task-path {output_path}"
-    return f"uv run hugin run --task-path {output_path}"
+        command.extend(["--task", task_name])
+    command.extend(["--task-path", output_path])
+    return shlex.join(command)
 
 
 def _readme(

--- a/src/gimle/hugin/apps/agent_builder/tools/agent_paths.py
+++ b/src/gimle/hugin/apps/agent_builder/tools/agent_paths.py
@@ -20,9 +20,7 @@ from typing import Dict, List, Optional
 
 # A generated key is always "<dir>/<stem>.<ext>" with snake_case components.
 # Anchored, so a traversal or an absolute path cannot match in the first place.
-GENERATED_KEY = re.compile(
-    r"^[a-z][a-z0-9_]*/[a-z][a-z0-9_]*\.(?:yaml|py)$"
-)
+GENERATED_KEY = re.compile(r"^[a-z][a-z0-9_]*/[a-z][a-z0-9_]*\.(?:yaml|py)$")
 
 # Written by the builder itself rather than generated, so exempt from the
 # snake_case key rule (dunder names would never match it).
@@ -163,9 +161,7 @@ def run_command(output_path: str, task_name: Optional[str]) -> str:
     named a ``run-agent`` entrypoint that does not exist.
     """
     if task_name:
-        return (
-            f"uv run hugin run --task {task_name} --task-path {output_path}"
-        )
+        return f"uv run hugin run --task {task_name} --task-path {output_path}"
     return f"uv run hugin run --task-path {output_path}"
 
 

--- a/src/gimle/hugin/apps/agent_builder/tools/write_agent_files.py
+++ b/src/gimle/hugin/apps/agent_builder/tools/write_agent_files.py
@@ -1,9 +1,13 @@
 """Write generated files to disk."""
 
+import errno
+import hashlib
 import logging
 import os
+import uuid
+from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
 
 from gimle.hugin.apps.agent_builder.tools.agent_paths import (
     PathConfinementError,
@@ -19,6 +23,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_OWNERSHIP_STATE = "agent_builder_written_files"
+_DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+
 
 def _first_task_name(generated_files: Dict[str, str]) -> Optional[str]:
     """Return the stem of the first generated task, for the run command."""
@@ -29,40 +36,41 @@ def _first_task_name(generated_files: Dict[str, str]) -> Optional[str]:
 
 
 def _classify(
-    files: Dict[str, str], output_dir: Path
-) -> Tuple[Dict[str, str], List[str], List[str]]:
-    """Split ``files`` into those needing a write and those already correct.
+    files: Dict[str, str], output_dir: Path, owned: Dict[str, str]
+) -> Tuple[Dict[str, str], List[str], List[str], List[str]]:
+    """Split files into writable, unchanged, conflicting, and escaping sets.
 
-    Returns ``(to_write, unchanged, escaping)``. A file whose on-disk content
-    already matches is left alone entirely, so re-running the builder over an
-    unchanged agent touches nothing and mtimes stay meaningful.
+    A differing file is writable only when its current content still matches
+    the hash recorded when this builder session wrote it. Unknown or edited
+    files are conflicts, preventing a re-run from destroying user changes.
     """
     to_write: Dict[str, str] = {}
     unchanged: List[str] = []
+    conflicts: List[str] = []
     escaping: List[str] = []
 
     for key, content in files.items():
         try:
-            target = confine(output_dir, key)
+            current = _read_confined(output_dir, key)
+        except FileNotFoundError:
+            to_write[key] = content
+            continue
         except PathConfinementError as error:
             escaping.append(str(error))
             continue
-        if target.exists():
-            try:
-                # Explicit utf-8, matching how content is written. The locale
-                # default made this comparison wrong off UTF-8, and a
-                # UnicodeDecodeError is a ValueError -- not an OSError -- so it
-                # escaped the handler below and aborted the whole agent run.
-                if target.read_text(encoding="utf-8") == content:
-                    unchanged.append(key)
-                    continue
-            except (OSError, UnicodeDecodeError):
-                # Unreadable, or not text -- treat as needing a write so the
-                # error surfaces at write time rather than as a traceback.
-                pass
-        to_write[key] = content
+        except OSError as error:
+            conflicts.append(f"{key}: cannot inspect existing file: {error}")
+            continue
 
-    return to_write, unchanged, escaping
+        desired = content.encode("utf-8")
+        if current == desired:
+            unchanged.append(key)
+        elif owned.get(key) == _digest(current):
+            to_write[key] = content
+        else:
+            conflicts.append(key)
+
+    return to_write, unchanged, conflicts, escaping
 
 
 def _as_bool(value: object) -> bool:
@@ -77,18 +85,174 @@ def _as_bool(value: object) -> bool:
     return bool(value)
 
 
-def _write_text(target: Path, content: str) -> None:
-    """Write ``content`` without following a symlink at the final component.
+def _digest(content: bytes) -> str:
+    """Return the ownership hash for file content."""
+    return hashlib.sha256(content).hexdigest()
 
-    Mirrors ``sandbox.write_file_nofollow`` but leaves the mode to the umask.
-    That helper hardcodes 0o600 for sandbox workspaces; generated agents are
-    ordinary project files, and 0600 made them unreadable to the service
-    account or container user that later runs them.
+
+def _root_key(output_dir: Path) -> str:
+    """Return a stable key that scopes ownership to one output directory."""
+    return os.path.realpath(output_dir)
+
+
+def _owned_files(env_vars: Dict[str, Any], output_dir: Path) -> Dict[str, str]:
+    """Return validated ownership hashes for ``output_dir``."""
+    state = env_vars.get(_OWNERSHIP_STATE)
+    if not isinstance(state, dict):
+        return {}
+    owned = state.get(_root_key(output_dir))
+    if not isinstance(owned, dict):
+        return {}
+    return {
+        key: value
+        for key, value in owned.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+
+
+def _set_owned_files(
+    env_vars: Dict[str, Any], output_dir: Path, owned: Dict[str, str]
+) -> None:
+    """Persist ownership hashes without mixing different output directories."""
+    existing = env_vars.get(_OWNERSHIP_STATE)
+    state = dict(existing) if isinstance(existing, dict) else {}
+    root = _root_key(output_dir)
+    if owned:
+        state[root] = dict(sorted(owned.items()))
+    else:
+        state.pop(root, None)
+    env_vars[_OWNERSHIP_STATE] = state
+
+
+@contextmanager
+def _open_directory_tree(path: Path, create: bool) -> Iterator[int]:
+    """Open every directory component with ``O_NOFOLLOW``.
+
+    Holding a descriptor for each next hop while it is opened closes the parent
+    symlink race left by resolving a full path and protecting only its final
+    component.
     """
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
-    handle = os.open(str(target), flags, 0o666)
-    with os.fdopen(handle, "w", encoding="utf-8") as stream:
-        stream.write(content)
+    absolute = Path(os.path.abspath(path))
+    descriptor = os.open(absolute.anchor, _DIRECTORY_FLAGS)
+    try:
+        for component in absolute.parts[1:]:
+            if create:
+                try:
+                    os.mkdir(component, 0o777, dir_fd=descriptor)
+                except FileExistsError:
+                    pass
+            next_descriptor = os.open(
+                component, _DIRECTORY_FLAGS, dir_fd=descriptor
+            )
+            os.close(descriptor)
+            descriptor = next_descriptor
+        yield descriptor
+    except OSError as error:
+        if error.errno in {errno.ELOOP, errno.ENOTDIR}:
+            raise PathConfinementError(
+                f"refusing a symlinked output path component: {path}"
+            ) from error
+        raise
+    finally:
+        os.close(descriptor)
+
+
+@contextmanager
+def _open_confined_parent(
+    root: Path, key: str, create: bool
+) -> Iterator[Tuple[int, str]]:
+    """Yield a no-follow descriptor and basename for a generated key."""
+    confine(root, key)  # Validate the key and reject already-present escapes.
+    parts = Path(key).parts
+    with _open_directory_tree(root, create=create) as root_descriptor:
+        descriptor = os.dup(root_descriptor)
+        try:
+            for component in parts[:-1]:
+                if create:
+                    try:
+                        os.mkdir(component, 0o777, dir_fd=descriptor)
+                    except FileExistsError:
+                        pass
+                next_descriptor = os.open(
+                    component, _DIRECTORY_FLAGS, dir_fd=descriptor
+                )
+                os.close(descriptor)
+                descriptor = next_descriptor
+            yield descriptor, parts[-1]
+        except OSError as error:
+            if error.errno in {
+                errno.ELOOP,
+                errno.ENOTDIR,
+            }:
+                raise PathConfinementError(
+                    f"generated file {key!r} crosses a symlinked directory"
+                ) from error
+            raise
+        finally:
+            os.close(descriptor)
+
+
+def _read_confined(root: Path, key: str) -> bytes:
+    """Read a generated path without following any symlink component."""
+    with _open_confined_parent(root, key, create=False) as (parent, name):
+        try:
+            descriptor = os.open(
+                name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=parent
+            )
+        except OSError as error:
+            if error.errno == errno.ELOOP:
+                raise PathConfinementError(
+                    f"generated file {key!r} is a symlink"
+                ) from error
+            raise
+        with os.fdopen(descriptor, "rb") as stream:
+            return stream.read()
+
+
+def _write_confined(root: Path, key: str, content: str) -> None:
+    """Atomically write content without following any symlink component.
+
+    The temporary file and destination are addressed relative to a securely
+    opened parent directory. ``os.replace`` replaces a final-component symlink
+    rather than following it and avoids truncating a good file on a short write.
+    """
+    with _open_confined_parent(root, key, create=True) as (parent, name):
+        temporary = f".{name}.hugin-{uuid.uuid4().hex}.tmp"
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o666,
+            dir_fd=parent,
+        )
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(
+                temporary,
+                name,
+                src_dir_fd=parent,
+                dst_dir_fd=parent,
+            )
+        finally:
+            try:
+                os.unlink(temporary, dir_fd=parent)
+            except FileNotFoundError:
+                pass
+
+
+def _unlink_owned(root: Path, key: str, expected_hash: str) -> bool:
+    """Remove an unmodified builder-owned file, returning whether it existed."""
+    try:
+        current = _read_confined(root, key)
+    except FileNotFoundError:
+        return False
+    if _digest(current) != expected_hash:
+        raise FileExistsError(f"superseded file was modified: {key}")
+    with _open_confined_parent(root, key, create=False) as (parent, name):
+        os.unlink(name, dir_fd=parent)
+    return True
 
 
 def write_agent_files(
@@ -99,10 +263,10 @@ def write_agent_files(
 ) -> ToolResponse:
     """Write the generated agent files to ``output_path``.
 
-    Writes are *incremental and additive*: only files whose content differs from
-    disk are written, and nothing is ever deleted. A file the user added or
-    hand-edited that the builder did not generate is left untouched, which is
-    what makes re-running the builder over an existing agent safe.
+    Writes are incremental and ownership-aware. Unknown or user-modified files
+    are never overwritten. Files written by this builder session may be updated
+    while their content still matches its recorded hash, and may be removed when
+    an unmodified file is superseded by a later generation.
 
     This replaces an unconditional ``shutil.rmtree(output_path)`` that destroyed
     whatever the target directory previously held.
@@ -152,7 +316,10 @@ def write_agent_files(
     )
 
     output_dir = Path(output_path).expanduser()
-    to_write, unchanged, escaping = _classify(files, output_dir)
+    owned = _owned_files(env_vars, output_dir)
+    to_write, unchanged, conflicts, escaping = _classify(
+        files, output_dir, owned
+    )
     if escaping:
         return ToolResponse(
             is_error=True,
@@ -161,8 +328,38 @@ def write_agent_files(
                 "escaping": escaping,
             },
         )
+    if conflicts:
+        return ToolResponse(
+            is_error=True,
+            content={
+                "error": (
+                    "Refusing to overwrite files not owned by this builder "
+                    "session, or files modified since it wrote them"
+                ),
+                "conflicts": sorted(conflicts),
+            },
+        )
 
-    preserved = _existing_unmanaged(output_dir, files)
+    superseded, superseded_conflicts = _classify_superseded(
+        owned, files, output_dir
+    )
+    if superseded_conflicts:
+        return ToolResponse(
+            is_error=True,
+            content={
+                "error": (
+                    "Refusing to remove superseded files that were modified "
+                    "after the builder wrote them"
+                ),
+                "conflicts": sorted(superseded_conflicts),
+            },
+        )
+
+    preserved = [
+        key
+        for key in _existing_unmanaged(output_dir, files)
+        if key not in superseded
+    ]
 
     if _as_bool(dry_run):
         return ToolResponse(
@@ -171,6 +368,7 @@ def write_agent_files(
                 "output_path": str(output_dir),
                 "dry_run": True,
                 "would_write": sorted(to_write),
+                "would_remove": sorted(superseded),
                 "unchanged": sorted(unchanged),
                 "preserved": preserved,
                 "message": (
@@ -182,14 +380,18 @@ def write_agent_files(
     written: List[str] = []
     try:
         for key, content in to_write.items():
-            target = confine(output_dir, key)
-            target.parent.mkdir(parents=True, exist_ok=True)
-            # O_NOFOLLOW closes the gap between the confinement check above and
-            # the write: a symlink swapped into the final component afterwards
-            # fails the open rather than being written through.
-            _write_text(target, content)
+            _write_confined(output_dir, key, content)
             written.append(key)
     except (OSError, PathConfinementError) as error:
+        partial_owned = dict(owned)
+        partial_owned.update(
+            _ownership_after_write(owned, files, unchanged, written)
+        )
+        _set_owned_files(
+            env_vars,
+            output_dir,
+            partial_owned,
+        )
         return ToolResponse(
             is_error=True,
             content={
@@ -198,7 +400,34 @@ def write_agent_files(
             },
         )
 
-    removed = _remove_superseded(env_vars, files, output_dir)
+    removed: List[str] = []
+    removal_errors: List[str] = []
+    for key, expected_hash in superseded.items():
+        try:
+            if _unlink_owned(output_dir, key, expected_hash):
+                removed.append(key)
+        except (OSError, PathConfinementError) as error:
+            removal_errors.append(f"{key}: {error}")
+
+    final_owned = _ownership_after_write(owned, files, unchanged, written)
+    for key in removal_errors:
+        failed_key = key.split(":", 1)[0]
+        if failed_key in owned:
+            final_owned[failed_key] = owned[failed_key]
+    _set_owned_files(env_vars, output_dir, final_owned)
+
+    if removal_errors:
+        return ToolResponse(
+            is_error=True,
+            content={
+                "error": "Failed removing superseded builder-owned files",
+                "written": sorted(written),
+                "removed": sorted(removed),
+                "removal_errors": sorted(removal_errors),
+                "preserved": preserved,
+            },
+        )
+
     registered = _register(stack, output_dir)
 
     return ToolResponse(
@@ -215,39 +444,44 @@ def write_agent_files(
     )
 
 
-def _remove_superseded(
-    env_vars: Dict[str, Any], files: Dict[str, str], output_dir: Path
-) -> List[str]:
-    """Delete files this builder wrote earlier but no longer generates.
-
-    Dropping ``rmtree`` removed the invariant that the directory holds exactly
-    the current generation. Without this, a builder that regenerates under new
-    names mid-session leaves the old config and tools behind, and
-    ``load_agent_from_path`` registers *both* -- returning whichever the
-    directory happens to yield last, so the user can be handed the obsolete,
-    known-broken iteration.
-
-    Only files this tool wrote in this session are removed: the record comes
-    from ``env_vars``, never from scanning the directory, so a file the user
-    added or hand-edited is still never touched.
-    """
-    previous = set(env_vars.get("written_keys") or [])
-    current = set(files)
-    env_vars["written_keys"] = sorted(current)
-
-    removed = []
-    for key in sorted(previous - current):
-        try:
-            target = confine(output_dir, key)
-        except PathConfinementError:
+def _classify_superseded(
+    owned: Dict[str, str], files: Dict[str, str], output_dir: Path
+) -> Tuple[Dict[str, str], List[str]]:
+    """Return safely removable superseded files and modified conflicts."""
+    removable: Dict[str, str] = {}
+    conflicts: List[str] = []
+    for key, expected_hash in owned.items():
+        if key in files:
             continue
         try:
-            if target.is_file():
-                target.unlink()
-                removed.append(key)
-        except OSError as error:
-            logger.warning("Could not remove superseded %s: %s", key, error)
-    return removed
+            current = _read_confined(output_dir, key)
+        except FileNotFoundError:
+            continue
+        except (OSError, PathConfinementError) as error:
+            conflicts.append(f"{key}: cannot inspect existing file: {error}")
+            continue
+        if _digest(current) == expected_hash:
+            removable[key] = expected_hash
+        else:
+            conflicts.append(key)
+    return removable, conflicts
+
+
+def _ownership_after_write(
+    previous: Dict[str, str],
+    files: Dict[str, str],
+    unchanged: List[str],
+    written: List[str],
+) -> Dict[str, str]:
+    """Return ownership for files actually written or still builder-owned."""
+    result: Dict[str, str] = {}
+    for key in written:
+        result[key] = _digest(files[key].encode("utf-8"))
+    for key in unchanged:
+        desired_hash = _digest(files[key].encode("utf-8"))
+        if previous.get(key) == desired_hash:
+            result[key] = desired_hash
+    return result
 
 
 def _existing_unmanaged(output_dir: Path, files: Dict[str, str]) -> List[str]:

--- a/src/gimle/hugin/apps/agent_builder/tools/write_agent_files.py
+++ b/src/gimle/hugin/apps/agent_builder/tools/write_agent_files.py
@@ -1,10 +1,17 @@
 """Write generated files to disk."""
 
 import logging
-import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
+from gimle.hugin.apps.agent_builder.tools.agent_paths import (
+    PathConfinementError,
+    check_output_path,
+    confine,
+    materialise,
+    validate_generated_keys,
+)
+from gimle.hugin.sandbox.sandbox import write_file_nofollow
 from gimle.hugin.tools.tool import ToolResponse
 
 if TYPE_CHECKING:
@@ -13,26 +20,76 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _first_task_name(generated_files: Dict[str, str]) -> Optional[str]:
+    """Return the stem of the first generated task, for the run command."""
+    for key in sorted(generated_files):
+        if key.startswith("tasks/") and key.endswith(".yaml"):
+            return Path(key).stem
+    return None
+
+
+def _classify(
+    files: Dict[str, str], output_dir: Path
+) -> Tuple[Dict[str, str], List[str], List[str]]:
+    """Split ``files`` into those needing a write and those already correct.
+
+    Returns ``(to_write, unchanged, escaping)``. A file whose on-disk content
+    already matches is left alone entirely, so re-running the builder over an
+    unchanged agent touches nothing and mtimes stay meaningful.
+    """
+    to_write: Dict[str, str] = {}
+    unchanged: List[str] = []
+    escaping: List[str] = []
+
+    for key, content in files.items():
+        try:
+            target = confine(output_dir, key)
+        except PathConfinementError as error:
+            escaping.append(str(error))
+            continue
+        if target.exists():
+            try:
+                if target.read_text() == content:
+                    unchanged.append(key)
+                    continue
+            except OSError:
+                # Unreadable (permissions, a directory in the way) -- treat as
+                # needing a write so the error surfaces at write time.
+                pass
+        to_write[key] = content
+
+    return to_write, unchanged, escaping
+
+
 def write_agent_files(
     stack: "Stack",
     output_path: str,
     agent_name: str = "",
+    dry_run: bool = False,
 ) -> ToolResponse:
-    """Write all generated files to the output directory.
+    """Write the generated agent files to ``output_path``.
+
+    Writes are *incremental and additive*: only files whose content differs from
+    disk are written, and nothing is ever deleted. A file the user added or
+    hand-edited that the builder did not generate is left untouched, which is
+    what makes re-running the builder over an existing agent safe.
+
+    This replaces an unconditional ``shutil.rmtree(output_path)`` that destroyed
+    whatever the target directory previously held.
 
     Args:
         stack: Agent stack (auto-injected)
         output_path: Directory where agent files should be written
-        agent_name: Optional name of the agent (for README)
+        agent_name: Optional name of the agent (for the README)
+        dry_run: Report what would be written without touching the filesystem
 
     Returns:
-        ToolResponse with list of written files
+        ToolResponse with the written / unchanged / preserved breakdown
     """
     env_vars = stack.agent.environment.env_vars
     generated_files = env_vars.get("generated_files", {})
     user_input = env_vars.get("user_input", {})
 
-    # Use provided agent_name or fall back to env_vars
     if not agent_name:
         agent_name = user_input.get("agent_name", "agent")
 
@@ -42,93 +99,121 @@ def write_agent_files(
             content={"error": "No files have been generated yet"},
         )
 
-    if not output_path:
+    path_error = check_output_path(output_path)
+    if path_error:
+        return ToolResponse(is_error=True, content={"error": path_error})
+
+    key_errors = validate_generated_keys(list(generated_files))
+    if key_errors:
         return ToolResponse(
             is_error=True,
-            content={"error": "No output path specified"},
+            content={
+                "error": "Generated file names are not writable",
+                "invalid_keys": key_errors,
+            },
         )
 
+    files = materialise(
+        generated_files,
+        agent_name=agent_name,
+        description=user_input.get("description", "A Hugin agent"),
+        output_path=output_path,
+        task_name=_first_task_name(generated_files),
+    )
+
     output_dir = Path(output_path)
-    written_files: List[str] = []
+    to_write, unchanged, escaping = _classify(files, output_dir)
+    if escaping:
+        return ToolResponse(
+            is_error=True,
+            content={
+                "error": "Generated files escape the output directory",
+                "escaping": escaping,
+            },
+        )
 
-    try:
-        # Clean up previous agent files in the output directory
-        if output_dir.exists():
-            shutil.rmtree(output_dir)
+    preserved = _existing_unmanaged(output_dir, files)
 
-        # Create output directory
-        output_dir.mkdir(parents=True, exist_ok=True)
-
-        # Create __init__.py for the agent package
-        init_file = output_dir / "__init__.py"
-        init_content = f'"""Generated Hugin agent: {agent_name}."""\n'
-        init_file.write_text(init_content)
-        written_files.append(str(init_file))
-
-        # Create tools __init__.py
-        tools_dir = output_dir / "tools"
-        tools_dir.mkdir(exist_ok=True)
-        tools_init = tools_dir / "__init__.py"
-        tools_init.write_text('"""Agent tools."""\n')
-        written_files.append(str(tools_init))
-
-        # Write all generated files
-        for file_path, content in generated_files.items():
-            full_path = output_dir / file_path
-            full_path.parent.mkdir(parents=True, exist_ok=True)
-            full_path.write_text(content)
-            written_files.append(str(full_path))
-
-        # Create README.md
-        description = user_input.get("description", "A Hugin agent")
-        readme_content = f"""# {agent_name}
-
-{description}
-
-## Running the Agent
-
-```bash
-uv run run-agent --task main --task-path {output_path}
-```
-
-## Structure
-
-- `configs/` - Agent configuration
-- `tasks/` - Task definitions
-- `templates/` - System prompts
-- `tools/` - Custom tools
-
-Generated by Hugin Agent Builder.
-"""
-        readme_path = output_dir / "README.md"
-        readme_path.write_text(readme_content)
-        written_files.append(str(readme_path))
-
-        # Register the new agent with the environment so it becomes
-        # immediately available to list_agents and launch_agent
-        environment = stack.agent.environment
-        loaded_config_name = environment.load_agent_from_path(str(output_dir))
-        if loaded_config_name:
-            logger.info(
-                f"Registered new agent '{loaded_config_name}' in environment"
-            )
-
+    if dry_run:
         return ToolResponse(
             is_error=False,
             content={
                 "output_path": str(output_dir),
-                "files_written": written_files,
-                "file_count": len(written_files),
-                "message": f"Successfully created agent at {output_dir}",
-                "registered_config": loaded_config_name,
+                "dry_run": True,
+                "would_write": sorted(to_write),
+                "unchanged": sorted(unchanged),
+                "preserved": preserved,
+                "message": (
+                    f"Would write {len(to_write)} file(s) to {output_dir}"
+                ),
             },
         )
 
-    except Exception as e:
+    written: List[str] = []
+    try:
+        for key, content in to_write.items():
+            target = confine(output_dir, key)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            # O_NOFOLLOW closes the gap between the confinement check above and
+            # the write: a symlink swapped into the final component afterwards
+            # fails the open rather than being written through.
+            write_file_nofollow(str(target), content.encode())
+            written.append(key)
+    except (OSError, PathConfinementError) as error:
         return ToolResponse(
             is_error=True,
             content={
-                "error": str(e),
-                "partial_files": written_files,
+                "error": f"Failed writing agent files: {error}",
+                "written_before_failure": written,
             },
         )
+
+    registered = _register(stack, output_dir)
+
+    return ToolResponse(
+        is_error=False,
+        content={
+            "output_path": str(output_dir),
+            "written": sorted(written),
+            "unchanged": sorted(unchanged),
+            "preserved": preserved,
+            "message": f"Wrote {len(written)} file(s) to {output_dir}",
+            "registered_config": registered,
+        },
+    )
+
+
+def _existing_unmanaged(output_dir: Path, files: Dict[str, str]) -> List[str]:
+    """List files already on disk that the builder does not manage.
+
+    Surfaced so the caller can see what was deliberately left alone -- the
+    previous implementation deleted exactly these without saying so.
+    """
+    if not output_dir.exists():
+        return []
+    managed = set(files)
+    found = []
+    for path in sorted(output_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = str(path.relative_to(output_dir))
+        if relative not in managed and "__pycache__" not in relative:
+            found.append(relative)
+    return found
+
+
+def _register(stack: "Stack", output_dir: Path) -> Optional[str]:
+    """Register the freshly written agent with the live environment.
+
+    Best effort: a generated agent that cannot be loaded is a validation
+    concern (PR 1.3), not a reason to report the write itself as failed.
+    """
+    try:
+        environment = stack.agent.environment
+        name = environment.load_agent_from_path(str(output_dir))
+        if name:
+            logger.info("Registered new agent '%s' in environment", name)
+        return name
+    except Exception as error:  # noqa: BLE001 - registration is advisory
+        logger.warning("Could not register generated agent: %s", error)
+        return None

--- a/src/gimle/hugin/apps/agent_builder/tools/write_agent_files.py
+++ b/src/gimle/hugin/apps/agent_builder/tools/write_agent_files.py
@@ -1,8 +1,9 @@
 """Write generated files to disk."""
 
 import logging
+import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from gimle.hugin.apps.agent_builder.tools.agent_paths import (
     PathConfinementError,
@@ -11,7 +12,6 @@ from gimle.hugin.apps.agent_builder.tools.agent_paths import (
     materialise,
     validate_generated_keys,
 )
-from gimle.hugin.sandbox.sandbox import write_file_nofollow
 from gimle.hugin.tools.tool import ToolResponse
 
 if TYPE_CHECKING:
@@ -49,16 +49,46 @@ def _classify(
             continue
         if target.exists():
             try:
-                if target.read_text() == content:
+                # Explicit utf-8, matching how content is written. The locale
+                # default made this comparison wrong off UTF-8, and a
+                # UnicodeDecodeError is a ValueError -- not an OSError -- so it
+                # escaped the handler below and aborted the whole agent run.
+                if target.read_text(encoding="utf-8") == content:
                     unchanged.append(key)
                     continue
-            except OSError:
-                # Unreadable (permissions, a directory in the way) -- treat as
-                # needing a write so the error surfaces at write time.
+            except (OSError, UnicodeDecodeError):
+                # Unreadable, or not text -- treat as needing a write so the
+                # error surfaces at write time rather than as a traceback.
                 pass
         to_write[key] = content
 
     return to_write, unchanged, escaping
+
+
+def _as_bool(value: object) -> bool:
+    """Coerce an LLM-supplied argument to a bool.
+
+    Tool arguments arrive unconverted, so a plain truthiness test made the
+    string "false" enable dry-run and silently skip the write while reporting
+    success.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _write_text(target: Path, content: str) -> None:
+    """Write ``content`` without following a symlink at the final component.
+
+    Mirrors ``sandbox.write_file_nofollow`` but leaves the mode to the umask.
+    That helper hardcodes 0o600 for sandbox workspaces; generated agents are
+    ordinary project files, and 0600 made them unreadable to the service
+    account or container user that later runs them.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    handle = os.open(str(target), flags, 0o666)
+    with os.fdopen(handle, "w", encoding="utf-8") as stream:
+        stream.write(content)
 
 
 def write_agent_files(
@@ -121,7 +151,7 @@ def write_agent_files(
         task_name=_first_task_name(generated_files),
     )
 
-    output_dir = Path(output_path)
+    output_dir = Path(output_path).expanduser()
     to_write, unchanged, escaping = _classify(files, output_dir)
     if escaping:
         return ToolResponse(
@@ -134,7 +164,7 @@ def write_agent_files(
 
     preserved = _existing_unmanaged(output_dir, files)
 
-    if dry_run:
+    if _as_bool(dry_run):
         return ToolResponse(
             is_error=False,
             content={
@@ -157,7 +187,7 @@ def write_agent_files(
             # O_NOFOLLOW closes the gap between the confinement check above and
             # the write: a symlink swapped into the final component afterwards
             # fails the open rather than being written through.
-            write_file_nofollow(str(target), content.encode())
+            _write_text(target, content)
             written.append(key)
     except (OSError, PathConfinementError) as error:
         return ToolResponse(
@@ -168,6 +198,7 @@ def write_agent_files(
             },
         )
 
+    removed = _remove_superseded(env_vars, files, output_dir)
     registered = _register(stack, output_dir)
 
     return ToolResponse(
@@ -176,11 +207,47 @@ def write_agent_files(
             "output_path": str(output_dir),
             "written": sorted(written),
             "unchanged": sorted(unchanged),
+            "removed": removed,
             "preserved": preserved,
             "message": f"Wrote {len(written)} file(s) to {output_dir}",
             "registered_config": registered,
         },
     )
+
+
+def _remove_superseded(
+    env_vars: Dict[str, Any], files: Dict[str, str], output_dir: Path
+) -> List[str]:
+    """Delete files this builder wrote earlier but no longer generates.
+
+    Dropping ``rmtree`` removed the invariant that the directory holds exactly
+    the current generation. Without this, a builder that regenerates under new
+    names mid-session leaves the old config and tools behind, and
+    ``load_agent_from_path`` registers *both* -- returning whichever the
+    directory happens to yield last, so the user can be handed the obsolete,
+    known-broken iteration.
+
+    Only files this tool wrote in this session are removed: the record comes
+    from ``env_vars``, never from scanning the directory, so a file the user
+    added or hand-edited is still never touched.
+    """
+    previous = set(env_vars.get("written_keys") or [])
+    current = set(files)
+    env_vars["written_keys"] = sorted(current)
+
+    removed = []
+    for key in sorted(previous - current):
+        try:
+            target = confine(output_dir, key)
+        except PathConfinementError:
+            continue
+        try:
+            if target.is_file():
+                target.unlink()
+                removed.append(key)
+        except OSError as error:
+            logger.warning("Could not remove superseded %s: %s", key, error)
+    return removed
 
 
 def _existing_unmanaged(output_dir: Path, files: Dict[str, str]) -> List[str]:

--- a/src/gimle/hugin/apps/agent_builder/tools/write_agent_files.yaml
+++ b/src/gimle/hugin/apps/agent_builder/tools/write_agent_files.yaml
@@ -1,8 +1,8 @@
 name: write_agent_files
 description: >-
-  Write the generated files to the output directory. Only files whose content
-  differs from disk are written; nothing is ever deleted, and files present in
-  the directory that were not generated are left untouched.
+  Write generated files without overwriting unknown or user-modified content.
+  Files written by this builder session are tracked by output directory and
+  content hash, so unmodified files can be updated or removed when superseded.
 parameters:
   output_path:
     type: string

--- a/src/gimle/hugin/apps/agent_builder/tools/write_agent_files.yaml
+++ b/src/gimle/hugin/apps/agent_builder/tools/write_agent_files.yaml
@@ -1,5 +1,8 @@
 name: write_agent_files
-description: Write all generated files to the output directory. Creates the directory structure and saves all files.
+description: >-
+  Write the generated files to the output directory. Only files whose content
+  differs from disk are written; nothing is ever deleted, and files present in
+  the directory that were not generated are left untouched.
 parameters:
   output_path:
     type: string
@@ -9,6 +12,12 @@ parameters:
     type: string
     description: Name of the agent being created
     required: false
+  dry_run:
+    type: boolean
+    description: >-
+      Report which files would be written without touching the filesystem.
+    required: false
+    default: false
 is_interactive: false
 implementation_path: agent_builder.tools.write_agent_files:write_agent_files
 options: {}

--- a/src/gimle/hugin/cli/create_agent.py
+++ b/src/gimle/hugin/cli/create_agent.py
@@ -330,7 +330,7 @@ def run_wizard(builder_model: Optional[str] = None) -> Dict[str, Any]:
         "description": description,
         "llm_model": llm_model,
         "full_implementation": full_implementation,
-        "output_path": str(Path(output_path).resolve()),
+        "output_path": str(Path(output_path).expanduser().resolve()),
         "builder_model": builder_model,
     }
 

--- a/src/gimle/hugin/cli/create_agent.py
+++ b/src/gimle/hugin/cli/create_agent.py
@@ -324,6 +324,24 @@ def run_wizard(builder_model: Optional[str] = None) -> Dict[str, Any]:
     }
 
 
+def _generated_run_command(output_path: str) -> str:
+    """Return the run command for a freshly generated agent.
+
+    Delegates to the same helper the generated README uses, so the CLI and the
+    README cannot disagree -- they previously gave two different commands, and
+    the README's named an entrypoint that does not exist.
+    """
+    from gimle.hugin.apps.agent_builder.tools.agent_paths import run_command
+
+    tasks_dir = Path(output_path) / "tasks"
+    task_name = None
+    if tasks_dir.is_dir():
+        tasks = sorted(tasks_dir.glob("*.yaml"))
+        if tasks:
+            task_name = tasks[0].stem
+    return run_command(output_path, task_name)
+
+
 def setup_file_logging(log_dir: Path, log_level: str) -> Path:
     """Configure logging to write to a file instead of stdout.
 
@@ -523,7 +541,7 @@ Examples:
     print()
     print("    Run your new agent with:")
     print()
-    print(f"        hugin run -p {user_input['output_path']}")
+    print(f"        {_generated_run_command(user_input['output_path'])}")
     print()
 
     # Ask if user wants to run the agent now

--- a/src/gimle/hugin/cli/create_agent.py
+++ b/src/gimle/hugin/cli/create_agent.py
@@ -285,9 +285,20 @@ def run_wizard(builder_model: Optional[str] = None) -> Dict[str, Any]:
 
     # Output path
     print()
-    output_path = prompt_user(
-        "    Output directory path", f"./agents/{agent_name}"
+    # Checked here, not only at write time: these refusals used to surface
+    # after the entire multi-stage LLM build had already run and been paid for.
+    from gimle.hugin.apps.agent_builder.tools.agent_paths import (
+        check_output_path,
     )
+
+    default_output = f"./agents/{agent_name}"
+    output_path = prompt_user("    Output directory path", default_output)
+    while True:
+        problem = check_output_path(output_path)
+        if not problem:
+            break
+        print(f"        {problem}")
+        output_path = prompt_user("    Output directory path", default_output)
 
     # Confirmation screen
     show_header("Ready to Build", "Review your configuration")

--- a/tasks/open/034-agent-creator-v2/description.md
+++ b/tasks/open/034-agent-creator-v2/description.md
@@ -49,14 +49,29 @@ Hugin change has to be written up in two places, and today they disagree.
 
 | Location | Defect |
 |---|---|
-| `tools/write_agent_files.py:60` | `shutil.rmtree(output_dir)` unconditionally. Point it at an existing directory and it is gone — no existence check, no backup, no confirmation. |
-| `tools/list_examples.py`, `tools/read_example.py` | 495 lines of example-catalog tooling **not listed in `configs/agent_builder.yaml`**. Dead code — the builder cannot study any existing example before generating. |
-| `tasks/build_agent.yaml:19`, `cli/create_agent.py:281` | `full_implementation` is asked in the wizard and declared as a task parameter, but referenced in **zero** prompts. Dead flag. |
-| `tools/write_agent_files.py:104` | Generated `README.md` tells users `uv run run-agent --task main …`. That entrypoint does not exist — `pyproject.toml:126` defines only `hugin`. Every generated agent ships broken run instructions. |
-| `tools/generate_tool.py:100-108` | Types every parameter as `str` in the emitted signature regardless of its declared schema type, then wraps the entire body in a bare `except Exception` returning only `str(e)` with no traceback. |
-| `tasks/review_agent.yaml` + `configs/reviewer.yaml` | The review stage is an LLM reading a *preview string*. Nothing ever dry-loads the environment, so a config referencing a nonexistent template or tool passes review and only fails at `test_agent` — or silently at the user's first run. |
-| `tools/test_agent.py:88-100` | Picks `configs[0]`/`tasks[0]` arbitrarily, mutates global `sys.path`, and injects the *tested* agent's templates into the *builder's* template registry. |
+| `tools/write_agent_files.py:57` | `shutil.rmtree(output_dir)` unconditionally. Point it at an existing directory and it is gone — no existence check, no backup, no confirmation. |
+| `tools/write_agent_files.py:77-79` | `output_dir / file_path` where `file_path` is an unvalidated LLM-chosen name. `pathlib` does not normalise `..`, and an absolute key *replaces* the root: `Path("/a/b") / "/etc/passwd"` is `/etc/passwd`. Combined with `mkdir(parents=True)`, a generated `tool_name` of `../../../.bashrc` writes anywhere the process can reach. None of the four `generate_*` tools validates a name. |
+| `utils/registry.py:20` | `self._items[name] = instance` — silent overwrite, no collision check, on a process-global `Tool.registry` (`tools/tool.py:96`). `write_agent_files.py:110` registers generated tools into it mid-build, so a generated tool named `finish` or `preview_files` replaces the builder's own for the rest of the run. |
+| `tools/tool.py:154` | `importlib.import_module` with no reload, against the flat module name `generate_tool.py:186` emits. After a repair, re-testing returns the **cached stale module** — so a fix-and-retest loop diagnoses the same failure and burns its attempts. A generated `tools/json.py` shadows stdlib process-wide. |
+| `tools/list_examples.py`, `tools/read_example.py` | 495 lines of example-catalog tooling **not listed in `configs/agent_builder.yaml`**. Dead code — the builder cannot study any existing example before generating. Both work as-is and inject `stack` only if declared (`tools/tool.py:353`), so wiring them is two lines of YAML. |
+| `tasks/build_agent.yaml:19`, `cli/create_agent.py:281,321` | `full_implementation` is asked in the wizard and declared as a task parameter, but referenced in **zero** prompts. Dead flag. |
+| `tools/write_agent_files.py:91` | Generated `README.md` tells users `uv run run-agent --task main …`. That entrypoint does not exist — `pyproject.toml:126` defines only `hugin`. The success screen (`cli/create_agent.py:525`) and `docs/src/how-to/use-creator.md:137` each give a *third* and *fourth* different command. |
+| `tools/generate_tool.py:87-98` | Types every parameter as `str` in the emitted signature regardless of its declared schema type, then wraps the entire body in a bare `except Exception` returning only `str(e)` with no traceback. |
+| `tasks/review_agent.yaml` + `configs/reviewer.yaml` | The review stage is an LLM reading a *preview string*. Nothing ever dry-loads the environment, so a config referencing a nonexistent template or tool passes review and only fails at `test_agent` — or silently at the user's first run. Because `TaskChain.step` chains on the *same stack and agent* (`interaction/task_chain.py:78-188`), the reviewer also sees the whole build transcript: this is self-review, not review. |
+| `tools/test_agent.py:92-114` | Picks `configs[0]`/`tasks[0]` arbitrarily, mutates global `sys.path` permanently, and injects the *tested* agent's templates into the *builder's* template registry. |
 | `cli/create_agent.py:167-170` | Model lists hardcoded (`sonnet-latest`, `gpt-4o`, …) instead of read from `llm/models/model_registry.py`. No non-interactive mode, so `hugin create` cannot be scripted or covered by an end-to-end test. |
+
+### Trust boundary
+
+`agent_builder` is a **code-execution tool**: it turns a natural-language description into Python and then imports and runs it. The bash-sandbox work (`tasks/closed/023-bash-tool`) states its threat model in prose and refuses a silent backend default; this surface has never had one written down. Stating it is part of this task.
+
+**Position taken: generated code is executed with the operator's full privileges, and the description, any `--reference-file`, and any analysed trace are assumed non-hostile.** Consequences, to be documented in the README and on the `hugin create` screen:
+
+- Validation must not be described as a sandbox. A subprocess is a crash boundary, not a security boundary — and it is void anyway, because `write_agent_files` imports the same modules in-process seconds later.
+- Where a *mechanical* guarantee is cheap, take it: path confinement, name validation, and reserved-name collision checks are ~40 lines and prevent the builder writing outside its target directory at all.
+- Anything that weakens this position — Phase 3's `shell` architecture, Phase 4's editing of hand-written code, Phase 5's unattended rewriting — must state its own additional constraints where it is specified.
+
+This repo already ships `src/gimle/hugin/sandbox/` (docker/local/ssh backends, egress proxy, reaper). Running generated code inside it is the upgrade path to a real boundary, and is deliberately **out of scope here** — noted so the choice is explicit rather than overlooked.
 
 ### What we cannot do today, and want to
 
@@ -84,14 +99,24 @@ See `spec.md` for the design and `plan.md` for the PR breakdown.
 
 ## Success Criteria
 
-- [ ] A generated agent that fails to load is impossible to write to disk — the
-      validator blocks it deterministically, without an LLM in the loop.
-- [ ] The creator can produce a multi-stage (`task_sequence`) agent and an agent
-      that delegates to sub-agents, verified by end-to-end tests.
-- [ ] Hugin reference documentation exists in exactly one place and both creator
-      surfaces read it.
-- [ ] `hugin create --edit <path>` modifies an existing agent without destroying
-      unrelated files.
-- [ ] `hugin improve <path> --storage-path <s>` produces a concrete, applied
-      improvement from real trace data.
+- [ ] `write_agent_files` refuses to write a payload it has not itself validated.
+      The gate lives in the tool, not in a prompt sentence — no reachable
+      instruction to the model can skip it.
+- [ ] No generated file can be written outside its target directory, and no
+      generated name can shadow a builtin tool or a stdlib module.
+- [ ] `hugin validate` passes clean on every directory in `examples/` and `apps/`,
+      enforced in CI. A validator that fails on the repo's own shipped agents is
+      wrong about the framework, not right about the agents.
+- [ ] A failed build always leaves the user something actionable: the rejected
+      payload on disk plus the validator's errors, never a silent zero after a
+      paid multi-stage run.
+- [ ] The creator can produce a multi-stage (`task_sequence`) agent, verified by
+      an end-to-end test — and the architecture claim is machine-checked, not
+      asserted by a reviewer.
+- [ ] `hugin create --edit <path>` shows a diff before writing and never
+      regenerates a file it has not read.
+- [ ] `hugin analyze` reports on real trace data with no LLM in the loop, and
+      `hugin improve` proposes by default and applies only on `--apply`.
 - [ ] `hugin create` runs non-interactively from flags and is covered end-to-end.
+- [ ] Schema knowledge is not duplicated further than today: measured by the
+      number of places that must change to add one `Config` field.

--- a/tasks/open/034-agent-creator-v2/description.md
+++ b/tasks/open/034-agent-creator-v2/description.md
@@ -1,0 +1,97 @@
+---
+title: Agent Creator v2
+state: OPEN
+labels: [enhancement, agent-builder]
+priority: high
+supersedes: 013-agent-builder-enhancements
+---
+
+# Agent Creator v2
+
+Significantly upgrade the meta-agent that builds Hugin agents, in five phases:
+correctness gate, unified knowledge base, architectural depth, edit-existing-agent
+mode, and finally trace-driven improvement of agents already in production.
+
+Folds in `tasks/open/013-agent-builder-enhancements.md` (read local files; embed
+and make examples searchable) — see Phase 2.
+
+## Why
+
+### The headline problem: the builder cannot build an agent as sophisticated as itself
+
+`tools/generate_task.py` emits only `name`, `description`, `parameters`, `prompt`,
+`tools`. It has no way to write `task_sequence`, `next_task`, `pass_result_as`,
+`chain_config`, or `system_template` — the exact fields that `agent_builder`'s own
+`tasks/build_agent.yaml` uses to run its 4-stage pipeline.
+
+`tools/generate_config.py` hardcodes `interactive: False` and `options: {}`, and
+cannot emit `state_namespaces`, `enable_builtin_agents`, or a `state_machine`.
+
+The consequence is that **every agent the creator produces is a single-shot loop
+with flat tools**. Sub-agents (`AgentCall`), task pipelines, branching, artifacts
+and insights, human-in-the-loop, shared state, and the bash sandbox — Hugin's
+entire differentiated feature surface — are structurally unreachable. We ship a
+framework capable of `apps/the_hugins` and a creator that generates the
+equivalent of `examples/basic_agent`.
+
+### Three creator surfaces, drifting apart
+
+| Surface | What it is | Knowledge source |
+|---|---|---|
+| `src/gimle/hugin/apps/agent_builder/` | The meta-agent: `build_agent → review_agent → finalize_agent → test_agent` | `templates/builder_system.yaml` (72 lines) |
+| `src/gimle/hugin/cli/create_agent.py` | The `hugin create` wizard (555 lines) | hardcoded model lists |
+| `skills/hugin-agent-creator/` | Claude Code plugin, 5 reference docs incl. a 449-line pattern catalog | `references/*.md` (~1770 lines) |
+
+The runtime builder never sees a single line of the skill's pattern catalog. Any
+Hugin change has to be written up in two places, and today they disagree.
+
+### Verified defects
+
+| Location | Defect |
+|---|---|
+| `tools/write_agent_files.py:60` | `shutil.rmtree(output_dir)` unconditionally. Point it at an existing directory and it is gone — no existence check, no backup, no confirmation. |
+| `tools/list_examples.py`, `tools/read_example.py` | 495 lines of example-catalog tooling **not listed in `configs/agent_builder.yaml`**. Dead code — the builder cannot study any existing example before generating. |
+| `tasks/build_agent.yaml:19`, `cli/create_agent.py:281` | `full_implementation` is asked in the wizard and declared as a task parameter, but referenced in **zero** prompts. Dead flag. |
+| `tools/write_agent_files.py:104` | Generated `README.md` tells users `uv run run-agent --task main …`. That entrypoint does not exist — `pyproject.toml:126` defines only `hugin`. Every generated agent ships broken run instructions. |
+| `tools/generate_tool.py:100-108` | Types every parameter as `str` in the emitted signature regardless of its declared schema type, then wraps the entire body in a bare `except Exception` returning only `str(e)` with no traceback. |
+| `tasks/review_agent.yaml` + `configs/reviewer.yaml` | The review stage is an LLM reading a *preview string*. Nothing ever dry-loads the environment, so a config referencing a nonexistent template or tool passes review and only fails at `test_agent` — or silently at the user's first run. |
+| `tools/test_agent.py:88-100` | Picks `configs[0]`/`tasks[0]` arbitrarily, mutates global `sys.path`, and injects the *tested* agent's templates into the *builder's* template registry. |
+| `cli/create_agent.py:167-170` | Model lists hardcoded (`sonnet-latest`, `gpt-4o`, …) instead of read from `llm/models/model_registry.py`. No non-interactive mode, so `hugin create` cannot be scripted or covered by an end-to-end test. |
+
+### What we cannot do today, and want to
+
+Run a generated agent for a while, look at its Hugin traces, and feed those back
+into the creator so it improves the agent. The storage layer already records
+everything needed (`Storage.list_sessions/list_agents/list_interactions`,
+per-interaction JSON, and `rendered_system_prompt`/`rendered_user_message` when
+`HUGIN_CAPTURE_RENDERED_PROMPTS=1`), but no tool reads it back.
+
+## Phases
+
+1. **Correctness gate** — deterministic `validate_agent`, plus the defect table above.
+2. **Unified knowledge base** — one canonical set of reference docs read by both the
+   runtime builder and the Claude Code skill; examples embedded and searchable
+   (closes 013).
+3. **Depth** — full config/task schema, architecture selection, sub-agent-capable
+   tool generation.
+4. **Edit mode** — load an existing agent and modify it instead of greenfield-only.
+5. **Trace-driven improvement** — `hugin improve`, analysing historic runs.
+
+Phases 1–4 are prerequisites for 5: trace-driven improvement is exactly Phase 4's
+edit path driven by a Phase 1 validator, informed by Phase 2/3 pattern knowledge.
+
+See `spec.md` for the design and `plan.md` for the PR breakdown.
+
+## Success Criteria
+
+- [ ] A generated agent that fails to load is impossible to write to disk — the
+      validator blocks it deterministically, without an LLM in the loop.
+- [ ] The creator can produce a multi-stage (`task_sequence`) agent and an agent
+      that delegates to sub-agents, verified by end-to-end tests.
+- [ ] Hugin reference documentation exists in exactly one place and both creator
+      surfaces read it.
+- [ ] `hugin create --edit <path>` modifies an existing agent without destroying
+      unrelated files.
+- [ ] `hugin improve <path> --storage-path <s>` produces a concrete, applied
+      improvement from real trace data.
+- [ ] `hugin create` runs non-interactively from flags and is covered end-to-end.

--- a/tasks/open/034-agent-creator-v2/plan.md
+++ b/tasks/open/034-agent-creator-v2/plan.md
@@ -54,16 +54,20 @@ The `rmtree` at `write_agent_files.py:57` is a data-loss bug and the unvalidated
 `output_dir / file_path` join at `:77-79` is an arbitrary-file-write. They ship
 together, first, alone.
 
-- [ ] Changed-only writes: never delete, write only differing files, report
-      `{written, unchanged, conflicting}`, `dry_run` flag. No `overwrite`, no
+- [x] Changed-only writes: never delete, write only differing files, report
+      `{written, unchanged, preserved}`, `dry_run` flag. No `overwrite`, no
       `.bak` (spec §1.4 explains why the backup design was dropped)
-- [ ] Path confinement + name validation (spec §1.1 checks 1-2), reusing
-      `sandbox/sandbox.py`'s `write_file_nofollow` / `reject_symlink_swap`
-- [ ] Constrain `output_path`: refuse `/`, `$HOME`, repo root, paths containing
+- [x] Path confinement + name validation (spec §1.1 checks 1-2) in
+      `tools/agent_paths.py`, mirroring `sandbox.local.LocalSandbox._confine`
+      and writing through `sandbox.sandbox.write_file_nofollow`
+- [x] Constrain `output_path`: refuse `/`, `$HOME`, repo root, paths containing
       `.git`, symlinked components
-- [ ] Unify the run command across `write_agent_files.py:91`,
-      `cli/create_agent.py:525`, `use-creator.md:137`, `create-agent.md`
-- [ ] `tests/test_write_agent_files_safety.py`, including `../` and absolute keys
+- [x] Unify the run command: `agent_paths.run_command()` now feeds both the
+      generated README and `cli/create_agent.py`'s success screen
+- [x] `tests/test_write_agent_files_safety.py` — 35 tests, including `../`,
+      absolute keys, symlink escape, and the preserve/no-op/update cases
+- [ ] Remaining: `docs/src/how-to/use-creator.md:137` and `create-agent.md`
+      still print their own run command — fold into PR 1.6's docs pass
 
 ### PR 1.2 — Examples wired in `task/034_wire_examples`
 Two lines of YAML plus three of prompt. Highest value-per-line in the document.

--- a/tasks/open/034-agent-creator-v2/plan.md
+++ b/tasks/open/034-agent-creator-v2/plan.md
@@ -8,157 +8,268 @@ state: OPEN
 Incremental PRs, each independently mergeable, each leaving `main` working.
 Branch per PR off `main`, snake_case, `task/` prefix. See `spec.md` for design.
 
-Rationale for the ordering: Phase 1's validator is the safety net every later
-phase leans on — widening the schema (Phase 3) without a validator would let the
-builder emit pipelines referencing tasks that do not exist, and Phase 5 rewrites
-agents automatically, which is only safe once writes are non-destructive (1.4)
-and incremental (4.2).
+## Sequencing rationale
+
+Revised after a five-judge panel review. Four changes to the original order:
+
+1. **Wiring `list_examples`/`read_example` moves to PR 1.2.** It is two lines of
+   YAML against tools that already work and already scan the 21 real examples.
+   It was buried as bullet 1 of a six-item grab-bag, scheduled behind a four-PR
+   knowledge migration that largely duplicates its benefit.
+2. **`hugin analyze` moves to Phase 1.5.** Read-only, zero LLM tokens, depends on
+   nothing from Phases 2-4, works on hand-written agents. It was the fifth phase
+   of a five-phase plan whose own dependency graph guaranteed it never shipped —
+   and it surfaces the storage-API problem (spec §5.1) in week one rather than
+   month four.
+3. **Phase 4 (edit) now precedes Phase 3 (depth).** The real user loop is
+   generate → 80% right → change one thing. A pipeline can be hand-written in ten
+   minutes by copying `examples/task_sequences`; a builder that can *emit*
+   pipelines but not *edit* them makes every pipeline mistake cost a full rebuild
+   at pipeline prices. PR 4.1 was already a stated prerequisite for Phase 5.
+4. **PRs that ship a tool with no caller are merged with their caller.** The
+   original 1.4/3.1/4.1 each landed dead code — reproducing the exact defect this
+   task exists to fix.
+
+**Do not itemise Phases 3-5 further until Phase 1 has actually run.** This repo's
+own proven method is task 023's: a phase spine, then standalone tasks filed *as
+each predecessor ships* — 029 was deliberately left unbuilt with the note "a
+design task, to be written after watching real agents use Phases 1-2 — do not
+build it blind." The checkboxes below get refined at each phase boundary.
+
+**Dissent, recorded.** One judge argued to cut this to three PRs and move
+Phases 2-5 to a roadmap README, on the evidence that `apps/agent_builder/`,
+`cli/create_agent.py` and `skills/hugin-agent-creator/` have not been touched
+since January 2026 and task 013 has sat open for six months, while the
+bash-sandbox series shipped ~19 PRs in six days. That evidence is real and worth
+re-reading before starting Phase 2. All five phases are kept in scope by explicit
+decision; the mitigation is the de-itemisation above and the fact that Phases 1
+and 1.5 stand alone if the rest stalls.
 
 ---
 
 ## Phase 1 — Correctness gate
 
-### PR 1.1 — `write_agent_files` safety `task/034_write_files_safety`
-The `shutil.rmtree` at `write_agent_files.py:60` is a data-loss bug; it goes
-first and alone.
+### PR 1.1 — Safe writes and path confinement `task/034_write_files_safety`
+The `rmtree` at `write_agent_files.py:57` is a data-loss bug and the unvalidated
+`output_dir / file_path` join at `:77-79` is an arbitrary-file-write. They ship
+together, first, alone.
 
-- [ ] Add `overwrite` / `dry_run` parameters; refuse a non-empty existing target
-      by default; back up to `<path>.bak.<timestamp>` when overwriting
-- [ ] Fix the generated README to `uv run hugin run --task <task> --task-path <path>`
-- [ ] `tests/test_write_agent_files_safety.py`
+- [ ] Changed-only writes: never delete, write only differing files, report
+      `{written, unchanged, conflicting}`, `dry_run` flag. No `overwrite`, no
+      `.bak` (spec §1.4 explains why the backup design was dropped)
+- [ ] Path confinement + name validation (spec §1.1 checks 1-2), reusing
+      `sandbox/sandbox.py`'s `write_file_nofollow` / `reject_symlink_swap`
+- [ ] Constrain `output_path`: refuse `/`, `$HOME`, repo root, paths containing
+      `.git`, symlinked components
+- [ ] Unify the run command across `write_agent_files.py:91`,
+      `cli/create_agent.py:525`, `use-creator.md:137`, `create-agent.md`
+- [ ] `tests/test_write_agent_files_safety.py`, including `../` and absolute keys
 
-### PR 1.2 — `validate_agent` tool `task/034_validate_agent`
-- [ ] `tools/validate_agent.py` + `.yaml`: structure, reference resolution, Jinja
-      parameter binding, tool contract, subprocess import check, subprocess dry load
-- [ ] Compact `{ok, errors, warnings, missing_dependencies, summary}` payload
-- [ ] `tests/test_validate_agent.py` — one broken fixture per check + a clean one
+### PR 1.2 — Examples wired in `task/034_wire_examples`
+Two lines of YAML plus three of prompt. Highest value-per-line in the document.
 
-### PR 1.3 — Wire the gate `task/034_validation_gate`
-- [ ] `validate_agent` in `configs/agent_builder.yaml`
-- [ ] `build_agent.yaml`: validate before `finish`, bounded repair loop (max 3)
-- [ ] `finalize_agent.yaml`: `ok: true` required before `write_agent_files`
-- [ ] Strip the now-mechanical checks (§2-§5) from `templates/reviewer_system.yaml`;
-      narrow the reviewer to description alignment
-- [ ] `hugin validate <path>` subcommand in `cli/cli.py`
-- [ ] `requirements.txt` emission from `missing_dependencies`
+- [ ] `list_examples`, `read_example` into `configs/agent_builder.yaml`
+- [ ] `builtins.read_file`, `builtins.list_files` into the same config
+- [ ] Three lines in `builder_system.yaml` telling the builder to study the
+      closest example before generating
+- [ ] `include_only_in_context_window` + small `context_window` on both, so they
+      do not accumulate in a never-truncated stack
 
-### PR 1.4 — Defect sweep `task/034_builder_defect_sweep`
-- [ ] Wire `list_examples` + `read_example` into `configs/agent_builder.yaml`
-- [ ] Remove the dead `full_implementation` flag (wizard, task, summary screen)
-- [ ] `generate_tool.py`: real type hints from the declared schema; include a
-      truncated traceback in the except branch
-- [ ] `cli/create_agent.py`: models from `model_registry.py`; non-interactive
-      flags (`--name`, `--description`, `--model`, `--builder-model`, `--output`,
-      `--yes`)
-- [ ] `tools/test_agent.py`: explicit `config_name`/`task_name`; stop polluting
-      the builder's template registry
-- [ ] End-to-end test of non-interactive `hugin create` with `MockModel`
+### PR 1.3 — `validate_agent` (static checks only) `task/034_validate_agent`
+- [ ] Checks 3-6: structure, reference resolution (reusing
+      `_BARE_TEMPLATE_REFERENCE`), Jinja binding **as warnings** with the
+      renderer-derived allowlist, AST-based tool contract
+- [ ] Compact `{ok, errors, warnings, observed_imports, summary}` payload
+- [ ] `check_imports` present but **defaulting False** (spec §1.5)
+- [ ] `tests/test_validate_agent.py` — one broken fixture per check + clean one
+- [ ] **Acceptance gate:** passes clean on every dir in `examples/` and `apps/`
+
+### PR 1.4 — The gate, in code `task/034_validation_gate`
+- [ ] `write_agent_files` calls the validator itself and refuses unless `ok`; no
+      `force` exposed to the model (spec §1.0)
+- [ ] `next_tool` chaining `validate_agent → write_agent_files`
+- [ ] Attempt counter in `env_vars`, per file, inside `validate_agent`
+- [ ] `read_generated_file(path)` + pre-repair snapshot/revert (spec §1.2b)
+- [ ] Capability-shrink check: tool/param/config-tool sets may not shrink across
+      a repair unless an error named the removed item
+- [ ] Failure path: `<output>.rejected/` + `VALIDATION_REPORT.md` + verbatim
+      errors in the CLI (spec §1.2c)
+- [ ] Strip the now-mechanical checks from `templates/reviewer_system.yaml`
+- [ ] `hugin validate <path>` subcommand, wired over `examples/`+`apps/` in CI
+
+### PR 1.5 — Stale-module and registry isolation `task/034_module_isolation`
+Without this every repair loop in every later phase re-tests cached code.
+
+- [ ] `test_agent` runs in a subprocess
+- [ ] Generated tool modules loaded via `spec_from_file_location` under
+      `<agent>__<tool>`, never a bare top-level name
+- [ ] `Registry.register(..., replace: bool = False)` raising on collision
+- [ ] `write_agent_files` stops registering into the live global registry
+- [ ] `test_agent` takes explicit `config_name`/`task_name`; stops polluting the
+      builder's template registry
+
+### PR 1.6 — CLI non-interactive + observability `task/034_cli_noninteractive`
+Its own feature, split out of the original six-item PR 1.4.
+
+- [ ] Models from `model_registry.py`, not the hardcoded lists at `:167-170`
+- [ ] `--name`, `--description`, `--model`, `--builder-model`, `--output`,
+      `--yes`, `--dry-run`, `--stub-tools`
+- [ ] Ask what to build *before* four screens of provider/credential selection
+- [ ] Per-stage progress, elapsed time, step count; token/cost on the success
+      screen
+- [ ] `BUILD_REPORT.md` in the generated directory (spec §1.4)
+- [ ] End-to-end test of non-interactive `hugin create` with `ScriptedToolModel`
+
+### PR 1.7 — Codegen quality `task/034_generate_tool_fixes`
+- [ ] Real type hints from the declared schema (`generate_tool.py:87-98`)
+- [ ] Redacted, truncated traceback in the generated except branch
+- [ ] `observed_imports` → `requirements.txt` with an import→distribution map;
+      missing deps are a **warning that still writes**, and skip `test_agent`
+- [ ] `--stub-tools` implemented (replacing the dead `full_implementation` at
+      `build_agent.yaml:19`, `create_agent.py:281,321`)
+
+---
+
+## Phase 1.5 — Read-only trace analysis
+
+Pulled forward from Phase 5. Zero LLM tokens, no dependency on Phases 2-4.
+
+### PR 1.8 — Storage access for foreign runs `task/034_trace_access`
+- [ ] Read `storage/agents/<uuid>` JSON + `load_interaction_metadata`, following
+      `cli/monitor_agents.py:671,747` — **not** `load_interaction(uuid, stack)`,
+      which needs a Stack that does not exist for historic runs (spec §5.1)
+- [ ] Decide and record: lift `load_interaction_metadata` to the `Storage` ABC,
+      or scope this to `LocalStorage` explicitly
+- [ ] Redactor + normalised error signatures, with a test asserting a seeded
+      fake key never reaches the report
+
+### PR 1.9 — `hugin analyze` `task/034_analyze_cli`
+- [ ] `analyze_traces` over the metrics in spec §5.1, top-N bounded
+- [ ] `hugin analyze <path> --storage-path <s>` printing the report
+- [ ] `tests/test_analyze_traces.py` against a synthetic storage dir
+- [ ] **Then** revise spec §5.1's metric table against one real storage dir
+      before anything consumes it
 
 ---
 
 ## Phase 2 — One knowledge base (closes task 013)
 
-### PR 2.1 — Canonical knowledge package `task/034_knowledge_package`
-- [ ] Create `src/gimle/hugin/knowledge/` with `references/` + `templates/`;
-      move the five reference docs out of `skills/hugin-agent-creator/`
-- [ ] `get_knowledge_path()`, `list_references()`, `read_reference()`
-- [ ] `pyproject.toml` package-data so it ships in the wheel
-- [ ] Repoint `skills/hugin-agent-creator/skills/*/SKILL.md` at the package path
-      with the in-repo path as development fallback
-- [ ] Test: both surfaces resolve the same dir; every file named in `SKILL.md` exists
+Re-read the dissent above before starting. PR 2.1 is the plan's most likely stall
+point, and a half-done Phase 2 leaves the plugin degraded and the builder
+unchanged.
 
-### PR 2.2 — Builder reads the knowledge base `task/034_read_reference_tool`
-- [ ] `read_reference` tool + config entry
-- [ ] Rewrite `templates/builder_system.yaml` as routing instructions; delete the
-      duplicated schema prose
-- [ ] Update `docs/src/how-to/use-creator.md`
+### PR 2.1 — Knowledge package `task/034_knowledge_package`
+- [ ] `src/gimle/hugin/knowledge/{references,templates}/`
+- [ ] `skills/hugin-agent-creator/references` keeps a **readable file** —
+      symlink, or physical copy plus a byte-identity test. No `python -c`
+      indirection (spec §2.1 lists the five breakages)
+- [ ] Hatchling `artifacts` already covers `*.md`/`*.yaml` — verify, do not add
+      setuptools `package-data`
+- [ ] Account for the five starter templates, not just the five reference docs
+- [ ] Test: both surfaces resolve the same bytes
 
-### PR 2.3 — Real example search `task/034_example_search`
-- [ ] Delete `FALLBACK_EXAMPLES`; derive the index by scanning `examples/` and
-      `apps/` (README heading, present directories, `task_sequence` usage,
-      `AgentCall` usage), cached in `env_vars`
-- [ ] `search_examples(query)` returning short snippets with file+line
-- [ ] Test: finds a known string in a known example
+### PR 2.2 — Schema into the prompt `task/034_schema_in_prompt`
+- [ ] Render the four schema references into `builder_system.yaml` from
+      `gimle.hugin.knowledge`; keep the token-efficiency and actual-Python rules
+- [ ] `read_reference(topic)` for `patterns.md` only, `topic` restricted to an
+      enumerated literal set
+- [ ] Derive `validate_agent`'s known-field checks from
+      `dataclasses.fields(Config)` / `Task` (spec §2.1b)
+- [ ] **Gated on the golden-set harness showing no regression**
+- [ ] Record places-to-change-per-`Config`-field, before and after
+
+### PR 2.3 — Example index `task/034_example_search`
+- [ ] Derive the index from `examples/`+`apps/`; **keep** a packaged curated set
+      as the installed-wheel path — do not delete `FALLBACK_EXAMPLES` blind
+- [ ] `search_examples(query)`, bounded by extension, size and file count
+- [ ] Test: usable index with `examples/` absent
 
 ### PR 2.4 — User reference files `task/034_reference_files`
-- [ ] `builtins.read_file` + `builtins.list_files` into the builder config
-- [ ] `reference_files` parameter on `build_agent`; `--reference-file` on the wizard
-- [ ] **Closes `tasks/open/013-agent-builder-enhancements.md`** — move it to
+- [ ] `reference_files` parameter + `--reference-file`, wrapped in a delimited
+      untrusted block, size- and count-capped
+- [ ] **Closes `tasks/open/013-agent-builder-enhancements.md`** — move to
       `tasks/closed/` in this PR
 
----
+### PR 2.5 — Golden-set eval harness `task/034_eval_harness`
+Ship before 2.2 lands. Nothing else in this plan measures the model.
 
-## Phase 3 — Architectural depth
-
-### PR 3.1 — Full task and config schema `task/034_full_schema`
-- [ ] `generate_task`: `task_sequence`, `next_task`, `pass_result_as`,
-      `chain_config`, `system_template`
-- [ ] `generate_config`: `interactive`, `state_namespaces`,
-      `enable_builtin_agents`, `options`; stop force-appending
-      `save_text`/`save_file`
-- [ ] Extend `validate_agent`: sequence/successor names must exist,
-      `pass_result_as` must name a declared parameter of the successor
-- [ ] Tests for each new field, including the cross-reference failures
-
-### PR 3.2 — Architecture selection `task/034_architecture_selection`
-- [ ] `architecture` parameter (categorical list, `auto` default) on `build_agent`
-- [ ] Architecture → reference-example mapping in the builder prompt
-- [ ] Reviewer checks the choice against the description
-- [ ] `--architecture` flag on `hugin create`
-- [ ] Per-architecture build test with `MockModel`, each asserted to validate clean
-
-### PR 3.3 — Sub-agent-capable tools `task/034_agent_call_tools`
-- [ ] `return_type: tool_response | agent_call` on `generate_tool`
-- [ ] Emit the `Union[ToolResponse, AgentCall]` form with config/task lookup
-- [ ] End-to-end test: generated delegating agent spawns a child and completes
+- [ ] 10-20 descriptions spanning the architectures
+- [ ] Scored run behind `slow`/`integration`: first-pass validation rate,
+      post-repair rate, attempts used, architecture match, `test_agent` success,
+      steps, tokens, dollars
+- [ ] Numbers recorded in this task file per PR
 
 ---
 
-## Phase 4 — Edit an existing agent
+## Phase 3 — Edit an existing agent
 
-### PR 4.1 — Load and incremental write `task/034_load_agent_files`
-- [ ] `load_agent_files` tool returning a manifest only
-- [ ] `write_agent_files(changed_only=True)` reporting written vs unchanged
-- [ ] Round-trip test: one regenerated file touches exactly one file on disk and
-      leaves a hand-added unrelated file intact
+*(Was Phase 4. Reordered — see rationale.)*
 
-### PR 4.2 — `edit_agent` task and CLI `task/034_edit_agent`
-- [ ] `tasks/edit_agent.yaml`
-- [ ] `hugin create --edit <path> --instruction "..."`
-- [ ] Docs + end-to-end test ("add a tool to this agent")
+### PR 3.1 — Load, read, diff, edit `task/034_edit_agent`
+Merged from the original 4.1+4.2: `load_agent_files` alone had no caller.
 
-### PR 4.3 — Interactive builder `task/034_interactive_builder`
+- [ ] `load_agent_files` (manifest) + `read_generated_file` from PR 1.4, so the
+      builder never regenerates a file it has not read (spec §4.1)
+- [ ] `tasks/edit_agent.yaml`; `hugin create --edit <path> --instruction "..."`
+- [ ] Unified diff + y/n confirmation before writing; `--dry-run` on `create` too
+- [ ] Authorised-write allowlist; git dirty-tree guard; provenance markers
+- [ ] Round-trip test: one regenerated file touches exactly one file and leaves a
+      hand-added unrelated file intact
+
+### PR 3.2 — Interactive builder `task/034_interactive_builder`
 - [ ] `agent_builder_interactive` config with `builtins.ask_user`
 - [ ] `hugin create --interactive`; default unchanged
 
 ---
 
+## Phase 4 — Architectural depth
+
+*(Was Phase 3.)*
+
+### PR 4.1 — Pipeline architecture, end to end `task/034_pipeline_architecture`
+Merged from the original 3.1+3.2, scoped to **one** architecture. Splitting them
+would ship task-schema parameters no prompt mentions plus a new failure mode.
+
+- [ ] `generate_task`: `task_sequence`, `next_task`, `pass_result_as`,
+      `chain_config`, `system_template`
+- [ ] `generate_config`: `interactive`, `state_namespaces`,
+      `enable_builtin_agents`, `options`; stop force-appending
+      `save_text`/`save_file` — and remove that assertion from all four places
+      (`generate_config.py:34-42`, `builder_system.yaml:14`,
+      `build_agent.yaml:48-50`, `reviewer_system.yaml:24-27`)
+- [ ] `architecture` as `type: array` with per-item validation — **not**
+      `categorical`, which cannot hold a list (spec §3.3)
+- [ ] Architecture invariants machine-checked in `validate_agent`
+- [ ] Selection as a separate cheap structured turn, not a mid-generation choice
+- [ ] `knowledge/references/*.md` updated in this same PR
+- [ ] Golden-set harness re-run
+
+### PR 4.2 — Further architectures `task/034_more_architectures`
+Add only on demand. `delegating` needs `generate_tool`'s
+`return_type: agent_call`; `shell` needs the sandbox posture rules in spec §3.3
+(`backend: docker` default, hard-fail on `allow_unrestricted_egress`,
+`network: false` until tasks 030/030b) plus a session-level agent-count cap.
+
+---
+
 ## Phase 5 — Trace-driven improvement
 
-Gated on Phases 1-4. Do not start before PR 4.1 merges — automated rewriting of a
-working agent is only safe on top of validated, incremental, non-destructive
-writes.
+Gated on PR 3.1. `hugin analyze` already shipped in Phase 1.5.
 
-### PR 5.1 — `analyze_traces` `task/034_analyze_traces`
-- [ ] Tool over the `Storage` API: success rate, step exhaustion, step
-      percentiles, per-tool call/error counts and top errors, dead tools,
-      oversized results, detected loops
-- [ ] Bounded report payload (top-N truncation on every list)
-- [ ] `tests/test_analyze_traces.py` against a synthetic storage dir produced by
-      running a fixture agent with `MockModel`
+### PR 5.1 — `improve_agent`, propose-only `task/034_improve_agent`
+- [ ] `propose_change(file, change_type, metric, observed_value, rationale)`
+      validating against the stored report — rejects uncited or mismatched
+      claims structurally (spec §5.2)
+- [ ] Trace-derived strings in a delimited untrusted block, never instructions
+- [ ] Replay set harvested from real trace parameters
+- [ ] Proposal printed as a diff; **no write path in this PR**
 
-### PR 5.2 — `improve_agent` `task/034_improve_agent`
-- [ ] `tasks/improve_agent.yaml`: analyze → load → evidence-linked proposal →
-      apply → validate → write → test
-- [ ] Every proposed change must cite the metric that motivated it
-- [ ] End-to-end test on an agent with a deliberately dead tool and a
-      deliberately oversized tool result
-
-### PR 5.3 — `hugin improve` CLI `task/034_improve_cli`
-- [ ] `hugin improve <path> --storage-path <s> [--limit N] [--dry-run]`
-- [ ] `--dry-run` prints the proposal without touching files
-- [ ] `docs/src/how-to/improve-agents.md`; note that
-      `HUGIN_CAPTURE_RENDERED_PROMPTS=1` materially enriches the analysis
+### PR 5.2 — `--apply` with a regression guard `task/034_improve_apply`
+- [ ] Before/after replay on identical harvested inputs via `test_agent`
+- [ ] Agent-directory hash stamped into session metadata for attribution
+- [ ] `dead_tools` proposals are warnings with a minimum-N threshold, never
+      automatic deletions
+- [ ] `--apply` opt-in, after a diff, with the revert path named in the output
 
 ---
 
@@ -167,7 +278,20 @@ writes.
 - [ ] `uv run pre-commit run --all-files` clean (mypy's pre-existing
       `openai/_client.py` failure excepted)
 - [ ] `uv run pytest -x -q` passes
-- [ ] New behaviour covered by tests
-- [ ] Docs updated when user-facing (`docs/src/how-to/use-creator.md`, CLAUDE.md)
+- [ ] New behaviour covered by tests, using `ScriptedToolModel` — **not**
+      `MockModel`, which cannot emit tool calls
+- [ ] `hugin validate` still clean over `examples/` and `apps/`
+- [ ] Docs updated when user-facing; schema changes update
+      `knowledge/references/*.md` in the same PR
 - [ ] Checkboxes ticked in this file as part of the PR
 - [ ] Reviewed with `/panel-review` before merge for anything beyond a defect fix
+
+## Docs owed (not yet scheduled to a PR)
+
+`docs/src/how-to/troubleshoot-builds.md` — the validator's error catalogue with a
+fix for each, what a missing dependency means, how to retry, roughly what a build
+costs. Given the failure path in spec §1.2c, this is the page users will actually
+open. Also: `hugin validate`, `hugin analyze`, the non-interactive flags,
+`--architecture`, `--reference-file`, `--edit`, and a model table generated from
+`model_registry.py` rather than restated (`use-creator.md:71-73` is already stale
+against `create_agent.py:167-170`).

--- a/tasks/open/034-agent-creator-v2/plan.md
+++ b/tasks/open/034-agent-creator-v2/plan.md
@@ -1,0 +1,173 @@
+---
+title: Agent Creator v2 — Implementation Plan
+state: OPEN
+---
+
+# Agent Creator v2 — Implementation Plan
+
+Incremental PRs, each independently mergeable, each leaving `main` working.
+Branch per PR off `main`, snake_case, `task/` prefix. See `spec.md` for design.
+
+Rationale for the ordering: Phase 1's validator is the safety net every later
+phase leans on — widening the schema (Phase 3) without a validator would let the
+builder emit pipelines referencing tasks that do not exist, and Phase 5 rewrites
+agents automatically, which is only safe once writes are non-destructive (1.4)
+and incremental (4.2).
+
+---
+
+## Phase 1 — Correctness gate
+
+### PR 1.1 — `write_agent_files` safety `task/034_write_files_safety`
+The `shutil.rmtree` at `write_agent_files.py:60` is a data-loss bug; it goes
+first and alone.
+
+- [ ] Add `overwrite` / `dry_run` parameters; refuse a non-empty existing target
+      by default; back up to `<path>.bak.<timestamp>` when overwriting
+- [ ] Fix the generated README to `uv run hugin run --task <task> --task-path <path>`
+- [ ] `tests/test_write_agent_files_safety.py`
+
+### PR 1.2 — `validate_agent` tool `task/034_validate_agent`
+- [ ] `tools/validate_agent.py` + `.yaml`: structure, reference resolution, Jinja
+      parameter binding, tool contract, subprocess import check, subprocess dry load
+- [ ] Compact `{ok, errors, warnings, missing_dependencies, summary}` payload
+- [ ] `tests/test_validate_agent.py` — one broken fixture per check + a clean one
+
+### PR 1.3 — Wire the gate `task/034_validation_gate`
+- [ ] `validate_agent` in `configs/agent_builder.yaml`
+- [ ] `build_agent.yaml`: validate before `finish`, bounded repair loop (max 3)
+- [ ] `finalize_agent.yaml`: `ok: true` required before `write_agent_files`
+- [ ] Strip the now-mechanical checks (§2-§5) from `templates/reviewer_system.yaml`;
+      narrow the reviewer to description alignment
+- [ ] `hugin validate <path>` subcommand in `cli/cli.py`
+- [ ] `requirements.txt` emission from `missing_dependencies`
+
+### PR 1.4 — Defect sweep `task/034_builder_defect_sweep`
+- [ ] Wire `list_examples` + `read_example` into `configs/agent_builder.yaml`
+- [ ] Remove the dead `full_implementation` flag (wizard, task, summary screen)
+- [ ] `generate_tool.py`: real type hints from the declared schema; include a
+      truncated traceback in the except branch
+- [ ] `cli/create_agent.py`: models from `model_registry.py`; non-interactive
+      flags (`--name`, `--description`, `--model`, `--builder-model`, `--output`,
+      `--yes`)
+- [ ] `tools/test_agent.py`: explicit `config_name`/`task_name`; stop polluting
+      the builder's template registry
+- [ ] End-to-end test of non-interactive `hugin create` with `MockModel`
+
+---
+
+## Phase 2 — One knowledge base (closes task 013)
+
+### PR 2.1 — Canonical knowledge package `task/034_knowledge_package`
+- [ ] Create `src/gimle/hugin/knowledge/` with `references/` + `templates/`;
+      move the five reference docs out of `skills/hugin-agent-creator/`
+- [ ] `get_knowledge_path()`, `list_references()`, `read_reference()`
+- [ ] `pyproject.toml` package-data so it ships in the wheel
+- [ ] Repoint `skills/hugin-agent-creator/skills/*/SKILL.md` at the package path
+      with the in-repo path as development fallback
+- [ ] Test: both surfaces resolve the same dir; every file named in `SKILL.md` exists
+
+### PR 2.2 — Builder reads the knowledge base `task/034_read_reference_tool`
+- [ ] `read_reference` tool + config entry
+- [ ] Rewrite `templates/builder_system.yaml` as routing instructions; delete the
+      duplicated schema prose
+- [ ] Update `docs/src/how-to/use-creator.md`
+
+### PR 2.3 — Real example search `task/034_example_search`
+- [ ] Delete `FALLBACK_EXAMPLES`; derive the index by scanning `examples/` and
+      `apps/` (README heading, present directories, `task_sequence` usage,
+      `AgentCall` usage), cached in `env_vars`
+- [ ] `search_examples(query)` returning short snippets with file+line
+- [ ] Test: finds a known string in a known example
+
+### PR 2.4 — User reference files `task/034_reference_files`
+- [ ] `builtins.read_file` + `builtins.list_files` into the builder config
+- [ ] `reference_files` parameter on `build_agent`; `--reference-file` on the wizard
+- [ ] **Closes `tasks/open/013-agent-builder-enhancements.md`** — move it to
+      `tasks/closed/` in this PR
+
+---
+
+## Phase 3 — Architectural depth
+
+### PR 3.1 — Full task and config schema `task/034_full_schema`
+- [ ] `generate_task`: `task_sequence`, `next_task`, `pass_result_as`,
+      `chain_config`, `system_template`
+- [ ] `generate_config`: `interactive`, `state_namespaces`,
+      `enable_builtin_agents`, `options`; stop force-appending
+      `save_text`/`save_file`
+- [ ] Extend `validate_agent`: sequence/successor names must exist,
+      `pass_result_as` must name a declared parameter of the successor
+- [ ] Tests for each new field, including the cross-reference failures
+
+### PR 3.2 — Architecture selection `task/034_architecture_selection`
+- [ ] `architecture` parameter (categorical list, `auto` default) on `build_agent`
+- [ ] Architecture → reference-example mapping in the builder prompt
+- [ ] Reviewer checks the choice against the description
+- [ ] `--architecture` flag on `hugin create`
+- [ ] Per-architecture build test with `MockModel`, each asserted to validate clean
+
+### PR 3.3 — Sub-agent-capable tools `task/034_agent_call_tools`
+- [ ] `return_type: tool_response | agent_call` on `generate_tool`
+- [ ] Emit the `Union[ToolResponse, AgentCall]` form with config/task lookup
+- [ ] End-to-end test: generated delegating agent spawns a child and completes
+
+---
+
+## Phase 4 — Edit an existing agent
+
+### PR 4.1 — Load and incremental write `task/034_load_agent_files`
+- [ ] `load_agent_files` tool returning a manifest only
+- [ ] `write_agent_files(changed_only=True)` reporting written vs unchanged
+- [ ] Round-trip test: one regenerated file touches exactly one file on disk and
+      leaves a hand-added unrelated file intact
+
+### PR 4.2 — `edit_agent` task and CLI `task/034_edit_agent`
+- [ ] `tasks/edit_agent.yaml`
+- [ ] `hugin create --edit <path> --instruction "..."`
+- [ ] Docs + end-to-end test ("add a tool to this agent")
+
+### PR 4.3 — Interactive builder `task/034_interactive_builder`
+- [ ] `agent_builder_interactive` config with `builtins.ask_user`
+- [ ] `hugin create --interactive`; default unchanged
+
+---
+
+## Phase 5 — Trace-driven improvement
+
+Gated on Phases 1-4. Do not start before PR 4.1 merges — automated rewriting of a
+working agent is only safe on top of validated, incremental, non-destructive
+writes.
+
+### PR 5.1 — `analyze_traces` `task/034_analyze_traces`
+- [ ] Tool over the `Storage` API: success rate, step exhaustion, step
+      percentiles, per-tool call/error counts and top errors, dead tools,
+      oversized results, detected loops
+- [ ] Bounded report payload (top-N truncation on every list)
+- [ ] `tests/test_analyze_traces.py` against a synthetic storage dir produced by
+      running a fixture agent with `MockModel`
+
+### PR 5.2 — `improve_agent` `task/034_improve_agent`
+- [ ] `tasks/improve_agent.yaml`: analyze → load → evidence-linked proposal →
+      apply → validate → write → test
+- [ ] Every proposed change must cite the metric that motivated it
+- [ ] End-to-end test on an agent with a deliberately dead tool and a
+      deliberately oversized tool result
+
+### PR 5.3 — `hugin improve` CLI `task/034_improve_cli`
+- [ ] `hugin improve <path> --storage-path <s> [--limit N] [--dry-run]`
+- [ ] `--dry-run` prints the proposal without touching files
+- [ ] `docs/src/how-to/improve-agents.md`; note that
+      `HUGIN_CAPTURE_RENDERED_PROMPTS=1` materially enriches the analysis
+
+---
+
+## Definition of done (per PR)
+
+- [ ] `uv run pre-commit run --all-files` clean (mypy's pre-existing
+      `openai/_client.py` failure excepted)
+- [ ] `uv run pytest -x -q` passes
+- [ ] New behaviour covered by tests
+- [ ] Docs updated when user-facing (`docs/src/how-to/use-creator.md`, CLAUDE.md)
+- [ ] Checkboxes ticked in this file as part of the PR
+- [ ] Reviewed with `/panel-review` before merge for anything beyond a defect fix

--- a/tasks/open/034-agent-creator-v2/plan.md
+++ b/tasks/open/034-agent-creator-v2/plan.md
@@ -54,17 +54,20 @@ The `rmtree` at `write_agent_files.py:57` is a data-loss bug and the unvalidated
 `output_dir / file_path` join at `:77-79` is an arbitrary-file-write. They ship
 together, first, alone.
 
-- [x] Changed-only writes: never delete, write only differing files, report
-      `{written, unchanged, preserved}`, `dry_run` flag. No `overwrite`, no
-      `.bak` (spec §1.4 explains why the backup design was dropped)
+- [x] Changed-only writes: refuse unknown or user-modified conflicts; track
+      session-written files per output path and content hash so only unchanged,
+      builder-owned files can be updated or removed when superseded. Report
+      `{written, unchanged, removed, preserved}` and support `dry_run`. No
+      `overwrite` escape hatch and no `.bak` siblings (spec §1.4 explains why
+      the backup design was dropped)
 - [x] Path confinement + name validation (spec §1.1 checks 1-2) in
       `tools/agent_paths.py`, mirroring `sandbox.local.LocalSandbox._confine`
-      and writing through `sandbox.sandbox.write_file_nofollow`
+      plus descriptor-relative, atomic writes that refuse symlinks at every hop
 - [x] Constrain `output_path`: refuse `/`, `$HOME`, repo root, paths containing
       `.git`, symlinked components
 - [x] Unify the run command: `agent_paths.run_command()` now feeds both the
       generated README and `cli/create_agent.py`'s success screen
-- [x] `tests/test_write_agent_files_safety.py` — 35 tests, including `../`,
+- [x] `tests/test_write_agent_files_safety.py` — 58 tests, including `../`,
       absolute keys, symlink escape, and the preserve/no-op/update cases
 - [ ] Remaining: `docs/src/how-to/use-creator.md:137` and `create-agent.md`
       still print their own run command — fold into PR 1.6's docs pass

--- a/tasks/open/034-agent-creator-v2/spec.md
+++ b/tasks/open/034-agent-creator-v2/spec.md
@@ -65,8 +65,9 @@ Checks 6-7 execute it and are **opt-in, off by default** (see §1.5).
    `os.path.normpath` starts with `..`; after resolution, `target.resolve()` must
    be relative to `root.resolve()`; no component may be a symlink. This is a
    **blocking error, not a warning** — see the trust-boundary note in
-   `description.md`. Reuse `sandbox/sandbox.py`'s existing `write_file_nofollow`
-   / `reject_symlink_swap` helpers rather than writing new ones.
+   `description.md`. Walk the output path through directory descriptors opened
+   with `O_NOFOLLOW`, then write and replace relative to the secured parent;
+   protecting only the final filename leaves intermediate-component races.
 2. **Reserved names** — no generated tool, config, task or template name may
    collide with a registered builtin, one of the builder's own tools, or
    `sys.stdlib_module_names`. Without this, `utils/registry.py:20` silently
@@ -247,20 +248,21 @@ silently useless, and it is not optional to fix.
 
 **`write_agent_files.py` — stop destroying directories.** The first draft
 proposed backup-to-`.bak.<timestamp>`, then Phase 4 proposed incremental writes,
-which are incompatible designs for the same tool. Do the incremental model
-**once, here**, and never delete:
+which are incompatible designs for the same tool. Do the ownership-aware
+incremental model **once, here**:
 
 ```python
 def write_agent_files(stack, output_path, agent_name="",
                       dry_run: bool = False)   # always changed-only
 ```
 
-- Write only files whose content differs from disk. Report
-  `{written, unchanged, preserved}` — `preserved` being files already in the
-  directory that the builder does not manage. (Drafted as `conflicting`; there
-  is no conflict once writes are additive, and naming them `preserved` says the
-  useful thing: these are exactly what the old `rmtree` destroyed silently.)
-- A file present on disk that the builder did not generate is **never** touched.
+- Track files actually written by this builder session by resolved output path
+  and content hash. A differing file is updated only when its current hash still
+  matches that record; unknown or user-modified files are blocking conflicts.
+- Remove a superseded file only when that same scoped ownership record still
+  matches its content. Modified and unknown files are **never** touched.
+- Report `{written, unchanged, removed, preserved}` — `preserved` being files
+  already in the directory that the builder does not manage.
 - `dry_run=True` → return the file list and bodies that *would* be written,
   writing nothing.
 - No `rmtree`, no `overwrite` flag, no `.bak` siblings. Backups were their own

--- a/tasks/open/034-agent-creator-v2/spec.md
+++ b/tasks/open/034-agent-creator-v2/spec.md
@@ -14,6 +14,29 @@ All paths are relative to the repo root. The meta-agent lives at
 
 ## Phase 1 — Deterministic correctness gate
 
+### 1.0 The gate must live in code
+
+The first draft of this spec put the gate in a prompt — "`finalize_agent.yaml`:
+`validate_agent` must return `ok: true` before `write_agent_files` is called."
+That is a request, not an enforcement point, and it is the same class of
+guarantee this task exists to remove. Two instructions in this very directory
+already demonstrate the failure: `finalize_agent.yaml:35-53` branches on
+APPROVED/NEEDS_FIXES with nothing preventing a write under NEEDS_FIXES, and
+`test_agent.yaml:53` says "Maximum 3 fix iterations" with no counter anywhere in
+code.
+
+The gate is therefore **inside `write_agent_files`**: it calls the validator on
+`env_vars["generated_files"]` itself and returns `is_error=True` unless `ok`.
+No `force` parameter is exposed to the model (the CLI may pass one; the builder
+cannot). Repair attempts are counted in `env_vars` by `validate_agent`, not in
+prose. Where a deterministic hand-off is wanted, use
+`ToolResponse.next_tool`/`next_tool_args` (`tools/tool.py:78-79`, honoured at
+`interaction/tool_result.py:85-98`) so the model never gets a turn in which
+skipping the gate is expressible.
+
+Prompts may still *ask* for validation — that improves the odds of a clean first
+pass. They are never what makes it safe.
+
 ### 1.1 `validate_agent` tool
 
 New tool `apps/agent_builder/tools/validate_agent.py` (+ `.yaml`). It is the
@@ -34,35 +57,58 @@ When `agent_path` is omitted it validates the in-memory
 `env_vars["generated_files"]` by materialising them into a `TemporaryDirectory`.
 This lets it run *before* anything touches the user's filesystem.
 
-Checks, in order (cheapest first, all deterministic — no LLM):
+Checks 1-5 are static — they parse files and never execute generated code.
+Checks 6-7 execute it and are **opt-in, off by default** (see §1.5).
 
-1. **Structure** — `configs/` and `tasks/` exist and are non-empty; every
+1. **Path confinement** — every key in `generated_files` matches
+   `[a-z][a-z0-9_]*/[a-z][a-z0-9_]*\.(yaml|py)`; no absolute keys; no key whose
+   `os.path.normpath` starts with `..`; after resolution, `target.resolve()` must
+   be relative to `root.resolve()`; no component may be a symlink. This is a
+   **blocking error, not a warning** — see the trust-boundary note in
+   `description.md`. Reuse `sandbox/sandbox.py`'s existing `write_file_nofollow`
+   / `reject_symlink_swap` helpers rather than writing new ones.
+2. **Reserved names** — no generated tool, config, task or template name may
+   collide with a registered builtin, one of the builder's own tools, or
+   `sys.stdlib_module_names`. Without this, `utils/registry.py:20` silently
+   replaces the real implementation process-wide.
+3. **Structure** — `configs/` and `tasks/` exist and are non-empty; every
    `tools/*.py` has a sibling `.yaml` and vice versa.
-2. **Reference resolution**
+4. **Reference resolution**
    - `config.system_template` resolves to a registered template name, or is an
-     inline Jinja string (contains `{{`). A bare string matching neither is the
-     failure mode that `tasks/open/019-warn-on-unknown-template-reference.md`
-     already flags — reuse that check.
+     inline prompt. Only flag when it *looks like* a reference — reuse the
+     identifier-only heuristic `_BARE_TEMPLATE_REFERENCE` at
+     `agent/environment.py:26`, so plain-prose system prompts are not rejected.
    - Every entry in `config.tools` resolves: `builtins.X:Y` exists in the builtin
      registry, or `X` names a generated tool.
    - `task.tools`, when present, is a subset of the resolvable tool set.
-3. **Jinja parameter binding** — parse each task `prompt` and `system_template`
-   with `jinja2.meta.find_undeclared_variables` over `Environment().parse(src)`.
-   Every undeclared root variable must be a declared task parameter. This catches
-   `{{ ticker.value }}` where `ticker` was never declared — the most common
-   silent breakage, and one the current pipeline cannot see at all.
-4. **Tool contract** — each `tools/*.py` compiles (`compile(src, path, "exec")`);
-   the function named by the YAML's `implementation_path` (`mod:func`) exists;
-   its signature accepts `stack`; every parameter in the YAML `parameters` block
-   appears in the signature.
-5. **Import check** (`check_imports=True`) — import each tool module in a
-   **subprocess** (`python -c "import importlib.util; …"`) so a broken or
-   side-effecting module cannot poison the builder process. `ModuleNotFoundError`
-   is reported as a *missing dependency* with the module name, not as a generic
-   failure — this feeds §1.3.
-6. **Dry load** — `Environment.load(tmpdir, storage=LocalStorage(tmp))` in the
-   same subprocess. Any exception is a hard failure with the traceback's last
-   frame.
+5. **Jinja parameter binding** — parse each task `prompt` with
+   `jinja2.meta.find_undeclared_variables`. An undeclared root variable is an
+   error only if it is not in the renderer-provided allowlist. That allowlist is
+   large and must be derived from the code, not guessed:
+   `llm/prompt/renderer.py:136-147` merges in **every registered template name**
+   plus `agent` and `format_df_to_string`; `renderer.py:171` injects `learnings`;
+   `renderer.__getattr__` exposes `stack` and agent attributes; and
+   `interaction/task_chain.py:118-128` **creates** the parameter named by an
+   upstream task's `pass_result_as` at runtime even when the successor never
+   declared it. Ship this check as a **warning** until its false-positive rate is
+   measured against the repo's own agents.
+   For `system_template`, warning only — a system template is rendered against
+   several different input sets over an agent's lifetime
+   (`interaction/ask_oracle.py:84-87,155-158,186-188`).
+   Add a separate warning for a declared parameter referenced without `.value`
+   (`{{ ticker }}` renders a dict repr into the prompt) — the more common bug,
+   and one the original spec missed.
+6. **Tool contract** — **AST-based, no import**: `ast.parse` each `tools/*.py`,
+   locate the `FunctionDef` named by the YAML's `implementation_path` (`mod:func`),
+   assert it exists, accepts `stack`, and covers every parameter in the YAML
+   `parameters` block. Also check the module name against
+   `importlib.util.find_spec` for stdlib shadowing.
+7. **Import check and dry load** (`check_imports=True`, **default False**) —
+   see §1.5.
+
+**Acceptance test for the whole checker:** `hugin validate` must pass clean on
+every directory in `examples/` and `apps/`, wired into CI. If it does not, the
+check is wrong about the framework, not right about the shipped agents.
 
 Return payload is deliberately small (the builder's own system template mandates
 token-efficient tools, and today none of its tools obey it):
@@ -82,13 +128,13 @@ needs to look.
 
 ### 1.2 Wiring the gate
 
-- `tasks/build_agent.yaml`: call `validate_agent` before `finish`; loop on errors
-  (bounded, max 3 attempts) rather than handing garbage to the reviewer.
-- `tasks/finalize_agent.yaml`: `validate_agent` **must** return `ok: true` before
-  `write_agent_files` is called. This is the enforcement point.
+- The gate itself is inside `write_agent_files` (§1.0).
 - `configs/agent_builder.yaml`: add `validate_agent` to `tools`.
+- `tasks/build_agent.yaml`: ask for validation before `finish` — advisory, to
+  improve first-pass odds.
 - New CLI subcommand `hugin validate <agent_path>` in `cli/cli.py` so humans and
   CI can run the same checks on any agent directory, generated or handwritten.
+  Wire it over `examples/` and `apps/` in `.github/workflows/ci.yml`.
 
 The LLM reviewer (`review_agent`) survives, but its remit narrows to what a
 machine cannot judge: *does this agent actually match the description?* All the
@@ -96,40 +142,157 @@ mechanical checks currently in `templates/reviewer_system.yaml` (§2 required
 builtins, §3 parameter schema, §4 return statement, §5 valid Python) move to the
 validator and are deleted from the prompt.
 
+Because `TaskChain.step` chains on the same stack and agent
+(`interaction/task_chain.py:78-188`) and `render_stack_context`
+(`interaction/stack.py:199-300`) continues rendering past a `TaskResult`, the
+reviewer currently sees the entire build transcript — it is reviewing its own
+work. Run it as an `AgentCall` sub-agent with a fresh context (description +
+files only). That is both cheaper and an actual second opinion.
+
+### 1.2b Repair loop
+
+A bounded repair loop is only safe with three properties the first draft lacked:
+
+- **The model can read back one file.** `preview_files` dumps all of them and
+  the `generate_*` tools overwrite wholesale, so "repair" today means re-emitting
+  a whole file from a one-line error. Add `read_generated_file(path)`.
+- **A failed repair reverts.** Snapshot each file in `env_vars` before a repair;
+  restore on regression. Otherwise attempt 3 is worse-informed than attempt 1 and
+  error counts oscillate instead of descending.
+- **Repair cannot delete the problem.** Every check has a cheap destructive fix:
+  drop the tool, delete the interpolation, remove the import. Make it a blocking
+  error for the set of tool names, task parameters, or config tools to *shrink*
+  across a repair unless an error explicitly named the removed item.
+
+Count attempts **per file**, in `env_vars`, inside `validate_agent`. Note that
+Anthropic models here run `max_tokens=5000` (`llm/models/anthropic.py:21`), so a
+full tool regeneration in one tool-call argument can truncate mid-code — raise it
+for the builder config.
+
+### 1.2c Failure path
+
+If repair is exhausted, the user must not get a silent zero after a paid
+multi-stage run. Write the last payload to `<output_path>.rejected/` with a
+`VALIDATION_REPORT.md`, print the validator's errors verbatim in the CLI, tell
+the user `hugin validate <path>` re-checks after a hand-fix, and `finish` with
+`failure`. Today `cli/create_agent.py:489` prints "Reached maximum steps" and
+`generated_files` — memory-only — is discarded.
+
 ### 1.3 Dependency declaration
 
 Generated agents routinely import `yfinance`, `pandas`, `requests` — none
-guaranteed present. `validate_agent`'s `missing_dependencies` gets written to a
-`requirements.txt` in the generated agent directory and surfaced in its README
-and in the `hugin create` success screen. We do not auto-install.
+guaranteed present. These are reported as **observed imports**, written to a
+`requirements.txt` and surfaced in the README and the `hugin create` success
+screen with `uv pip install -r <path>/requirements.txt`. We do not auto-install.
+
+Two constraints the first draft got wrong:
+
+- **A missing dependency is a warning that still writes.** It is the single most
+  common shape of a *correct* agent, and `agent/environment.py:157-160` already
+  degrades a failed tool import to a `logger.warning`. Blocking on it would mean
+  a working pandas agent can never be written. It also means `test_agent` is
+  **skipped**, not retried three times, when dependencies are known-missing.
+- **Import name ≠ distribution name.** `yaml`→`PyYAML`, `bs4`→`beautifulsoup4`,
+  `cv2`→`opencv-python`, `sklearn`→`scikit-learn`. Map the common cases and mark
+  anything unmapped as unverified — the names come from an LLM and may be
+  hallucinated or typosquatted.
+
+### 1.5 Executing generated code
+
+Checks 6-7 (import each tool module, `Environment.load` the tree) execute
+LLM-authored Python. Three things follow:
+
+- **Do not call a subprocess a sandbox.** It is a crash boundary. It inherits the
+  full environment — `ANTHROPIC_API_KEY`, cloud credentials, cwd, network, home
+  directory write access. And it is void regardless, because
+  `write_agent_files.py:110` calls `load_agent_from_path` → `importlib.import_module`
+  in the builder process seconds later, and `test_agent` then runs the generated
+  code in the same session.
+- **Default `check_imports=False` for v1.** These are the expensive checks and
+  they catch the rarer bugs; checks 1-6 catch the common ones without executing
+  anything. Ship them opt-in.
+- **When they do run, harden them as a correctness tool:** `sys.executable`,
+  `start_new_session=True` with process-group kill, `timeout=10`, `cwd=tmpdir`,
+  `stdin=DEVNULL`, scrubbed `env`, and `resource` rlimits. Without a timeout, a
+  module that blocks at import hangs the builder forever.
+
+Validator and writer must share **one** materialisation function so their view of
+the tree cannot diverge (`write_agent_files.py:63-73` adds `__init__.py` files the
+validator's tempdir would otherwise lack), and the dry load must replicate
+`Environment.load`'s `sys.path` insertion of `tools/`.
+
+### 1.6 Stale-module and registry isolation
+
+`tools/tool.py:154` imports by flat module name with no reload, so after a repair
+`test_agent` re-tests the **cached old code**, sees the identical failure, and
+burns every attempt. This makes every repair loop in every phase of this task
+silently useless, and it is not optional to fix.
+
+- Run `test_agent` in a subprocess.
+- Load generated tool modules via `importlib.util.spec_from_file_location` under
+  a namespaced name (`<agent>__<tool>`), never a bare top-level name.
+- Namespace registry keys per loaded agent, and add
+  `Registry.register(..., replace: bool = False)` that raises on silent
+  collision rather than overwriting (`utils/registry.py:20`).
+- Stop `write_agent_files` registering generated tools into the live global
+  registry, or register them under a prefix.
 
 ### 1.4 Defect fixes
 
-**`write_agent_files.py` — stop destroying directories.** Replace the
-unconditional `shutil.rmtree(output_dir)` with:
+**`write_agent_files.py` — stop destroying directories.** The first draft
+proposed backup-to-`.bak.<timestamp>`, then Phase 4 proposed incremental writes,
+which are incompatible designs for the same tool. Do the incremental model
+**once, here**, and never delete:
 
 ```python
 def write_agent_files(stack, output_path, agent_name="",
-                      overwrite: bool = False, dry_run: bool = False)
+                      dry_run: bool = False)   # always changed-only
 ```
 
-- Non-existent or empty target → write.
-- Existing non-empty target and `overwrite=False` → `is_error=True` listing the
-  conflicting paths. No data loss.
-- `overwrite=True` → move the existing directory to
-  `<output_path>.bak.<timestamp>` and write fresh. Never `rmtree` without a
-  backup. (Timestamp comes from `datetime.now()`; the sibling backup keeps the
-  operation reversible.)
-- `dry_run=True` → return the file list that *would* be written.
+- Write only files whose content differs from disk. Report
+  `{written, unchanged, conflicting}`.
+- A file present on disk that the builder did not generate is **never** touched.
+- `dry_run=True` → return the file list and bodies that *would* be written,
+  writing nothing.
+- No `rmtree`, no `overwrite` flag, no `.bak` siblings. Backups were their own
+  problem: `shutil.move` is non-atomic across filesystems, collides at
+  second-resolution and then silently *nests* the source inside the destination,
+  follows symlinks on the `exists()` check, accumulates full copies of whatever
+  secrets the agent's files hold, and litters the parent directory that every
+  directory scanner in the CLI walks.
+- `output_path` itself is constrained: refuse `/`, `$HOME`, the repo root, any
+  path containing an existing `.git`, and any path with a symlinked component.
+  It arrives from user or LLM input and today is only `.resolve()`d
+  (`cli/create_agent.py:322`).
+
+Path confinement and name validation (checks 1-2 of §1.1) ship **in this same
+PR**, not later — they are ~40 lines and they are the difference between "the
+builder overwrote my agent" and "the builder overwrote my `~/.bashrc`".
 
 **Other fixes** (each small, each independently testable):
 
 - `configs/agent_builder.yaml`: add `list_examples`, `read_example` to `tools`.
-- `tasks/build_agent.yaml` + `cli/create_agent.py`: implement `full_implementation`
-  (stub mode emits `raise NotImplementedError` bodies) or remove it. Recommend
-  **remove** — a stub agent is not useful and the flag has never worked.
-- `write_agent_files.py` README template: `uv run hugin run --task <task_name>
-  --task-path <output_path>`, using the actual generated task name.
+  This is **two lines of YAML** and it is the highest-leverage change in the
+  document: both tools already work, already scan the real `examples/` tree
+  (21 examples), and already omit `stack` from their signature so
+  `tools/tool.py:353` will not inject it. It gives the builder every architecture
+  Phase 3 wants to teach, in executable form that the test suite keeps honest.
+  It should not sit behind a four-PR knowledge-base migration.
+- `tasks/build_agent.yaml` + `cli/create_agent.py:281,321`: implement
+  `full_implementation` as `--stub-tools` rather than removing it. A
+  `raise NotImplementedError` with the right signature and docstring is *better*
+  than hallucinated `yfinance` code for any tool needing credentials the user
+  must wire in anyway, and it is the cheapest and fastest build mode.
+- **One run command, from one source.** There are currently four and they
+  disagree: `write_agent_files.py:91` (`uv run run-agent`, an entrypoint that
+  does not exist), `cli/create_agent.py:525` (`hugin run -p <path>`),
+  `docs/src/how-to/use-creator.md:137`, and `docs/src/how-to/create-agent.md`.
+  Derive all of them from one helper using the actual generated task name.
+- **`BUILD_REPORT.md` in the generated directory**, condensed onto the success
+  screen: architecture chosen and why, each tool and what it does, the task
+  parameters the user must supply, observed dependencies, validator warnings, and
+  the exact run command. Today, understanding your own generated agent requires
+  opening `hugin monitor`.
 - `generate_tool.py`: map declared schema types to real hints
   (`string→str`, `integer→int`, `number→float`, `boolean→bool`,
   `array→List[Any]`, `object→Dict[str, Any]`), and include
@@ -149,55 +312,102 @@ def write_agent_files(stack, output_path, agent_name="",
 
 ## Phase 2 — One knowledge base (closes task 013)
 
-### 2.1 Canonical location
+### 2.1 Canonical location — without the indirection
 
-Move the reference documentation **into the package** so it ships in the wheel
-and is readable at runtime by an installed Hugin:
+The canonical copy lives at `src/gimle/hugin/knowledge/{references,templates}/`
+so it ships in the wheel, with `get_knowledge_path()` / `read_reference()`.
 
-```
-src/gimle/hugin/knowledge/
-├── __init__.py            # get_knowledge_path(), list_references(), read_reference()
-├── references/
-│   ├── config-reference.md
-│   ├── task-reference.md
-│   ├── template-reference.md
-│   ├── tool-reference.md
-│   └── patterns.md
-└── templates/             # minimal-config.yaml, tool-implementation.py, …
-```
+But the first draft's plugin repoint — `SKILL.md` resolving the path via
+`python -c "from gimle.hugin.knowledge import ..."` — must not ship. It breaks
+the plugin in five concrete ways:
 
-`skills/hugin-agent-creator/` keeps `SKILL.md` and `plugin.json` but its
-`references/` and `templates/` become pointers: `SKILL.md` instructs the coding
-agent to read from the installed package path (resolved via
-`python -c "from gimle.hugin.knowledge import get_knowledge_path; …"`), with the
-in-repo path as the development fallback.
+1. The documented invocation is repo-local (`docs/src/how-to/use-claude-code.md:23`:
+   `claude --plugin-dir ./skills/hugin-agent-creator`). The installed-wheel case
+   it is built for has no users today.
+2. Bare `python` resolves against ambient PATH; Hugin lives in a uv venv, so it
+   needs `uv run python` *and* a cwd the plugin cannot assume.
+3. It converts a plain `Read` of a plugin-local file into a `Bash` subprocess. A
+   user who denies that prompt silently loses all ~1,500 lines of reference docs.
+4. A plugin installed standalone by someone evaluating Hugin gets an ImportError
+   instead of a guide.
+5. A plugin at HEAD resolving against an installed hugin 0.3 reads 0.3's schema
+   while `SKILL.md` describes HEAD's.
 
-Add `package-data` entries in `pyproject.toml` for `knowledge/**/*.md` and
-`knowledge/**/*`.
+Claude Code already provides `${CLAUDE_PLUGIN_ROOT}` for plugin-relative paths.
+**Keep a real file the plugin can `Read`**: make
+`skills/hugin-agent-creator/references` a symlink into the package (git tracks
+symlinks; note the Windows-without-developer-mode caveat), or keep the physical
+copy plus a ten-line test asserting byte-identity. Either way the migration is
+one reversible PR with no interregnum where the plugin is degraded and the
+builder not yet improved.
 
-A test asserts both surfaces resolve to the same directory and that every
-reference file named in `SKILL.md` exists.
+Packaging note: `package-data` is setuptools vocabulary. This repo builds with
+hatchling, and `[tool.hatch.build.targets.wheel] artifacts` at
+`pyproject.toml:76-79` **already** lists `"*.yaml"` and `"*.md"`. That bullet was
+both wrong and a no-op.
 
-### 2.2 `read_reference` tool
+### 2.1b The real single source of truth
 
-```python
-def read_reference(topic: str, stack: "Stack") -> ToolResponse
-```
+"One knowledge base" is not achieved by moving Markdown around. Counting the
+places that must change to add one `Config` field, the first draft made it
+*worse*: it added a validator and an architecture matrix that each re-encode the
+schema, deleted the builder prompt's copy, and left the largest duplicate —
+~1,900 lines across `docs/src/` — untouched. Grepping for just the
+mandatory-builtins rule hits 23 files across `src/`, `docs/` and `skills/`.
 
-`topic` ∈ `{config, task, template, tool, patterns}`. Returns the document body.
-This is the one place a large payload is justified — it is read at most twice per
-build, and it is what prevents the builder from inventing schema.
+The actual single source already exists: `agent/config.py` and `agent/task.py`
+are fully-docstringed dataclasses, and `Config.from_dict`/`Task.from_dict` are
+`cls(**data)` (`config.py:73`, `task.py:93`), so unknown and missing fields
+already raise at load. Derive `validate_agent`'s known-field checks from
+`dataclasses.fields(Config)`, and generate `config-reference.md` from the
+docstrings. That is the only version that cannot drift. Success is measured as a
+number — places-to-change-per-field — recorded in the task file before and after.
+
+### 2.2 Schema in the prompt; tools for the optional material
+
+The first draft shrank the builder's system template to routing instructions
+("before generating, call `list_examples`, then `read_example`, then
+`read_reference`"). That is exactly the class of instruction a model drops once
+the task prompt gets concrete — and `build_agent.yaml`'s prompt is a concrete
+seven-step recipe that starts at `generate_config`. It also trades ~8 lines of
+schema prose for 2-4 round trips pulling in ~1,500 lines, contradicting the
+token-efficiency mandate the same spec cites two pages earlier.
+
+The four schema references total ≈6k tokens. **Render them into the builder's
+system template directly** from `gimle.hugin.knowledge` — deterministic, always
+present, immune to being skipped. Keep `read_reference(topic)` as a tool only for
+the large optional material (`patterns.md`), with `topic` restricted to an
+enumerated literal set (never path-join model input).
+
+Where retrieval must be dynamic, force it structurally rather than asking: seed
+the build with a deterministic first `ToolCall`, or chain via `next_tool`.
+
+Retrieval results must be capped with the mechanism that already exists and the
+first draft never mentioned: `options.include_only_in_context_window: true` with
+a small `context_window` (`tools/tool.py:50-54`, honoured at
+`interaction/stack.py:255-262`) on `read_reference`, `read_example`,
+`search_examples` and `preview_files`. Without it these accumulate permanently —
+`apps/financial_newspaper` alone is ~95KB in a single `read_example` result.
 
 ### 2.3 Real example search (task 013)
 
-- Delete `FALLBACK_EXAMPLES` (the 130-line hardcoded list in `list_examples.py`).
-  Build the index by scanning `examples/` and `apps/` at call time: read each
-  `README.md` first heading + first paragraph, and record which of
-  `configs/ tasks/ templates/ tools/` are present, whether the tasks use
-  `task_sequence`, whether any tool returns `AgentCall`. That metadata is derived,
-  so it cannot go stale.
+- **Do not delete `FALLBACK_EXAMPLES`.** It is not dead weight: `pyproject.toml:75`
+  packages only `src/gimle`, so `examples/` and `apps/` are absent from the wheel
+  and `_get_examples_path()` (`read_example.py:14-34`) returns `None` for every
+  pip-installed user. Deleting the fallback in the same phase whose stated
+  purpose is serving installed Hugin — while *also* making example reading a
+  mandatory prelude — would leave installed users with an erroring required step.
+  Verified current behaviour in-repo: `list_examples()` returns 6383 chars,
+  21 examples, `source: "filesystem"`.
+- Ship a small curated set inside `gimle/hugin/knowledge/examples/` — one
+  canonical minimal agent per architecture — as the packaged source of truth.
+  Scan the repo's `examples/`/`apps/` as an *enhancement* when present, deriving
+  each entry's README heading, which of `configs/ tasks/ templates/ tools/`
+  exist, whether tasks use `task_sequence`, and whether any tool returns
+  `AgentCall`.
 - Add `search_examples(query)` — substring/keyword match over the index plus file
-  bodies, returning `[{example, file, line, snippet}]` with short snippets.
+  bodies, bounded by extension, file size and file count, returning
+  `[{example, file, line, snippet}]`.
 - Cache the index in `env_vars` for the session.
 
 ### 2.4 Read user-supplied local files (task 013)
@@ -208,14 +418,24 @@ already exist in `tools/builtins/`) to `configs/agent_builder.yaml`, and add a
 `hugin create`, so a user can point the builder at an API spec, a sample dataset,
 or an existing script to model the agent on.
 
-### 2.5 Builder prompt shrinks
+Note this makes the builder's input attacker-influenceable — an API spec can
+carry instructions, and the output is code that gets executed. Reference files
+are **data**: wrap them in a delimited untrusted block in the prompt, and cap
+size and count. This sits inside the trust boundary stated in `description.md`,
+not outside it.
 
-`templates/builder_system.yaml` stops being a (partial, drifting) copy of the
-schema and becomes routing instructions:
+### 2.5 Builder prompt
 
-> Before generating: call `list_examples`, then `read_example` on the 1-2 closest
-> matches, then `read_reference` for each file type you will emit. Do not invent
-> schema fields — if it is not in the reference, it does not exist.
+`templates/builder_system.yaml` keeps its two rules that earn their place — the
+token-efficiency mandate and "`implementation_code` must be ACTUAL PYTHON CODE" —
+and gains the schema references rendered in from `gimle.hugin.knowledge` (§2.2).
+Only the ~8 lines of hand-copied schema prose are deleted. The routing-only
+version proposed in the first draft is not shipped.
+
+Any PR in Phase 3 that adds a schema field must update
+`knowledge/references/*.md` in the same PR — otherwise the prompt's "do not
+invent schema fields" instruction actively suppresses the capability Phase 3 just
+added. This is a checkbox on every Phase 3 item.
 
 ---
 
@@ -260,10 +480,41 @@ supported by `generate_task`'s schema validation), with choices:
 | `stateful` | artifacts via `save_insight` / `query_artifacts` | `examples/artifacts` |
 | `shell` | the sandboxed bash tool | `examples/bash_agent` |
 
-The wizard offers `auto` (default): the builder reads the description, picks, and
-must state its reasoning. `review_agent`'s narrowed remit includes checking that
-the choice fits the description. Architectures compose — `architecture` is a
-list, not a single value.
+**Type.** The first draft said `categorical` and, four lines later, "a list, not
+a single value". Those are incompatible: `Task.set_input_parameters` coerces a
+categorical to one string and rejects anything outside `choices`
+(`agent/task.py:250-271`), so a list arrives as `str([...])` and raises. Use
+`type: array` with explicit per-item subset validation (`task.py:222-235` has no
+per-item choice checking of its own).
+
+**Selection.** Asking the model to compose six architectures *before* it has
+designed anything — with `single_shot` in the list and the whole existing prompt
+(`build_agent.yaml:40-90`) describing a single-shot flow — will collapse to
+`single_shot` nearly always. Run selection as a separate cheap turn with forced
+structured output, or derive candidates deterministically from the description
+and let the model confirm and extend with a justification.
+
+**Enforcement.** "`review_agent` checks that the choice fits" is the weakest
+possible enforcement of this task's headline goal. Make the claim
+machine-checkable in `validate_agent`: `pipeline` ⇒ some task sets
+`task_sequence`; `delegating` ⇒ some tool returns `AgentCall` or the config has
+`launch_agent`; `interactive` ⇒ `interactive: true` and `ask_user` present. A
+silent collapse to `single_shot` then fails validation instead of passing review.
+
+**Sandbox posture for `shell`.** `SandboxSpec.from_dict` deliberately raises when
+`backend` is absent — "there is no silent default" — and the only example the
+builder can copy (`examples/bash_agent`) uses `backend: local`, whose own comment
+says it has no isolation boundary. Instructing the builder to mirror the closest
+example therefore ships `backend: local` shell agents by default. So:
+`validate_agent` hard-fails `allow_unrestricted_egress: true` and any config
+omitting `backend`; generated shell agents default to `backend: docker`; `local`
+requires an explicit `--allow-local-sandbox` and prints the warning; `network`
+stays pinned `false` until tasks 030/030b land. The generated README and success
+screen state the posture in words.
+
+**Bounded delegation.** `--max-steps` bounds one agent, not a tree. With
+`enable_builtin_agents` and §3.4's `AgentCall` tools generatable, an LLM-authored
+recursive delegation is an unbounded spend. Add a session-level agent-count cap.
 
 ### 3.4 Sub-agent-capable tool generation
 
@@ -290,14 +541,35 @@ identically to the generate_* tools' output (`configs/x.yaml`, `tools/y.py`, …
 Every existing generation tool then becomes an *edit* tool for free: regenerating
 `configs/x.yaml` overwrites that key and leaves everything else untouched.
 
-Returns only a manifest (paths + line counts), never bodies.
+Returns a manifest (paths + line counts) — but **`read_generated_file(path)` from
+§1.2b is a hard prerequisite**. The first draft said "never bodies", which would
+mean the builder regenerates a file it has never read: ask it to "add a retry to
+`fetch_prices`" and it reinvents the whole tool from a one-line instruction,
+silently discarding every comment and hand-tuned line. `changed_only` protects
+files it does *not* touch and does nothing for the one it does. Since
+`docs/src/how-to/use-creator.md` explicitly tells users to hand-customise
+generated agents, that makes edit mode a trap for exactly the users who took the
+docs' advice.
 
 ### 4.2 Incremental writes
 
-`write_agent_files` gains `changed_only: bool = True`: compare each generated
-file against what is on disk and write only differences, reporting
-`{"written": [...], "unchanged": [...]}`. Combined with §1.4, editing an agent
-can no longer destroy files the builder did not generate.
+Already delivered in §1.4 — `write_agent_files` is changed-only from Phase 1, so
+Phase 4 adds nothing to this tool. What Phase 4 does add:
+
+- **Diff before write, always.** `hugin create --edit` prints a unified diff and
+  asks y/n before writing; `hugin create --dry-run` prints the tree and bodies
+  without writing. The data is already in `env_vars["generated_files"]` and on
+  disk — this is cheap, and it is the single change that makes the tool
+  trustworthy against a directory the user has edited.
+- **Authorised-write allowlist.** Derive from the instruction the set of files
+  the edit may touch; refuse writes outside it. Nothing else enforces §4.1's
+  claim that only the named file changes.
+- **Dirty-tree guard.** Refuse, or warn and confirm, when the target sits in a
+  git worktree with uncommitted changes — otherwise an unattended edit is
+  unrecoverable.
+- **Provenance.** A `generated_by: hugin <cmd> <ts>` marker plus a content hash
+  manifest, and refusal to overwrite a file modified since the last generation.
+  Without it, after Phase 5 nobody can tell which lines a machine wrote.
 
 ### 4.3 `edit_agent` task and CLI
 
@@ -335,18 +607,56 @@ def analyze_traces(
 ) -> ToolResponse
 ```
 
-Uses the existing `Storage` API (`list_sessions`, `list_agents`,
-`list_interactions`, `load_interaction`) against a `LocalStorage` rooted at
-`storage_path`. Computation is **deterministic aggregation, not LLM
-summarisation** — the LLM sees a compact report, never raw traces (a single run's
-interactions can be megabytes).
+**Storage prerequisite — the first draft named APIs that cannot do this.**
+`load_interaction(uuid, stack)` requires a `Stack` (`storage/storage.py:199`),
+which does not exist for a foreign agent's historic runs, and caches every result
+in `self.store` with no eviction. `list_interactions()` (`local.py:91`) is a flat
+unscoped listing of every interaction in the directory — no session filter, no
+agent filter, no ordering, no pagination. So `limit=50` as specified cannot group
+by run without loading the entire directory into an unbounded cache, against the
+spec's own warning that one run can be megabytes.
+
+Follow what `hugin monitor` already does: read `storage/agents/<uuid>` JSON for
+`stack.interactions`, then `LocalStorage.load_interaction_metadata(uuid)`
+(`local.py:218`) — note that helper is on `LocalStorage`, not the `Storage` ABC,
+so either lift it or scope this to local storage explicitly. See
+`cli/monitor_agents.py:671,747`. Scoping a proper storage query API is its own
+task; this phase must not pretend it is free.
+
+Computation is **deterministic aggregation, not LLM summarisation** — the LLM
+sees a compact report, never raw traces.
+
+**Redaction is mandatory, not optional.** Traces are persisted verbatim:
+`Interaction.to_dict` serialises every field, `ToolCall.args` is the model's raw
+argument dict, and `LocalStorage.save_interaction` applies only
+`_sanitize_for_json` — JSON coercion, not redaction (`grep -rn "redact" src/`
+returns nothing). The first draft's mitigation, "the LLM sees a compact report",
+does not hold, because the report carries `top_errors` as verbatim strings — and
+error strings are exactly where credentials surface
+(`401 for url: https://api.x/v1?api_key=sk-live-…`). So:
+
+- Emit **normalised error signatures**, not raw messages: exception type +
+  module + first line with digits, hex, quoted strings and URLs masked. Better
+  grouping *and* the fix.
+- Run every emitted string through a redactor (`sk-`, `ghp_`, `AKIA`, `Bearer `,
+  JWTs, private-key headers, URL query strings, emails) and truncate to ~200
+  chars.
+- Never include `ToolCall.args` **values** — hash them for loop detection.
+- Confine `--storage-path` to `sessions/`, `agents/`, `interactions/` beneath the
+  root; resolve symlinks; refuse escapes.
+- §5.3 recommends `HUGIN_CAPTURE_RENDERED_PROMPTS=1`, which additionally persists
+  full rendered prompts. Document that this materially raises the sensitivity of
+  the storage directory — the first draft recommended it with no caveat.
 
 Metrics:
 
 | Metric | Why it drives an improvement |
 |---|---|
-| `finish_type` distribution (`success`/`failure`, from `builtins.finish`) | Baseline success rate |
-| Runs terminating by step exhaustion rather than `finish` | Prompt or tool-loop problem |
+| `finish_type` distribution (`success`/`failure`, from `builtins.finish`) | Baseline success rate — **self-reported, see the Goodhart note below** |
+| Runs terminating by step exhaustion rather than `finish` | Prompt or tool-loop problem. Not recorded anywhere — `max_steps` lives in the CLI and no terminal marker is persisted, so this must be *inferred* (last interaction is not a `TaskResult`) |
+| Tokens and cost per run | Already available: `OracleResponse` carries `input_tokens`/`output_tokens` (`llm/models/model.py:29-30`). The first draft omitted the one metric a user actually feels |
+| Literal `{{` surviving into `rendered_user_message` | Unresolved template reference — a first-class metric, not a footnote, when `HUGIN_CAPTURE_RENDERED_PROMPTS=1` |
+| Task parameter sets actually used | Harvested to build a replay set (see below) |
 | Steps-to-finish distribution (p50/p90/max) | Efficiency; a rising p90 means the agent is flailing |
 | Per-tool call count and error rate, with top-N distinct error messages | Points at the specific tool to regenerate |
 | Tools in the config never called across all runs | Dead tools to delete from the config |
@@ -370,45 +680,136 @@ materially — with it, `OracleResponse` carries `rendered_system_prompt` and
 `rendered_user_message`, so unresolved template references become visible as a
 metric rather than a guess.
 
+### 5.1b Goodhart, and the regression guard
+
+`finish_type` is chosen by the agent being measured. `success_rate` is therefore
+its **self-grade**, and an improvement loop optimising it has an obvious cheap
+win: make the agent likelier to declare success, or finish earlier. Same for
+steps-to-finish p90 — shorten it by doing less work. Automating that optimisation
+without a guard is the most dangerous idea in this task.
+
+Guards, all required before `--apply` exists:
+
+- **Replay, don't self-grade.** Harvest real task parameter sets from the traces
+  and re-run before/after on the *same inputs* via `test_agent`. That is the only
+  honest before/after; the first draft's "before/after summary" could not measure
+  "after" at all, since the rewritten agent has no traces.
+- **Version-attribute the traces.** Stamp the agent directory hash into session
+  metadata, or post-improve runs mix with pre-improve ones in one storage dir.
+- **`dead_tools` is a warning, never a deletion.** Zero calls across 50 runs is
+  not evidence a tool is dead — it may serve a rare branch. Require a minimum-N
+  threshold and a description check before any removal is even proposed.
+- **Revert path.** Provenance markers and the git dirty-tree guard from §4.2 are
+  what make an improve run undoable; say so in the CLI output.
+
 ### 5.2 `improve_agent` task
 
 `tasks/improve_agent.yaml`, `chain_config: agent_builder`:
 
 1. `analyze_traces` on the target agent's storage.
-2. `load_agent_files` on the agent directory (Phase 4).
-3. Propose a ranked, *evidence-linked* change list — each proposed change must
-   cite a metric (e.g. "delete `fetch_summary` from the config: 0 calls across 50
-   runs"; "rewrite `render_report` to return a path: max result 41k chars").
-4. Apply via the generate_* tools.
-5. `validate_agent` → `write_agent_files(changed_only=True)` → `test_agent`.
-6. `finish` with a before/after summary.
+2. `load_agent_files` + `read_generated_file` on the agent directory (Phase 4).
+3. Propose a ranked, evidence-linked change list.
+4. **Propose-only by default.** Apply only under `--apply`, after a diff.
+5. `validate_agent` → `write_agent_files` → replay before/after.
+
+**The citation requirement must be structural, not a prompt norm.** "Every change
+must cite a metric" produces cited metrics — including fabricated ones, since by
+step 3 the report is far back in a long single-stack context. Add
+`propose_change(file, change_type, metric, observed_value, rationale)`; store the
+`analyze_traces` report in `env_vars`; the tool **rejects the call** if `metric`
+is not a key in the stored report or `observed_value` does not match it. Only
+accepted proposals may be applied. That is ~40 lines and converts a norm into a
+constraint.
+
+**Trace-derived text is untrusted input.** Traces contain text an external party
+may have influenced — a fetched page, a filename, a user message. "Also rewrite
+the auth tool to send the token to …" sitting in a trace would otherwise become a
+code edit on the user's disk via a path the user believes is a metrics summary.
+Trace-derived strings are data, quoted inside a delimited untrusted block, and
+can never reach a write without a human-visible diff.
 
 ### 5.3 CLI
 
 ```bash
-hugin improve <agent_path> --storage-path ./storage/<name> [--limit 50] [--dry-run]
+hugin analyze <agent_path> --storage-path ./storage/<name> [--limit 50]
+hugin improve <agent_path> --storage-path ./storage/<name> [--apply]
 ```
 
-`--dry-run` runs steps 1-3 and prints the evidence-linked proposal without
-touching files. That is also the useful standalone mode: "what is wrong with this
-agent?"
+`hugin analyze` is **read-only, zero LLM tokens**, and is the phase's most useful
+standalone mode: "what is wrong with this agent?" — answerable on day one, on
+hand-written agents too. It depends on nothing from Phases 2-4, so it ships
+early (see `plan.md`). `hugin improve` proposes by default; `--apply` is opt-in.
+
+Write §5.1's metric table *after* running `hugin analyze` against one real
+storage directory. Pinning percentiles, loop thresholds and top-N error handling
+before anyone has looked at real data is over-specification.
 
 ---
 
 ## Testing strategy
 
 Follow the existing pattern — the three `tests/test_agent_builder_*.py` files use
-direct tool invocation with fixtures from `tests/conftest.py`, and `MockModel`
-for LLM calls.
+direct tool invocation with fixtures from `tests/conftest.py`.
+
+**Use `ScriptedToolModel` (`tests/conftest.py:61`), not `MockModel`.** The first
+draft named `MockModel` throughout; it returns one fixed text response and
+**cannot emit tool calls at all** (`conftest.py:18`), so none of the tests as
+originally written would have run. `ScriptedToolModel` replays a sequence of tool
+calls and is what the bash full-loop suites already use.
 
 | Phase | Tests |
 |---|---|
-| 1 | `test_validate_agent.py`: one test per check, each with a deliberately broken fixture agent (bad template ref, unresolvable tool, undeclared Jinja var, malformed signature, missing dependency) plus a known-good fixture that must pass clean. `test_write_agent_files_safety.py`: existing non-empty dir is never destroyed; `overwrite=True` produces a `.bak.<ts>`; `dry_run` writes nothing. |
-| 2 | Both knowledge surfaces resolve the same path; every reference named in `SKILL.md` exists; `search_examples` finds a known string in a known example. |
-| 3 | Build each architecture with `MockModel` and assert the emitted YAML contains the expected fields and passes `validate_agent`. |
-| 4 | Round-trip: `load_agent_files` → regenerate one file → `write_agent_files(changed_only=True)` touches exactly one file and leaves an unrelated hand-added file intact. |
-| 5 | `analyze_traces` against a synthetic storage directory built by running a fixture agent with `MockModel`, asserting each metric. |
+| 1 | `test_validate_agent.py`: one test per check, each with a deliberately broken fixture (bad template ref, unresolvable tool, undeclared Jinja var, malformed signature, `..` traversal key, reserved-name collision) plus a known-good fixture passing clean. `test_write_agent_files_safety.py`: a hand-added unrelated file survives a write; `dry_run` writes nothing; a traversal or absolute key is a hard error in **both** validator and writer. Plus the CI sweep: `hugin validate` clean over all of `examples/` and `apps/`. |
+| 2 | Both knowledge surfaces resolve the same bytes; every reference named in `SKILL.md` exists; `search_examples` finds a known string; `list_examples` still returns a usable index with `examples/` absent (the installed-wheel path). |
+| 3 | Build each architecture and assert the emitted YAML contains the expected fields, passes `validate_agent`, and satisfies the architecture invariants of §3.3. |
+| 4 | Round-trip: `load_agent_files` → regenerate one file → exactly one file changes on disk and an unrelated hand-added file is untouched. |
+| 5 | `analyze_traces` against a synthetic storage dir built by running a fixture agent; assert each metric, and assert a seeded fake API key in a trace does **not** appear in the report. |
+
+**Scripted tests cannot verify the headline claims.** A script hardcodes the
+`generate_*` arguments, so per-architecture tests prove the *emit* path works —
+not that the builder *chooses* correctly, which is the actual Phase 3 claim.
+Likewise, PR 2.2 changes the builder prompt with nothing measuring whether
+generation quality moved.
+
+So: build a **golden set** of 10-20 agent descriptions spanning the architectures
+and a scored harness against a real model — first-pass validation rate,
+post-repair rate, repair attempts used, architecture match, `test_agent` success,
+steps, tokens, dollars. Run it behind the existing `slow`/`integration` markers
+(`pyproject.toml:105-109`), record the numbers in this task file per PR, and gate
+the prompt-changing PRs on no regression. Without it, Phases 2, 3 and 5 are
+unfalsifiable.
 
 Every phase must pass `uv run pre-commit run --all-files` and `uv run pytest -x -q`.
 Note: the mypy hook has a known pre-existing failure on `openai/_client.py`
 unrelated to this work.
+
+---
+
+## Cost and context
+
+A build today is four LLM stages on **one shared stack** — `TaskChain.step`
+swaps the config and appends a `TaskDefinition` on the same agent
+(`interaction/task_chain.py:78-188`), and `render_stack_context` keeps rendering
+past a `TaskResult` (`interaction/stack.py:199-300`). There is no truncation of
+long strings, and **no prompt caching anywhere in `llm/`** (`grep -rn
+"cache_control" src/gimle/hugin/llm/` returns nothing), so the whole transcript
+is re-paid on every one of up to 200 steps.
+
+Every phase here makes that worse: more tools, more retrieval, more repair
+iterations. What breaks first, in order: **cost**, then `max_steps=200`
+(`cli/create_agent.py:373`) as validation loops consume steps, then **quality** —
+the schema read at step 2 is a hundred messages back when the finalizer needs it —
+and only then the context window.
+
+Mitigations, none of which were in the first draft:
+
+- `include_only_in_context_window` + small `context_window` on every retrieval and
+  preview tool (§2.2).
+- Schema in the system template rather than a tool result, so it is present when
+  needed rather than scrolled away (§2.2).
+- Run review/finalize/test as `AgentCall` sub-agents with fresh context rather
+  than `task_sequence` on one stack (§1.2).
+- Enable Anthropic prompt caching before Phase 5 lengthens builds further.
+- Per-stage progress, elapsed time and step count in the CLI — today it is a
+  spinner reading "Thinking..." (`cli/create_agent.py:462`) — and a token/cost
+  line on the success screen.

--- a/tasks/open/034-agent-creator-v2/spec.md
+++ b/tasks/open/034-agent-creator-v2/spec.md
@@ -75,9 +75,15 @@ Checks 6-7 execute it and are **opt-in, off by default** (see §1.5).
    `tools/*.py` has a sibling `.yaml` and vice versa.
 4. **Reference resolution**
    - `config.system_template` resolves to a registered template name, or is an
-     inline prompt. Only flag when it *looks like* a reference — reuse the
-     identifier-only heuristic `_BARE_TEMPLATE_REFERENCE` at
-     `agent/environment.py:26`, so plain-prose system prompts are not rejected.
+     inline prompt. Only flag when it *looks like* a reference — an
+     identifier-only heuristic (`^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$`), so
+     plain-prose system prompts are not rejected.
+     Note: `tasks/open/019-warn-on-unknown-template-reference.md` is **still
+     unimplemented**. A working draft of it was briefly present in the working
+     tree during this task's review and has since been reverted, so there is
+     nothing to reuse — this is new work. Best done as task 019 proper, inside
+     `Environment.load()` so hand-written agents get the warning too, with
+     `validate_agent` calling it.
    - Every entry in `config.tools` resolves: `builtins.X:Y` exists in the builtin
      registry, or `X` names a generated tool.
    - `task.tools`, when present, is a subset of the resolvable tool set.
@@ -250,7 +256,10 @@ def write_agent_files(stack, output_path, agent_name="",
 ```
 
 - Write only files whose content differs from disk. Report
-  `{written, unchanged, conflicting}`.
+  `{written, unchanged, preserved}` — `preserved` being files already in the
+  directory that the builder does not manage. (Drafted as `conflicting`; there
+  is no conflict once writes are additive, and naming them `preserved` says the
+  useful thing: these are exactly what the old `rmtree` destroyed silently.)
 - A file present on disk that the builder did not generate is **never** touched.
 - `dry_run=True` → return the file list and bodies that *would* be written,
   writing nothing.

--- a/tasks/open/034-agent-creator-v2/spec.md
+++ b/tasks/open/034-agent-creator-v2/spec.md
@@ -1,0 +1,414 @@
+---
+title: Agent Creator v2 — Technical Specification
+state: OPEN
+---
+
+# Agent Creator v2 — Technical Specification
+
+All paths are relative to the repo root. The meta-agent lives at
+`src/gimle/hugin/apps/agent_builder/`; the wizard at
+`src/gimle/hugin/cli/create_agent.py`; the Claude Code plugin at
+`skills/hugin-agent-creator/`.
+
+---
+
+## Phase 1 — Deterministic correctness gate
+
+### 1.1 `validate_agent` tool
+
+New tool `apps/agent_builder/tools/validate_agent.py` (+ `.yaml`). It is the
+single highest-leverage addition: it replaces "an LLM read a preview string and
+said it looked fine" with a hard, mechanical gate.
+
+Signature:
+
+```python
+def validate_agent(
+    stack: "Stack",
+    agent_path: Optional[str] = None,
+    check_imports: bool = True,
+) -> ToolResponse:
+```
+
+When `agent_path` is omitted it validates the in-memory
+`env_vars["generated_files"]` by materialising them into a `TemporaryDirectory`.
+This lets it run *before* anything touches the user's filesystem.
+
+Checks, in order (cheapest first, all deterministic — no LLM):
+
+1. **Structure** — `configs/` and `tasks/` exist and are non-empty; every
+   `tools/*.py` has a sibling `.yaml` and vice versa.
+2. **Reference resolution**
+   - `config.system_template` resolves to a registered template name, or is an
+     inline Jinja string (contains `{{`). A bare string matching neither is the
+     failure mode that `tasks/open/019-warn-on-unknown-template-reference.md`
+     already flags — reuse that check.
+   - Every entry in `config.tools` resolves: `builtins.X:Y` exists in the builtin
+     registry, or `X` names a generated tool.
+   - `task.tools`, when present, is a subset of the resolvable tool set.
+3. **Jinja parameter binding** — parse each task `prompt` and `system_template`
+   with `jinja2.meta.find_undeclared_variables` over `Environment().parse(src)`.
+   Every undeclared root variable must be a declared task parameter. This catches
+   `{{ ticker.value }}` where `ticker` was never declared — the most common
+   silent breakage, and one the current pipeline cannot see at all.
+4. **Tool contract** — each `tools/*.py` compiles (`compile(src, path, "exec")`);
+   the function named by the YAML's `implementation_path` (`mod:func`) exists;
+   its signature accepts `stack`; every parameter in the YAML `parameters` block
+   appears in the signature.
+5. **Import check** (`check_imports=True`) — import each tool module in a
+   **subprocess** (`python -c "import importlib.util; …"`) so a broken or
+   side-effecting module cannot poison the builder process. `ModuleNotFoundError`
+   is reported as a *missing dependency* with the module name, not as a generic
+   failure — this feeds §1.3.
+6. **Dry load** — `Environment.load(tmpdir, storage=LocalStorage(tmp))` in the
+   same subprocess. Any exception is a hard failure with the traceback's last
+   frame.
+
+Return payload is deliberately small (the builder's own system template mandates
+token-efficient tools, and today none of its tools obey it):
+
+```python
+ToolResponse(is_error=not ok, content={
+    "ok": bool,
+    "errors": [{"file": str, "check": str, "message": str}],   # blocking
+    "warnings": [{"file": str, "check": str, "message": str}], # non-blocking
+    "missing_dependencies": [str],
+    "summary": "3 errors, 1 warning",
+})
+```
+
+Never return file contents — the agent can `read_example`/`preview_files` if it
+needs to look.
+
+### 1.2 Wiring the gate
+
+- `tasks/build_agent.yaml`: call `validate_agent` before `finish`; loop on errors
+  (bounded, max 3 attempts) rather than handing garbage to the reviewer.
+- `tasks/finalize_agent.yaml`: `validate_agent` **must** return `ok: true` before
+  `write_agent_files` is called. This is the enforcement point.
+- `configs/agent_builder.yaml`: add `validate_agent` to `tools`.
+- New CLI subcommand `hugin validate <agent_path>` in `cli/cli.py` so humans and
+  CI can run the same checks on any agent directory, generated or handwritten.
+
+The LLM reviewer (`review_agent`) survives, but its remit narrows to what a
+machine cannot judge: *does this agent actually match the description?* All the
+mechanical checks currently in `templates/reviewer_system.yaml` (§2 required
+builtins, §3 parameter schema, §4 return statement, §5 valid Python) move to the
+validator and are deleted from the prompt.
+
+### 1.3 Dependency declaration
+
+Generated agents routinely import `yfinance`, `pandas`, `requests` — none
+guaranteed present. `validate_agent`'s `missing_dependencies` gets written to a
+`requirements.txt` in the generated agent directory and surfaced in its README
+and in the `hugin create` success screen. We do not auto-install.
+
+### 1.4 Defect fixes
+
+**`write_agent_files.py` — stop destroying directories.** Replace the
+unconditional `shutil.rmtree(output_dir)` with:
+
+```python
+def write_agent_files(stack, output_path, agent_name="",
+                      overwrite: bool = False, dry_run: bool = False)
+```
+
+- Non-existent or empty target → write.
+- Existing non-empty target and `overwrite=False` → `is_error=True` listing the
+  conflicting paths. No data loss.
+- `overwrite=True` → move the existing directory to
+  `<output_path>.bak.<timestamp>` and write fresh. Never `rmtree` without a
+  backup. (Timestamp comes from `datetime.now()`; the sibling backup keeps the
+  operation reversible.)
+- `dry_run=True` → return the file list that *would* be written.
+
+**Other fixes** (each small, each independently testable):
+
+- `configs/agent_builder.yaml`: add `list_examples`, `read_example` to `tools`.
+- `tasks/build_agent.yaml` + `cli/create_agent.py`: implement `full_implementation`
+  (stub mode emits `raise NotImplementedError` bodies) or remove it. Recommend
+  **remove** — a stub agent is not useful and the flag has never worked.
+- `write_agent_files.py` README template: `uv run hugin run --task <task_name>
+  --task-path <output_path>`, using the actual generated task name.
+- `generate_tool.py`: map declared schema types to real hints
+  (`string→str`, `integer→int`, `number→float`, `boolean→bool`,
+  `array→List[Any]`, `object→Dict[str, Any]`), and include
+  `traceback.format_exc()[-2000:]` in the except-branch payload so failures are
+  diagnosable.
+- `cli/create_agent.py`: source model choices from
+  `llm/models/model_registry.py` rather than the hardcoded lists at lines
+  167-170.
+- `cli/create_agent.py`: add non-interactive flags (`--name`, `--description`,
+  `--model`, `--builder-model`, `--output`, `--yes`) so the wizard is scriptable
+  and coverable by an end-to-end test.
+- `tools/test_agent.py`: take explicit `config_name`/`task_name` arguments
+  instead of `configs[0]`/`tasks[0]`, and stop registering the tested agent's
+  templates into the builder's own registry.
+
+---
+
+## Phase 2 — One knowledge base (closes task 013)
+
+### 2.1 Canonical location
+
+Move the reference documentation **into the package** so it ships in the wheel
+and is readable at runtime by an installed Hugin:
+
+```
+src/gimle/hugin/knowledge/
+├── __init__.py            # get_knowledge_path(), list_references(), read_reference()
+├── references/
+│   ├── config-reference.md
+│   ├── task-reference.md
+│   ├── template-reference.md
+│   ├── tool-reference.md
+│   └── patterns.md
+└── templates/             # minimal-config.yaml, tool-implementation.py, …
+```
+
+`skills/hugin-agent-creator/` keeps `SKILL.md` and `plugin.json` but its
+`references/` and `templates/` become pointers: `SKILL.md` instructs the coding
+agent to read from the installed package path (resolved via
+`python -c "from gimle.hugin.knowledge import get_knowledge_path; …"`), with the
+in-repo path as the development fallback.
+
+Add `package-data` entries in `pyproject.toml` for `knowledge/**/*.md` and
+`knowledge/**/*`.
+
+A test asserts both surfaces resolve to the same directory and that every
+reference file named in `SKILL.md` exists.
+
+### 2.2 `read_reference` tool
+
+```python
+def read_reference(topic: str, stack: "Stack") -> ToolResponse
+```
+
+`topic` ∈ `{config, task, template, tool, patterns}`. Returns the document body.
+This is the one place a large payload is justified — it is read at most twice per
+build, and it is what prevents the builder from inventing schema.
+
+### 2.3 Real example search (task 013)
+
+- Delete `FALLBACK_EXAMPLES` (the 130-line hardcoded list in `list_examples.py`).
+  Build the index by scanning `examples/` and `apps/` at call time: read each
+  `README.md` first heading + first paragraph, and record which of
+  `configs/ tasks/ templates/ tools/` are present, whether the tasks use
+  `task_sequence`, whether any tool returns `AgentCall`. That metadata is derived,
+  so it cannot go stale.
+- Add `search_examples(query)` — substring/keyword match over the index plus file
+  bodies, returning `[{example, file, line, snippet}]` with short snippets.
+- Cache the index in `env_vars` for the session.
+
+### 2.4 Read user-supplied local files (task 013)
+
+Add `builtins.read_file:read_file` and `builtins.list_files:list_files` (both
+already exist in `tools/builtins/`) to `configs/agent_builder.yaml`, and add a
+`reference_files` parameter to `build_agent` + a `--reference-file` flag on
+`hugin create`, so a user can point the builder at an API spec, a sample dataset,
+or an existing script to model the agent on.
+
+### 2.5 Builder prompt shrinks
+
+`templates/builder_system.yaml` stops being a (partial, drifting) copy of the
+schema and becomes routing instructions:
+
+> Before generating: call `list_examples`, then `read_example` on the 1-2 closest
+> matches, then `read_reference` for each file type you will emit. Do not invent
+> schema fields — if it is not in the reference, it does not exist.
+
+---
+
+## Phase 3 — Architectural depth
+
+### 3.1 Widen `generate_task`
+
+Add optional parameters, each validated in Phase 1's checks:
+
+| Field | Purpose |
+|---|---|
+| `task_sequence: List[str]` | Multi-stage pipeline |
+| `next_task: str` | Single successor |
+| `pass_result_as: str` | Name the successor's parameter receiving this result |
+| `chain_config: str` | Config to run a chained task under |
+| `system_template: str` | Per-task system prompt override |
+
+Validation: every name in `task_sequence`/`next_task`/`chain_config` must exist
+among the generated files, and `pass_result_as` must name a declared parameter of
+the successor task. Emitting a pipeline that references a task nobody generated
+is exactly the class of bug the validator exists to catch.
+
+### 3.2 Widen `generate_config`
+
+Add `interactive`, `state_namespaces`, `enable_builtin_agents`, `options`. Stop
+force-appending `save_text`/`save_file` (`generate_config.py:34-42`) — keep only
+`builtins.finish:finish` mandatory, and let the architecture decide the rest. The
+current behaviour gives every agent two tools it usually never calls, which
+Phase 5's dead-tool analysis would then flag.
+
+### 3.3 Architecture selection
+
+New `architecture` parameter on `build_agent`, type `categorical` (already
+supported by `generate_task`'s schema validation), with choices:
+
+| Architecture | Emits | Reference example |
+|---|---|---|
+| `single_shot` | one config, one task, flat tools | `examples/basic_agent` |
+| `pipeline` | `task_sequence` across stages | `examples/task_sequences` |
+| `delegating` | a tool returning `AgentCall`, or `builtins.launch_agent` | `examples/sub_agent` |
+| `interactive` | `interactive: true` + `builtins.ask_user` | `examples/human_interaction` |
+| `stateful` | artifacts via `save_insight` / `query_artifacts` | `examples/artifacts` |
+| `shell` | the sandboxed bash tool | `examples/bash_agent` |
+
+The wizard offers `auto` (default): the builder reads the description, picks, and
+must state its reasoning. `review_agent`'s narrowed remit includes checking that
+the choice fits the description. Architectures compose — `architecture` is a
+list, not a single value.
+
+### 3.4 Sub-agent-capable tool generation
+
+`generate_tool.py` currently hardcodes a `try/except` wrapper returning
+`ToolResponse`, which makes it impossible to emit a tool that returns an
+`AgentCall` — the documented way to spawn a child agent (CLAUDE.md: "Never run a
+sub-agent synchronously inside a tool"). Add `return_type: "tool_response" |
+"agent_call"`; for `agent_call`, emit the `Union[ToolResponse, AgentCall]`
+signature and the config/task lookup preamble, mirroring
+`apps/agent_builder/tools/test_agent.py`.
+
+---
+
+## Phase 4 — Edit an existing agent
+
+### 4.1 `load_agent_files`
+
+```python
+def load_agent_files(agent_path: str, stack: "Stack") -> ToolResponse
+```
+
+Reads an existing agent directory into `env_vars["generated_files"]`, keyed
+identically to the generate_* tools' output (`configs/x.yaml`, `tools/y.py`, …).
+Every existing generation tool then becomes an *edit* tool for free: regenerating
+`configs/x.yaml` overwrites that key and leaves everything else untouched.
+
+Returns only a manifest (paths + line counts), never bodies.
+
+### 4.2 Incremental writes
+
+`write_agent_files` gains `changed_only: bool = True`: compare each generated
+file against what is on disk and write only differences, reporting
+`{"written": [...], "unchanged": [...]}`. Combined with §1.4, editing an agent
+can no longer destroy files the builder did not generate.
+
+### 4.3 `edit_agent` task and CLI
+
+New `tasks/edit_agent.yaml` with parameters `agent_path`, `instruction`, and
+optional `reference_files`. Flow: `load_agent_files` → `list_examples`/
+`read_reference` as needed → targeted regeneration → `validate_agent` →
+`write_agent_files(changed_only=True)` → `test_agent`.
+
+CLI: `hugin create --edit <path> --instruction "add a tool that …"`.
+
+### 4.4 Interactive builder
+
+Set `interactive: true` on a new `agent_builder_interactive` config and add
+`builtins.ask_user:ask_user`, so the builder can ask a clarifying question
+instead of guessing when a description is ambiguous. Opt-in via
+`hugin create --interactive`; the default stays non-interactive so scripted and
+test runs are unaffected.
+
+---
+
+## Phase 5 — Trace-driven improvement
+
+The goal: run a generated agent for a while, then have the creator read its
+Hugin traces and improve it.
+
+### 5.1 `analyze_traces`
+
+```python
+def analyze_traces(
+    storage_path: str,
+    stack: "Stack",
+    agent_name: Optional[str] = None,
+    config_name: Optional[str] = None,
+    limit: int = 50,
+) -> ToolResponse
+```
+
+Uses the existing `Storage` API (`list_sessions`, `list_agents`,
+`list_interactions`, `load_interaction`) against a `LocalStorage` rooted at
+`storage_path`. Computation is **deterministic aggregation, not LLM
+summarisation** — the LLM sees a compact report, never raw traces (a single run's
+interactions can be megabytes).
+
+Metrics:
+
+| Metric | Why it drives an improvement |
+|---|---|
+| `finish_type` distribution (`success`/`failure`, from `builtins.finish`) | Baseline success rate |
+| Runs terminating by step exhaustion rather than `finish` | Prompt or tool-loop problem |
+| Steps-to-finish distribution (p50/p90/max) | Efficiency; a rising p90 means the agent is flailing |
+| Per-tool call count and error rate, with top-N distinct error messages | Points at the specific tool to regenerate |
+| Tools in the config never called across all runs | Dead tools to delete from the config |
+| Tool results exceeding N chars | Violates the builder's own token-efficiency rule; rewrite to return a path |
+| Repeated identical `ToolCall` (name + args) within one run | Detected loops |
+| Tasks whose `AskOracle` produced no tool call | Prompt not landing |
+
+Report shape (small, bounded — truncate every list to top-N):
+
+```python
+{"runs_analyzed": int, "success_rate": float,
+ "step_exhaustion_rate": float, "steps": {"p50": int, "p90": int, "max": int},
+ "tools": [{"name": str, "calls": int, "errors": int,
+            "top_errors": [str], "avg_result_chars": int}],
+ "dead_tools": [str], "loops_detected": [{"tool": str, "count": int}],
+ "oversized_results": [{"tool": str, "max_chars": int}]}
+```
+
+Note in the docs that `HUGIN_CAPTURE_RENDERED_PROMPTS=1` enriches this
+materially — with it, `OracleResponse` carries `rendered_system_prompt` and
+`rendered_user_message`, so unresolved template references become visible as a
+metric rather than a guess.
+
+### 5.2 `improve_agent` task
+
+`tasks/improve_agent.yaml`, `chain_config: agent_builder`:
+
+1. `analyze_traces` on the target agent's storage.
+2. `load_agent_files` on the agent directory (Phase 4).
+3. Propose a ranked, *evidence-linked* change list — each proposed change must
+   cite a metric (e.g. "delete `fetch_summary` from the config: 0 calls across 50
+   runs"; "rewrite `render_report` to return a path: max result 41k chars").
+4. Apply via the generate_* tools.
+5. `validate_agent` → `write_agent_files(changed_only=True)` → `test_agent`.
+6. `finish` with a before/after summary.
+
+### 5.3 CLI
+
+```bash
+hugin improve <agent_path> --storage-path ./storage/<name> [--limit 50] [--dry-run]
+```
+
+`--dry-run` runs steps 1-3 and prints the evidence-linked proposal without
+touching files. That is also the useful standalone mode: "what is wrong with this
+agent?"
+
+---
+
+## Testing strategy
+
+Follow the existing pattern — the three `tests/test_agent_builder_*.py` files use
+direct tool invocation with fixtures from `tests/conftest.py`, and `MockModel`
+for LLM calls.
+
+| Phase | Tests |
+|---|---|
+| 1 | `test_validate_agent.py`: one test per check, each with a deliberately broken fixture agent (bad template ref, unresolvable tool, undeclared Jinja var, malformed signature, missing dependency) plus a known-good fixture that must pass clean. `test_write_agent_files_safety.py`: existing non-empty dir is never destroyed; `overwrite=True` produces a `.bak.<ts>`; `dry_run` writes nothing. |
+| 2 | Both knowledge surfaces resolve the same path; every reference named in `SKILL.md` exists; `search_examples` finds a known string in a known example. |
+| 3 | Build each architecture with `MockModel` and assert the emitted YAML contains the expected fields and passes `validate_agent`. |
+| 4 | Round-trip: `load_agent_files` → regenerate one file → `write_agent_files(changed_only=True)` touches exactly one file and leaves an unrelated hand-added file intact. |
+| 5 | `analyze_traces` against a synthetic storage directory built by running a fixture agent with `MockModel`, asserting each metric. |
+
+Every phase must pass `uv run pre-commit run --all-files` and `uv run pytest -x -q`.
+Note: the mypy hook has a known pre-existing failure on `openai/_client.py`
+unrelated to this work.

--- a/tests/test_write_agent_files_safety.py
+++ b/tests/test_write_agent_files_safety.py
@@ -25,7 +25,7 @@ from gimle.hugin.apps.agent_builder.tools.write_agent_files import (
 
 @pytest.fixture
 def generated_files():
-    """A minimal, valid generated-agent payload."""
+    """Return a minimal, valid generated-agent payload."""
     return {
         "configs/demo.yaml": "name: demo\n",
         "tasks/main.yaml": "name: main\n",
@@ -35,7 +35,7 @@ def generated_files():
 
 @pytest.fixture
 def stack(generated_files):
-    """A stack stub exposing only what the writer touches."""
+    """Return a stack stub exposing only what the writer touches."""
     environment = SimpleNamespace(
         env_vars={
             "generated_files": generated_files,
@@ -178,9 +178,7 @@ class TestWriterDoesNotDestroy:
 
         assert custom.read_text() == "# mine\n"
 
-    def test_second_run_writes_nothing_when_unchanged(
-        self, stack, tmp_path
-    ):
+    def test_second_run_writes_nothing_when_unchanged(self, stack, tmp_path):
         """Re-running over an identical agent is a no-op, not a rewrite."""
         output = tmp_path / "demo"
 
@@ -255,9 +253,7 @@ class TestDryRun:
     def test_reports_what_would_be_written(self, stack, tmp_path):
         """The reported set matches what a real write produces."""
         output = tmp_path / "demo"
-        preview = write_agent_files(
-            stack, str(output), "demo", dry_run=True
-        )
+        preview = write_agent_files(stack, str(output), "demo", dry_run=True)
         actual = write_agent_files(stack, str(output), "demo")
 
         assert preview.content["would_write"] == actual.content["written"]

--- a/tests/test_write_agent_files_safety.py
+++ b/tests/test_write_agent_files_safety.py
@@ -259,6 +259,150 @@ class TestDryRun:
         assert preview.content["would_write"] == actual.content["written"]
 
 
+class TestNamingStyleDoesNotDiscardTheBuild:
+    """Confinement is a security rule; snake_case was taste, and it aborted."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "tools/getWeather.py",
+            "tools/my-tool.py",
+            "tools/fetch.v2.py",
+            "configs/Demo.yaml",
+        ],
+    )
+    def test_unconventional_but_safe_names_are_accepted(self, key):
+        """One oddly-named tool must not discard an otherwise good agent."""
+        assert validate_generated_key(key) is None
+
+    def test_a_camelcase_tool_still_writes_the_whole_agent(
+        self, stack, tmp_path
+    ):
+        """The regression: every valid file was dropped over one name."""
+        env_vars = stack.agent.environment.env_vars
+        env_vars["generated_files"]["tools/getWeather.py"] = "x = 1\n"
+
+        result = write_agent_files(stack, str(tmp_path / "demo"), "demo")
+
+        assert not result.is_error
+        assert "tools/getWeather.py" in result.content["written"]
+
+    def test_traversal_is_still_refused(self):
+        """Loosening style must not loosen confinement."""
+        assert validate_generated_key("tools/../../evil.py") is not None
+
+
+class TestEncoding:
+    """Content is written as UTF-8, so it must be read back as UTF-8."""
+
+    def test_non_ascii_roundtrips_as_unchanged(self, stack, tmp_path):
+        """A locale-default read made this comparison wrong off UTF-8."""
+        env_vars = stack.agent.environment.env_vars
+        env_vars["generated_files"][
+            "templates/demo_system.yaml"
+        ] = "name: demo_system\ntemplate: Grüße, naïve café\n"
+        output = tmp_path / "demo"
+
+        write_agent_files(stack, str(output), "demo")
+        second = write_agent_files(stack, str(output), "demo")
+
+        assert "templates/demo_system.yaml" in second.content["unchanged"]
+
+    def test_undecodable_existing_file_does_not_escape(self, stack, tmp_path):
+        """A decode error is a ValueError, so it slipped past OSError."""
+        output = tmp_path / "demo"
+        (output / "configs").mkdir(parents=True)
+        (output / "configs" / "demo.yaml").write_bytes(b"\xff\xfe\x00bad")
+
+        result = write_agent_files(stack, str(output), "demo")
+
+        assert not result.is_error
+        assert "configs/demo.yaml" in result.content["written"]
+
+
+class TestFileMode:
+    """Generated agents are ordinary project files, not sandbox scratch."""
+
+    def test_files_are_not_owner_only(self, stack, tmp_path):
+        """0600 broke running the agent as a service or container user."""
+        output = tmp_path / "demo"
+        write_agent_files(stack, str(output), "demo")
+
+        mode = (output / "configs" / "demo.yaml").stat().st_mode & 0o777
+
+        assert mode & 0o044, oct(mode)
+
+
+class TestArgumentCoercion:
+    """Tool arguments arrive from the model unconverted."""
+
+    def test_string_false_does_not_skip_the_write(self, stack, tmp_path):
+        """bool("false") is True, which silently turned a write into a no-op."""
+        output = tmp_path / "demo"
+
+        result = write_agent_files(stack, str(output), "demo", dry_run="false")
+
+        assert result.content.get("dry_run") is not True
+        assert (output / "configs" / "demo.yaml").exists()
+
+    def test_string_true_still_previews(self, stack, tmp_path):
+        """The affirmative spelling keeps working."""
+        output = tmp_path / "demo"
+
+        result = write_agent_files(stack, str(output), "demo", dry_run="true")
+
+        assert result.content["dry_run"] is True
+        assert not output.exists()
+
+
+class TestSupersededFiles:
+    """Dropping rmtree lost the "directory holds one generation" invariant."""
+
+    def test_regenerated_under_a_new_name_removes_the_old(
+        self, stack, tmp_path
+    ):
+        """Otherwise both configs register and the stale one can win."""
+        output = tmp_path / "demo"
+        write_agent_files(stack, str(output), "demo")
+        assert (output / "configs" / "demo.yaml").exists()
+
+        env_vars = stack.agent.environment.env_vars
+        files = env_vars["generated_files"]
+        files["configs/renamed.yaml"] = files.pop("configs/demo.yaml")
+
+        result = write_agent_files(stack, str(output), "demo")
+
+        assert not (output / "configs" / "demo.yaml").exists()
+        assert (output / "configs" / "renamed.yaml").exists()
+        assert "configs/demo.yaml" in result.content["removed"]
+
+    def test_user_files_are_never_removed(self, stack, tmp_path):
+        """Removal is driven by what we wrote, never by scanning the dir."""
+        output = tmp_path / "demo"
+        write_agent_files(stack, str(output), "demo")
+        mine = output / "configs" / "mine.yaml"
+        mine.write_text("hand-written")
+
+        env_vars = stack.agent.environment.env_vars
+        files = env_vars["generated_files"]
+        files["configs/renamed.yaml"] = files.pop("configs/demo.yaml")
+        write_agent_files(stack, str(output), "demo")
+
+        assert mine.read_text() == "hand-written"
+
+
+class TestHomeDirectoryExpansion:
+    """One half of check_output_path expanded ~ and the other did not."""
+
+    def test_tilde_home_is_refused(self):
+        """The guard whose only job is refusing $HOME must see it."""
+        assert check_output_path("~") is not None
+
+    def test_tilde_subpath_is_allowed_but_expanded(self, stack, tmp_path):
+        """~ paths must not create a literal '~' directory in the cwd."""
+        assert check_output_path("~/agents/demo") is None
+
+
 class TestGeneratedReadme:
     """The README used to name an entrypoint that does not exist."""
 

--- a/tests/test_write_agent_files_safety.py
+++ b/tests/test_write_agent_files_safety.py
@@ -6,6 +6,7 @@ Covers the two data-loss bugs PR 1.1 exists to fix: the unconditional
 filesystem.
 """
 
+import shlex
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -19,8 +20,10 @@ from gimle.hugin.apps.agent_builder.tools.agent_paths import (
     validate_generated_key,
 )
 from gimle.hugin.apps.agent_builder.tools.write_agent_files import (
+    _write_confined,
     write_agent_files,
 )
+from gimle.hugin.cli import create_agent
 
 
 @pytest.fixture
@@ -178,6 +181,40 @@ class TestWriterDoesNotDestroy:
 
         assert custom.read_text() == "# mine\n"
 
+    def test_refuses_to_overwrite_existing_generated_path(
+        self, stack, tmp_path
+    ):
+        """A same-named user file is a conflict, not permission to truncate."""
+        output = tmp_path / "demo"
+        (output / "configs").mkdir(parents=True)
+        custom = output / "configs" / "demo.yaml"
+        custom.write_text("# customized\n")
+
+        result = write_agent_files(stack, str(output), "demo")
+
+        assert result.is_error
+        assert result.content["conflicts"] == ["configs/demo.yaml"]
+        assert custom.read_text() == "# customized\n"
+        assert not (output / "tasks" / "main.yaml").exists()
+
+    def test_refuses_to_overwrite_builder_file_modified_by_user(
+        self, stack, tmp_path
+    ):
+        """Ownership ends when on-disk content no longer matches its hash."""
+        output = tmp_path / "demo"
+        write_agent_files(stack, str(output), "demo")
+        config = output / "configs" / "demo.yaml"
+        config.write_text("# user's change\n")
+        stack.agent.environment.env_vars["generated_files"][
+            "configs/demo.yaml"
+        ] = "name: regenerated\n"
+
+        result = write_agent_files(stack, str(output), "demo")
+
+        assert result.is_error
+        assert "configs/demo.yaml" in result.content["conflicts"]
+        assert config.read_text() == "# user's change\n"
+
     def test_second_run_writes_nothing_when_unchanged(self, stack, tmp_path):
         """Re-running over an identical agent is a no-op, not a rewrite."""
         output = tmp_path / "demo"
@@ -308,16 +345,17 @@ class TestEncoding:
 
         assert "templates/demo_system.yaml" in second.content["unchanged"]
 
-    def test_undecodable_existing_file_does_not_escape(self, stack, tmp_path):
-        """A decode error is a ValueError, so it slipped past OSError."""
+    def test_undecodable_existing_file_is_preserved(self, stack, tmp_path):
+        """Unknown binary content is a conflict rather than overwrite fodder."""
         output = tmp_path / "demo"
         (output / "configs").mkdir(parents=True)
-        (output / "configs" / "demo.yaml").write_bytes(b"\xff\xfe\x00bad")
+        existing = output / "configs" / "demo.yaml"
+        existing.write_bytes(b"\xff\xfe\x00bad")
 
         result = write_agent_files(stack, str(output), "demo")
 
-        assert not result.is_error
-        assert "configs/demo.yaml" in result.content["written"]
+        assert result.is_error
+        assert existing.read_bytes() == b"\xff\xfe\x00bad"
 
 
 class TestFileMode:
@@ -390,6 +428,75 @@ class TestSupersededFiles:
 
         assert mine.read_text() == "hand-written"
 
+    def test_modified_builder_file_is_not_removed(self, stack, tmp_path):
+        """A superseded path is deletable only while its ownership hash matches."""
+        output = tmp_path / "demo"
+        write_agent_files(stack, str(output), "demo")
+        old = output / "configs" / "demo.yaml"
+        old.write_text("# user changed this\n")
+
+        files = stack.agent.environment.env_vars["generated_files"]
+        files["configs/renamed.yaml"] = files.pop("configs/demo.yaml")
+        result = write_agent_files(stack, str(output), "demo")
+
+        assert result.is_error
+        assert "configs/demo.yaml" in result.content["conflicts"]
+        assert old.read_text() == "# user changed this\n"
+        assert not (output / "configs" / "renamed.yaml").exists()
+
+    def test_identical_preexisting_file_is_not_claimed_or_removed(
+        self, stack, tmp_path
+    ):
+        """An unchanged file is not proof that this builder created it."""
+        output = tmp_path / "demo"
+        (output / "configs").mkdir(parents=True)
+        old = output / "configs" / "demo.yaml"
+        old.write_text("name: demo\n")
+        write_agent_files(stack, str(output), "demo")
+
+        files = stack.agent.environment.env_vars["generated_files"]
+        files["configs/renamed.yaml"] = files.pop("configs/demo.yaml")
+        result = write_agent_files(stack, str(output), "demo")
+
+        assert not result.is_error
+        assert old.read_text() == "name: demo\n"
+        assert "configs/demo.yaml" in result.content["preserved"]
+
+    def test_ownership_is_scoped_to_output_directory(self, stack, tmp_path):
+        """Writes in one destination never authorize deletion in another."""
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        write_agent_files(stack, str(first), "demo")
+        (second / "configs").mkdir(parents=True)
+        keep = second / "configs" / "demo.yaml"
+        keep.write_text("name: demo\n")
+
+        files = stack.agent.environment.env_vars["generated_files"]
+        files["configs/renamed.yaml"] = files.pop("configs/demo.yaml")
+        result = write_agent_files(stack, str(second), "demo")
+
+        assert not result.is_error
+        assert keep.exists()
+        assert "configs/demo.yaml" in result.content["preserved"]
+
+
+class TestNoFollowWrites:
+    """Every directory hop is protected, not only the final filename."""
+
+    def test_refuses_symlinked_parent_even_when_target_stays_inside_root(
+        self, tmp_path
+    ):
+        """A parent symlink cannot redirect the descriptor-relative write."""
+        root = tmp_path / "agent"
+        real = root / "real-tools"
+        real.mkdir(parents=True)
+        (root / "tools").symlink_to(real, target_is_directory=True)
+
+        with pytest.raises(PathConfinementError):
+            _write_confined(root, "tools/escape.py", "escaped = True\n")
+
+        assert not (real / "escape.py").exists()
+
 
 class TestHomeDirectoryExpansion:
     """One half of check_output_path expanded ~ and the other did not."""
@@ -401,6 +508,25 @@ class TestHomeDirectoryExpansion:
     def test_tilde_subpath_is_allowed_but_expanded(self, stack, tmp_path):
         """~ paths must not create a literal '~' directory in the cwd."""
         assert check_output_path("~/agents/demo") is None
+
+    def test_wizard_returns_the_expanded_home_path(self, monkeypatch, tmp_path):
+        """Validation and the path handed to the builder must agree."""
+        answers = iter(["demo", "description", "haiku-latest", "~/agents/demo"])
+        confirmations = iter([True, True])
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            create_agent, "prompt_user", lambda *args, **kwargs: next(answers)
+        )
+        monkeypatch.setattr(
+            create_agent,
+            "prompt_yes_no",
+            lambda *args, **kwargs: next(confirmations),
+        )
+        monkeypatch.setattr(create_agent, "show_header", lambda *args: None)
+
+        result = create_agent.run_wizard(builder_model="builder-model")
+
+        assert result["output_path"] == str(tmp_path / "agents" / "demo")
 
 
 class TestGeneratedReadme:
@@ -430,3 +556,18 @@ class TestGeneratedReadme:
         assert run_command("/tmp/demo", None) == (
             "uv run hugin run --task-path /tmp/demo"
         )
+
+    def test_run_command_shell_quotes_output_path(self):
+        """Spaces in a user-selected output directory remain one argument."""
+        command = run_command("/tmp/my generated agent", "main")
+
+        assert shlex.split(command) == [
+            "uv",
+            "run",
+            "hugin",
+            "run",
+            "--task",
+            "main",
+            "--task-path",
+            "/tmp/my generated agent",
+        ]

--- a/tests/test_write_agent_files_safety.py
+++ b/tests/test_write_agent_files_safety.py
@@ -1,0 +1,292 @@
+"""Safety tests for the agent builder's file writer.
+
+Covers the two data-loss bugs PR 1.1 exists to fix: the unconditional
+``shutil.rmtree`` of the output directory, and the unvalidated
+``output_dir / key`` join that let an LLM-chosen file name write anywhere on the
+filesystem.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gimle.hugin.apps.agent_builder.tools.agent_paths import (
+    PathConfinementError,
+    check_output_path,
+    confine,
+    run_command,
+    validate_generated_key,
+)
+from gimle.hugin.apps.agent_builder.tools.write_agent_files import (
+    write_agent_files,
+)
+
+
+@pytest.fixture
+def generated_files():
+    """A minimal, valid generated-agent payload."""
+    return {
+        "configs/demo.yaml": "name: demo\n",
+        "tasks/main.yaml": "name: main\n",
+        "templates/demo_system.yaml": "name: demo_system\n",
+    }
+
+
+@pytest.fixture
+def stack(generated_files):
+    """A stack stub exposing only what the writer touches."""
+    environment = SimpleNamespace(
+        env_vars={
+            "generated_files": generated_files,
+            "user_input": {
+                "agent_name": "demo",
+                "description": "A demo agent",
+            },
+        },
+        load_agent_from_path=lambda path: "demo",
+    )
+    return SimpleNamespace(agent=SimpleNamespace(environment=environment))
+
+
+class TestGeneratedKeyValidation:
+    """Keys come from the LLM, so they are validated before any path join."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "../../../../etc/passwd",
+            "tools/../../../escape.py",
+            "/etc/passwd",
+            "~/.bashrc",
+            "..",
+            "tools\\win.py",
+            " configs/demo.yaml",
+        ],
+    )
+    def test_rejects_escaping_keys(self, key):
+        """Traversal, absolute and home-relative keys are refused."""
+        assert validate_generated_key(key) is not None
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "configs/demo.yaml",
+            "tasks/main.yaml",
+            "tools/fetch_prices.py",
+            "templates/demo_system.yaml",
+        ],
+    )
+    def test_accepts_well_formed_keys(self, key):
+        """The shape the generators actually emit passes."""
+        assert validate_generated_key(key) is None
+
+    def test_rejects_unexpected_extension(self):
+        """Only YAML and Python belong in a generated agent."""
+        assert validate_generated_key("configs/demo.txt") is not None
+
+
+class TestConfinement:
+    """An absolute operand replaces the root, so joins must be checked."""
+
+    def test_absolute_key_would_escape_without_confinement(self, tmp_path):
+        """Documents the pathlib behaviour this module exists to defeat."""
+        assert str(tmp_path / "/etc/passwd") == "/etc/passwd"
+
+    def test_confine_rejects_absolute_key(self, tmp_path):
+        """The same join goes through confine() and is refused."""
+        with pytest.raises(PathConfinementError):
+            confine(tmp_path, "/etc/passwd")
+
+    def test_confine_rejects_traversal(self, tmp_path):
+        """``..`` never resolves outside the output directory."""
+        with pytest.raises(PathConfinementError):
+            confine(tmp_path, "../../evil.py")
+
+    def test_confine_resolves_valid_key_under_root(self, tmp_path):
+        """A well-formed key lands where it should."""
+        resolved = confine(tmp_path, "tools/fetch.py")
+        assert resolved == Path(tmp_path).resolve() / "tools" / "fetch.py"
+
+    def test_confine_rejects_symlink_escape(self, tmp_path):
+        """A symlinked subdirectory pointing outside the tree is refused."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        root = tmp_path / "agent"
+        root.mkdir()
+        (root / "tools").symlink_to(outside, target_is_directory=True)
+        with pytest.raises(PathConfinementError):
+            confine(root, "tools/evil.py")
+
+
+class TestOutputPathGuards:
+    """``output_path`` arrives as a plain task parameter."""
+
+    def test_rejects_filesystem_root(self):
+        """Writing an agent to / is never intended."""
+        assert check_output_path("/") is not None
+
+    def test_rejects_home_directory(self):
+        """The old rmtree pointed at $HOME would have erased it."""
+        assert check_output_path(str(Path.home())) is not None
+
+    def test_rejects_repository_root(self, tmp_path):
+        """A directory containing .git is a repo, not an agent target."""
+        (tmp_path / ".git").mkdir()
+        assert check_output_path(str(tmp_path)) is not None
+
+    def test_rejects_symlinked_target(self, tmp_path):
+        """A symlinked component means the real target is elsewhere."""
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real, target_is_directory=True)
+        assert check_output_path(str(link)) is not None
+
+    def test_accepts_ordinary_subdirectory(self, tmp_path):
+        """The normal case is not blocked."""
+        assert check_output_path(str(tmp_path / "agents" / "demo")) is None
+
+
+class TestWriterDoesNotDestroy:
+    """The headline regression: the writer used to rmtree its target."""
+
+    def test_preserves_unrelated_existing_file(
+        self, stack, tmp_path, generated_files
+    ):
+        """A hand-added file survives a write and is reported as preserved."""
+        output = tmp_path / "demo"
+        output.mkdir()
+        keep = output / "my_notes.md"
+        keep.write_text("hand-written, do not delete")
+
+        result = write_agent_files(stack, str(output), "demo")
+
+        assert not result.is_error
+        assert keep.exists()
+        assert keep.read_text() == "hand-written, do not delete"
+        assert "my_notes.md" in result.content["preserved"]
+
+    def test_preserves_hand_edited_tool(self, stack, tmp_path):
+        """Files the builder did not generate are never overwritten."""
+        output = tmp_path / "demo"
+        (output / "tools").mkdir(parents=True)
+        custom = output / "tools" / "my_own_tool.py"
+        custom.write_text("# mine\n")
+
+        write_agent_files(stack, str(output), "demo")
+
+        assert custom.read_text() == "# mine\n"
+
+    def test_second_run_writes_nothing_when_unchanged(
+        self, stack, tmp_path
+    ):
+        """Re-running over an identical agent is a no-op, not a rewrite."""
+        output = tmp_path / "demo"
+
+        first = write_agent_files(stack, str(output), "demo")
+        assert first.content["written"]
+
+        second = write_agent_files(stack, str(output), "demo")
+        assert second.content["written"] == []
+        assert "configs/demo.yaml" in second.content["unchanged"]
+
+    def test_updates_only_the_changed_file(self, stack, tmp_path):
+        """A single regenerated file touches exactly one path on disk."""
+        output = tmp_path / "demo"
+        write_agent_files(stack, str(output), "demo")
+
+        env_vars = stack.agent.environment.env_vars
+        env_vars["generated_files"]["configs/demo.yaml"] = "name: demo2\n"
+
+        result = write_agent_files(stack, str(output), "demo")
+
+        assert result.content["written"] == ["configs/demo.yaml"]
+
+
+class TestWriterRefusals:
+    """Bad input is refused rather than written."""
+
+    def test_refuses_escaping_generated_key(self, stack, tmp_path):
+        """A traversal key is a hard error, and nothing is written."""
+        env_vars = stack.agent.environment.env_vars
+        env_vars["generated_files"]["../../evil.py"] = "pwned"
+        output = tmp_path / "demo"
+
+        result = write_agent_files(stack, str(output), "demo")
+
+        assert result.is_error
+        assert not (tmp_path.parent / "evil.py").exists()
+        assert not output.exists()
+
+    def test_refuses_absolute_generated_key(self, stack, tmp_path):
+        """An absolute key would otherwise replace the output directory."""
+        env_vars = stack.agent.environment.env_vars
+        env_vars["generated_files"]["/tmp/pwned.py"] = "pwned"
+
+        result = write_agent_files(stack, str(tmp_path / "demo"), "demo")
+
+        assert result.is_error
+
+    def test_refuses_unsafe_output_path(self, stack):
+        """The output path guards apply to the tool, not just the helper."""
+        result = write_agent_files(stack, str(Path.home()), "demo")
+        assert result.is_error
+
+    def test_refuses_when_nothing_generated(self, stack, tmp_path):
+        """Unchanged behaviour, kept under test."""
+        stack.agent.environment.env_vars["generated_files"] = {}
+        result = write_agent_files(stack, str(tmp_path / "demo"), "demo")
+        assert result.is_error
+
+
+class TestDryRun:
+    """``dry_run`` is what makes a preview possible before any write."""
+
+    def test_writes_nothing(self, stack, tmp_path):
+        """The directory is not even created."""
+        output = tmp_path / "demo"
+        result = write_agent_files(stack, str(output), "demo", dry_run=True)
+
+        assert not result.is_error
+        assert not output.exists()
+        assert result.content["dry_run"] is True
+
+    def test_reports_what_would_be_written(self, stack, tmp_path):
+        """The reported set matches what a real write produces."""
+        output = tmp_path / "demo"
+        preview = write_agent_files(
+            stack, str(output), "demo", dry_run=True
+        )
+        actual = write_agent_files(stack, str(output), "demo")
+
+        assert preview.content["would_write"] == actual.content["written"]
+
+
+class TestGeneratedReadme:
+    """The README used to name an entrypoint that does not exist."""
+
+    def test_run_command_uses_the_real_entrypoint(self, stack, tmp_path):
+        """``run-agent`` is gone; ``hugin run`` is the only command."""
+        output = tmp_path / "demo"
+        write_agent_files(stack, str(output), "demo")
+
+        readme = (output / "README.md").read_text()
+
+        assert "run-agent" not in readme
+        assert "uv run hugin run" in readme
+
+    def test_run_command_names_the_generated_task(self, stack, tmp_path):
+        """The command is runnable as printed, not a placeholder."""
+        output = tmp_path / "demo"
+        write_agent_files(stack, str(output), "demo")
+
+        readme = (output / "README.md").read_text()
+
+        assert "--task main" in readme
+
+    def test_run_command_helper_omits_task_when_unknown(self):
+        """Without a task the command degrades rather than lying."""
+        assert run_command("/tmp/demo", None) == (
+            "uv run hugin run --task-path /tmp/demo"
+        )


### PR DESCRIPTION
## Summary

`write_agent_files` had two destructive behaviors reachable from an ordinary
`hugin create` run: it removed the whole output directory before writing, and it
joined LLM-generated file names to that directory without validating or
confining them.

This is the first PR of task 034 (Agent Creator v2); the reviewed task documents
land with it under `tasks/open/034-agent-creator-v2/`.

## Changes

- Added shared generated-key validation and path confinement in
  `tools/agent_paths.py`.
- Reworked `write_agent_files` around scoped ownership:
  - unknown or user-modified files are blocking conflicts and are never
    overwritten;
  - files actually written by the current builder session are tracked by
    resolved output directory and content hash;
  - builder-owned files can be updated or removed when superseded only while
    their on-disk hash still matches;
  - writes are atomic and descriptor-relative, with `O_NOFOLLOW` applied at
    every directory hop rather than only the final filename;
  - `dry_run` reports writes and safe removals without touching the filesystem.
- Preserved unrelated files and report them explicitly.
- Fixed `~/...` output paths so validation and the path handed to the builder
  use the same expanded location.
- Unified the generated README and CLI success command on the real
  `uv run hugin run` entrypoint, with shell-safe argument quoting.
- Updated the task plan/spec to document the ownership and confinement model.

## Testing

- `tests/test_write_agent_files_safety.py`: 58 tests, including traversal,
  absolute paths, symlink escapes and symlinked parents, same-name user files,
  post-write user edits, output-scoped ownership, safe superseded cleanup,
  `dry_run`, `~` expansion, modes, encoding, and shell quoting.
- Full suite: **1154 passed, 53 skipped**.
- Standalone mypy on all changed source files: clean.
- Black (file-by-file), isort, flake8, YAML, whitespace, EOF, and
  detect-secrets checks: clean.

The combined pre-commit mypy hook still encounters its known internal error in
the installed third-party `openai/_client.py`; the changed source files pass the
repository's standalone mypy configuration.
