### PR TITLE
fix(dreaming): bound the episodic corpus by size, newest-first

### DIFF
--- a/src/gimle/hugin/dreaming/consolidate.py
+++ b/src/gimle/hugin/dreaming/consolidate.py
@@ -22,24 +22,72 @@ from gimle.hugin.dreaming.provenance import (
 logger = logging.getLogger(__name__)
 
 DREAMER_CONFIG_NAME = "dreamer"
+#: Character budget for one scope's episodic corpus in a single dream prompt.
+#: ~30k tokens: comfortably inside any current context alongside the system
+#: prompt and the worker's own reasoning, while still spanning weeks of a
+#: short-form scope. Raise it when models grow; do not remove it — unbounded was
+#: the bug.
+DEFAULT_CORPUS_CHARS = 120_000
 DREAM_SCOPE_KEY = "dream_scope"
 DREAM_DRY_RUN_KEY = "dream_dry_run"
 DREAM_RESULTS_KEY = "dream_results"
 
 
 def _episodic_block(
-    environment: Environment, provenances: List[ArtifactProvenance]
+    environment: Environment,
+    provenances: List[ArtifactProvenance],
+    max_chars: int = DEFAULT_CORPUS_CHARS,
 ) -> str:
-    """Fetch the episodic artifacts' content as a readable block."""
+    """Fetch episodic content as a readable block, newest-first within a budget.
+
+    The budget is the point. This replayed a config's ENTIRE history every night,
+    so the prompt grew without bound as the corpus accumulated, and a scope whose
+    artifacts are large crossed the model's usable limit and started consolidating
+    nothing — silently, since a dream that saves zero learnings still succeeds.
+
+    Bounded on SIZE rather than count because artifact sizes differ by an order of
+    magnitude between scopes writing to the same store. In the case that exposed
+    this, three personas each had 53 artifacts: the one writing short pieces still
+    worked, while the two writing long ones had been dead for weeks. A count cap
+    ("last 30") would have left both of those broken and needlessly starved the
+    third; a character budget self-balances with no per-scope tuning.
+
+    Newest-first selection, then presented oldest-first so the corpus still reads
+    chronologically. Anything dropped is LOGGED — a silently trimmed corpus reads
+    as "it considered everything", which is how this went unnoticed in the first
+    place.
+    """
     engine = environment.query_engine
-    lines: List[str] = []
-    for provenance in provenances:
+    # Newest first, so the budget keeps recent memory. A missing created_at sorts
+    # oldest and is therefore dropped first — the conservative direction.
+    ordered = sorted(
+        provenances, key=lambda p: p.created_at or "", reverse=True
+    )
+
+    chosen: List[tuple[ArtifactProvenance, str]] = []
+    used = 0
+    for provenance in ordered:
         content = engine.get_artifact_content(provenance.artifact_id) or ""
-        task_label = provenance.task or "general"
-        lines.append(
-            f"- [{provenance.artifact_id}] (task: {task_label})\n  {content}"
+        entry = f"- [{provenance.artifact_id}] (task: {provenance.task or 'general'})\n  {content}"
+        # Always take at least one, or a single oversized artifact yields an empty
+        # corpus and the dream silently does nothing — the failure this fixes.
+        if chosen and used + len(entry) > max_chars:
+            continue
+        chosen.append((provenance, entry))
+        used += len(entry)
+
+    dropped = len(ordered) - len(chosen)
+    if dropped:
+        logger.info(
+            "dream: corpus trimmed to %d of %d artifacts (%d chars, budget %d) — "
+            "oldest dropped first",
+            len(chosen),
+            len(ordered),
+            used,
+            max_chars,
         )
-    return "\n".join(lines)
+    # Back to chronological for the reader.
+    return "\n".join(entry for _, entry in reversed(chosen))
 
 
 def _consolidate_prompt(config_name: str, episodic_block: str) -> str:

--- a/src/gimle/hugin/dreaming/provenance.py
+++ b/src/gimle/hugin/dreaming/provenance.py
@@ -38,6 +38,15 @@ class ArtifactProvenance:
     config: Optional[str]
     task: Optional[str]
     interaction_id: Optional[str]
+    #: The artifact's own ``created_at`` (ISO-8601), for ordering a corpus
+    #: newest-first. Free to carry: ``scan_provenance`` already loads and parses
+    #: the whole record to read ``data["interaction"]``, and every artifact gets a
+    #: ``created_at`` from ``@with_uuid``. Nothing about the stored artifact
+    #: changes — this dataclass is built fresh per scan and never serialized.
+    #:
+    #: ``None`` only for a record written before that decorator applied; such an
+    #: artifact sorts oldest, so it is dropped first when a corpus is trimmed.
+    created_at: Optional[str] = None
 
 
 def _config_by_position(agent: Agent) -> Dict[int, Optional[str]]:
@@ -148,6 +157,7 @@ def scan_provenance(
                 config=config,
                 task=task,
                 interaction_id=interaction_id,
+                created_at=data.get("created_at"),
             )
         )
     return provenances

--- a/tests/test_dream_corpus_window.py
+++ b/tests/test_dream_corpus_window.py
@@ -1,0 +1,120 @@
+"""The dream's episodic corpus is bounded by SIZE, newest-first.
+
+This replayed a scope's entire history into one prompt every night, so the corpus
+grew without bound. A scope whose artifacts are large eventually crossed the
+model's usable limit and started consolidating nothing — silently, because a dream
+that saves zero learnings still succeeds.
+
+Bounded on size rather than count because artifact sizes differ by an order of
+magnitude between scopes sharing a store. In the case that exposed this, three
+personas each had 53 artifacts: the short-form one still worked while the two
+long-form ones had been dead for weeks. A count cap would have left both broken.
+"""
+
+from types import SimpleNamespace
+
+from gimle.hugin.dreaming.consolidate import (
+    DEFAULT_CORPUS_CHARS,
+    _episodic_block,
+)
+from gimle.hugin.dreaming.provenance import ArtifactProvenance
+
+
+def _env(contents):
+    """Build an Environment stub returning canned artifact content."""
+    return SimpleNamespace(
+        query_engine=SimpleNamespace(
+            get_artifact_content=lambda aid: contents[aid]
+        )
+    )
+
+
+def _prov(aid, created_at=None):
+    return ArtifactProvenance(
+        artifact_id=aid,
+        artifact_type="Text",
+        config="c",
+        task="t",
+        interaction_id="i",
+        created_at=created_at,
+    )
+
+
+def test_small_corpus_is_untouched():
+    """Keep a within-budget scope byte-identical to the old behaviour.
+
+    The short-form persona was still working, and must keep working.
+    """
+    contents = {"a": "alpha", "b": "beta", "c": "gamma"}
+    provs = [
+        _prov("a", "2026-01-01T00:00:00Z"),
+        _prov("b", "2026-01-02T00:00:00Z"),
+        _prov("c", "2026-01-03T00:00:00Z"),
+    ]
+    block = _episodic_block(_env(contents), provs)
+    for text in contents.values():
+        assert text in block
+
+
+def test_oldest_are_dropped_when_over_budget():
+    """Drop the oldest memories first when the corpus exceeds its budget."""
+    contents = {"old": "O" * 400, "mid": "M" * 400, "new": "N" * 400}
+    provs = [
+        _prov("old", "2026-01-01T00:00:00Z"),
+        _prov("mid", "2026-06-01T00:00:00Z"),
+        _prov("new", "2026-12-01T00:00:00Z"),
+    ]
+    block = _episodic_block(_env(contents), provs, max_chars=900)
+    assert "N" * 400 in block, "the newest memory must survive"
+    assert "M" * 400 in block
+    assert "O" * 400 not in block, "the oldest is dropped first"
+
+
+def test_kept_corpus_reads_chronologically():
+    """Selection is newest-first, but the prompt should still read oldest→newest."""
+    contents = {"one": "FIRST", "two": "SECOND", "three": "THIRD"}
+    provs = [
+        _prov("three", "2026-03-01T00:00:00Z"),
+        _prov("one", "2026-01-01T00:00:00Z"),
+        _prov("two", "2026-02-01T00:00:00Z"),
+    ]
+    block = _episodic_block(_env(contents), provs)
+    assert block.index("FIRST") < block.index("SECOND") < block.index("THIRD")
+
+
+def test_one_oversized_artifact_still_yields_a_corpus():
+    """Never return an empty block.
+
+    An empty corpus makes the dream silently do nothing, which is the exact
+    failure this fixes.
+    """
+    contents = {"huge": "H" * 5000}
+    block = _episodic_block(
+        _env(contents), [_prov("huge", "2026-01-01T00:00:00Z")], max_chars=10
+    )
+    assert "H" * 5000 in block
+
+
+def test_missing_created_at_sorts_oldest_and_is_dropped_first():
+    """Treat an undated artifact as the oldest.
+
+    Conservative: it is dropped before anything we can actually date.
+    """
+    contents = {"undated": "U" * 400, "dated": "D" * 400}
+    provs = [_prov("undated", None), _prov("dated", "2026-01-01T00:00:00Z")]
+    block = _episodic_block(_env(contents), provs, max_chars=500)
+    assert "D" * 400 in block
+    assert "U" * 400 not in block
+
+
+def test_budget_default_is_generous_enough_for_a_short_form_scope():
+    """Leave a healthy short-form scope entirely untrimmed at the default."""
+    # ~53 artifacts of ~1.5KB (the working persona's real shape) must not be
+    # trimmed at all — the fix must not degrade a scope that was healthy.
+    contents = {f"a{i}": "x" * 1500 for i in range(53)}
+    provs = [
+        _prov(f"a{i}", f"2026-01-{i % 28 + 1:02d}T00:00:00Z") for i in range(53)
+    ]
+    block = _episodic_block(_env(contents), provs)
+    assert block.count("[a") == 53
+    assert 53 * 1500 < DEFAULT_CORPUS_CHARS


### PR DESCRIPTION
## Summary

`_episodic_block` replayed a config's **entire history** into one prompt on every dream. No cap, no window, no sampling — so the corpus grew without bound as artifacts accumulated, and a scope whose artifacts are large eventually crossed the model's usable limit and started consolidating **nothing**.

Silently. A dream that saves zero learnings still succeeds and reports success.

## Found in production

Three newspaper personas write into one store, each with **53 artifacts**. The one filing short op-eds still worked; the two filing whole editions and long-form deep-dives had been dead for weeks — and they died in descending order of artifact size (editions first, long-reads second, op-eds still alive).

Same artifact count, very different prompt.

## Why the bound is on size, not count

A count cap (`last 30`) would have left both large scopes broken **and** needlessly starved the healthy one. A character budget self-balances with no per-scope tuning, and a scope already inside it is untouched.

- **Newest-first selection**, then presented **oldest-first** so the corpus still reads chronologically.
- **Trimming is logged.** A silently shortened corpus reads as "it considered everything" — the same class of quiet failure that let the original bug run for weeks.
- **At least one artifact is always included**, or a single oversized one yields an empty corpus and the dream does nothing: precisely the failure being fixed.

## On `created_at` — no artifact change

`ArtifactProvenance` now carries `created_at` to order by. This costs nothing and changes **no stored data**:

- `scan_provenance` already loads and parses each full record to read `data["interaction"]` — this is one more `.get()` on a dict already in hand, no extra I/O.
- Every artifact already gets a `created_at` from `@with_uuid` and already persists it via `to_dict()`. The field exists on disk today.
- `ArtifactProvenance` is an in-memory dataclass built fresh per scan and **never serialized**.

Nothing is migrated or rewritten. An artifact without a timestamp sorts oldest and is dropped first — the conservative direction.

## Testing

`tests/test_dream_corpus_window.py` — 6 tests: a within-budget scope is untouched (the healthy persona must keep working); oldest dropped first when over budget; kept corpus reads chronologically; one oversized artifact still yields a corpus; a missing `created_at` sorts oldest; and the default budget leaves a realistic short-form scope (53 × ~1.5KB) entirely untrimmed.

Full suite: **1078 passed, 53 skipped**. `flake8` / `black` / `isort` / secrets clean.

> `mypy` fails in this repo with an INTERNAL ERROR inside the vendored `openai` package — verified pre-existing on clean `main`, unrelated to this change.

## Companion

gimle-heimdall #1034 fixes the other half of the same outage: the daily job pinned `--model haiku-latest`, which bails before its first tool call. Together they restore all three personas; either alone restores only some.