### PR TITLE
Report terminal Hugin session outcomes to the router

### DIFF
--- a/src/gimle/hugin/agent/session.py
+++ b/src/gimle/hugin/agent/session.py
@@ -7,6 +7,7 @@ from gimle.hugin.agent.agent import Agent
 from gimle.hugin.agent.config import Config
 from gimle.hugin.agent.environment import Environment
 from gimle.hugin.agent.session_state import SessionState
+from gimle.hugin.llm.router_outcome import report_outcome
 from gimle.hugin.sandbox.background import BackgroundExecutor
 from gimle.hugin.utils.uuid import with_uuid
 
@@ -57,6 +58,11 @@ class Session:
         # command doesn't freeze sibling agents. Lazy (no threads until a command
         # actually backgrounds); in-memory, not serialized (like sandboxes).
         self.background = BackgroundExecutor()
+        # A session may be stepped or ``run`` more than once (for example after
+        # external input).  The router contract is one terminal outcome per
+        # edition, so keep an in-process latch while still allowing a
+        # non-terminal run to resume and report later.
+        self._router_outcome_reported = False
 
     @property
     def id(self) -> str:
@@ -179,33 +185,90 @@ class Session:
             The number of steps run.
         """
         step_count = 0
+        max_steps_reached = False
         logger.info(f"Running session {self.id}")
-        while True:
-            # Track which agents had activity
-            active_agents: List[Agent] = []
-            for agent in self.agents:
-                if agent.step():
-                    active_agents.append(agent)
+        try:
+            while True:
+                # Track which agents had activity
+                active_agents: List[Agent] = []
+                for agent in self.agents:
+                    if agent.step():
+                        active_agents.append(agent)
 
-            if not active_agents:
-                break
+                if not active_agents:
+                    break
 
+                if self.storage:
+                    self.storage.save_session(self)
+                step_count += 1
+
+                # Call the callback for each active agent
+                if step_callback:
+                    for agent in active_agents:
+                        step_callback(step_count, agent)
+
+                if max_steps and step_count >= max_steps:
+                    logger.info(f"Max steps reached ({max_steps})")
+                    max_steps_reached = True
+                    break
+                logger.info(f"Step {step_count} completed")
             if self.storage:
                 self.storage.save_session(self)
-            step_count += 1
 
-            # Call the callback for each active agent
-            if step_callback:
-                for agent in active_agents:
-                    step_callback(step_count, agent)
+            terminal_success = self._terminal_success()
+            if terminal_success is not None:
+                self._report_router_outcome(terminal_success)
+            elif max_steps_reached:
+                self._report_router_outcome(False)
+            return step_count
+        except Exception:
+            self._report_router_outcome(False)
+            raise
 
-            if max_steps and step_count >= max_steps:
-                logger.info(f"Max steps reached ({max_steps})")
-                break
-            logger.info(f"Step {step_count} completed")
-        if self.storage:
-            self.storage.save_session(self)
-        return step_count
+    def _terminal_success(self) -> Optional[bool]:
+        """Return the completed root-task result, or ``None`` while waiting.
+
+        Child-agent failures are inputs to their caller and must not overwrite
+        the edition's final result.  With several independent root agents, the
+        edition succeeds only when every root task has completed successfully.
+        """
+        from gimle.hugin.interaction.task_definition import TaskDefinition
+        from gimle.hugin.interaction.task_result import TaskResult
+
+        results: List[bool] = []
+        for agent in self.agents:
+            task_definition = next(
+                (
+                    interaction
+                    for interaction in agent.stack.interactions
+                    if isinstance(interaction, TaskDefinition)
+                ),
+                None,
+            )
+            if task_definition is None or task_definition.caller_id is not None:
+                continue
+            task_result = next(
+                (
+                    interaction
+                    for interaction in reversed(agent.stack.interactions)
+                    if isinstance(interaction, TaskResult)
+                ),
+                None,
+            )
+            if task_result is None or task_result.finish_type is None:
+                return None
+            results.append(task_result.finish_type == "success")
+        return all(results) if results else None
+
+    def _report_router_outcome(self, success: bool) -> None:
+        """Best-effort, once-per-session bridge to gimle-router."""
+        if self._router_outcome_reported:
+            return
+        self._router_outcome_reported = True
+        try:
+            report_outcome(self.id, success=success)
+        except Exception as error:  # observability must never break an edition
+            logger.warning("gimle-router outcome reporting failed: %s", error)
 
     def close(self) -> None:
         """Release session-owned resources (background jobs, then sandboxes).

--- a/tests/test_session_router_outcome.py
+++ b/tests/test_session_router_outcome.py
@@ -1,0 +1,168 @@
+"""Session boundaries report one correlated outcome to gimle-router."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from gimle.hugin.agent.agent import Agent
+from gimle.hugin.agent.config import Config
+from gimle.hugin.agent.environment import Environment
+from gimle.hugin.agent.session import Session
+from gimle.hugin.agent.task import Task
+from gimle.hugin.interaction.task_definition import TaskDefinition
+from gimle.hugin.interaction.task_result import TaskResult
+from gimle.hugin.interaction.waiting import Waiting
+
+
+def _task() -> Task:
+    return Task(name="root", description="test task", prompt="test")
+
+
+def _agent(
+    session: Session,
+    *,
+    caller_id: str | None = None,
+    finish_type: str | None = None,
+    waiting: bool = True,
+) -> Agent:
+    agent = Agent(
+        session=session,
+        config=Config(
+            name="test-agent",
+            description="test agent",
+            system_template="test",
+            tools=[],
+        ),
+    )
+    agent.stack.add_interaction(
+        TaskDefinition(
+            stack=agent.stack,
+            task=_task(),
+            caller_id=caller_id,
+        )
+    )
+    if finish_type is not None:
+        agent.stack.add_interaction(
+            TaskResult(
+                stack=agent.stack,
+                finish_type=finish_type,
+                result={"finish_type": finish_type},
+            )
+        )
+    if waiting:
+        agent.stack.add_interaction(Waiting(stack=agent.stack))
+    session.add_agent(agent)
+    return agent
+
+
+@pytest.mark.parametrize(
+    ("finish_type", "success"),
+    [("success", True), ("failure", False)],
+)
+def test_terminal_root_task_reports_once(finish_type, success):
+    """A terminal root result is emitted exactly once with its status."""
+    session = Session(environment=Environment())
+    _agent(session, finish_type=finish_type)
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        assert session.run() == 0
+        session.run()
+
+    report.assert_called_once_with(session.id, success=success)
+
+
+def test_waiting_session_does_not_report_a_premature_failure():
+    """A session waiting for more work has not reached an outcome boundary."""
+    session = Session(environment=Environment())
+    _agent(session)
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        assert session.run() == 0
+
+    report.assert_not_called()
+
+
+def test_child_result_does_not_override_root_result():
+    """Only the root task decides the edition-level outcome."""
+    session = Session(environment=Environment())
+    root = _agent(session, finish_type="success")
+    _agent(session, caller_id=root.id, finish_type="failure")
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        session.run()
+
+    report.assert_called_once_with(session.id, success=True)
+
+
+def test_max_steps_without_terminal_result_reports_failure():
+    """Exhausting the caller's step budget is an explicit failed edition."""
+    session = Session(environment=Environment())
+    agent = Agent(
+        session=session,
+        config=Config(
+            name="test-agent",
+            description="test agent",
+            system_template="test",
+            tools=[],
+        ),
+    )
+    interaction = Mock()
+    interaction.step.return_value = True
+    interaction.artifacts = []
+    interaction.branch = None
+    agent.stack.add_interaction(interaction)
+    session.add_agent(agent)
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        assert session.run(max_steps=1) == 1
+
+    report.assert_called_once_with(session.id, success=False)
+
+
+def test_terminal_result_wins_when_created_on_the_last_allowed_step():
+    """A terminal result at the limit is not mislabeled as exhaustion."""
+    session = Session(environment=Environment())
+    _agent(session, finish_type="success", waiting=False)
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        assert session.run(max_steps=1) == 1
+
+    report.assert_called_once_with(session.id, success=True)
+
+
+def test_session_exception_reports_failure_and_is_reraised():
+    """Unhandled edition errors report failure without changing propagation."""
+    session = Session(environment=Environment())
+    agent = Agent(
+        session=session,
+        config=Config(
+            name="test-agent",
+            description="test agent",
+            system_template="test",
+            tools=[],
+        ),
+    )
+    interaction = Mock()
+    interaction.step.side_effect = RuntimeError("boom")
+    interaction.artifacts = []
+    interaction.branch = None
+    agent.stack.add_interaction(interaction)
+    session.add_agent(agent)
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        with pytest.raises(RuntimeError, match="boom"):
+            session.run()
+
+    report.assert_called_once_with(session.id, success=False)
+
+
+def test_reporting_failure_never_breaks_the_completed_session():
+    """Unexpected reporter errors remain best-effort observability failures."""
+    session = Session(environment=Environment())
+    _agent(session, finish_type="success")
+
+    with patch(
+        "gimle.hugin.agent.session.report_outcome",
+        side_effect=RuntimeError("router unavailable"),
+    ):
+        assert session.run() == 0


### PR DESCRIPTION
Summary:
- connect the existing router outcome client to the actual Session.run edition boundary
- report terminal root-task success/failure, step-budget exhaustion, and unhandled failures exactly once in process
- avoid premature outcomes for waiting sessions and prevent child-agent results from overriding the root result
- keep outcome reporting best-effort so observability never breaks an edition

Production evidence:
- smoke-20260813-203849 produced 6 correlated router calls and 1 task but 0 outcomes
- Hugin recorded the same run as a completed benchmark pass, proving the outcome transport existed but was never invoked by production code

Validation:
- 1089 passed, 71 skipped in the full Hugin suite
- 69 passed in the session plus router integration suite
- full mypy clean across 172 source files
- black, isort, flake8, detect-secrets, whitespace, and EOF checks pass
- the isolated pre-commit mypy 1.16.1 environment crashes inside the installed OpenAI client stubs; the repository CI command uv run mypy src examples passes