### PR TITLE
Make router outcome reporting runner-complete

### DIFF
--- a/apps/rap_machine/run.py
+++ b/apps/rap_machine/run.py
@@ -366,6 +366,10 @@ def run_battle_simulation(
 
         step_count += 1
 
+    session.finalize_router_outcome(
+        max_steps_reached=step_count >= max_steps,
+    )
+
     # Final re-read and save
     battle = _get_live_battle()
     save_battle_state(battle, LIVE_DIR)

--- a/apps/the_hugins/world_server.py
+++ b/apps/the_hugins/world_server.py
@@ -533,7 +533,9 @@ class WorldHTTPRequestHandler(BaseHTTPRequestHandler):
                     if not any_activity:
                         time.sleep(1.0)
                         continue
+                session.finalize_router_outcome(max_steps_reached=True)
             except Exception as e:
+                session.finalize_router_outcome(error=True)
                 logger.error(f"Simulation error: {e}", exc_info=True)
 
         WorldHTTPRequestHandler._simulation_thread = threading.Thread(

--- a/src/gimle/hugin/agent/session.py
+++ b/src/gimle/hugin/agent/session.py
@@ -156,16 +156,26 @@ class Session:
         )
 
     def step(self) -> bool:
-        """Step the session.
+        """Step the session and report an outcome at a terminal boundary.
 
         Returns:
             True if there is any activity in the session, False otherwise.
         """
-        any_activity = False
-        for agent in self.agents:
-            agent_activity = agent.step()
-            if agent_activity:
-                any_activity = True
+        try:
+            any_activity = False
+            for agent in self.agents:
+                agent_activity = agent.step()
+                if agent_activity:
+                    any_activity = True
+        except Exception:
+            self.finalize_router_outcome(error=True)
+            raise
+
+        # ``Session.step`` is the public execution boundary used by the CLI,
+        # TUI, and several apps. A false step may mean either terminal work or
+        # a resumable wait, so let the branch-aware finalizer distinguish them.
+        if not any_activity:
+            self.finalize_router_outcome()
         return any_activity
 
     def run(
@@ -215,50 +225,138 @@ class Session:
             if self.storage:
                 self.storage.save_session(self)
 
-            terminal_success = self._terminal_success()
-            if terminal_success is not None:
-                self._report_router_outcome(terminal_success)
-            elif max_steps_reached:
-                self._report_router_outcome(False)
+            self.finalize_router_outcome(max_steps_reached=max_steps_reached)
             return step_count
         except Exception:
-            self._report_router_outcome(False)
+            self.finalize_router_outcome(error=True)
             raise
+
+    @staticmethod
+    def _task_has_pending_continuation(task: "Task") -> bool:
+        """Return whether an unstepped task result still has work to chain."""
+        if task.next_task is not None:
+            return True
+        if not task.task_sequence:
+            return False
+
+        chain_index = task.parameters.get("_chain_sequence_index")
+        stored_index = (
+            chain_index.get("value") if isinstance(chain_index, dict) else None
+        )
+        if isinstance(stored_index, int):
+            next_index = stored_index + 1
+        elif stored_index is not None:
+            # Corrupt/foreign internal state must not turn observability into a
+            # run failure. Conservatively assume the continuation is pending.
+            return True
+        else:
+            try:
+                next_index = task.task_sequence.index(task.name) + 1
+            except ValueError:
+                next_index = 0
+        return next_index < len(task.task_sequence)
 
     def _terminal_success(self) -> Optional[bool]:
         """Return the completed root-task result, or ``None`` while waiting.
 
-        Child-agent failures are inputs to their caller and must not overwrite
-        the edition's final result.  With several independent root agents, the
-        edition succeeds only when every root task has completed successfully.
+        Child agents and named branches are inputs to their root task and must
+        not overwrite the edition's final result. With several independent root
+        agents, the edition succeeds only when every root task is terminal and
+        successful.
         """
+        from gimle.hugin.interaction.task_chain import TaskChain
         from gimle.hugin.interaction.task_definition import TaskDefinition
         from gimle.hugin.interaction.task_result import TaskResult
 
         results: List[bool] = []
         for agent in self.agents:
-            task_definition = next(
+            main_interactions = [
+                interaction
+                for interaction in agent.stack.interactions
+                if interaction.branch is None
+            ]
+            root_definition = next(
                 (
                     interaction
-                    for interaction in agent.stack.interactions
+                    for interaction in main_interactions
                     if isinstance(interaction, TaskDefinition)
                 ),
                 None,
             )
-            if task_definition is None or task_definition.caller_id is not None:
+            if root_definition is None or root_definition.caller_id is not None:
                 continue
-            task_result = next(
+
+            result_index = next(
                 (
-                    interaction
-                    for interaction in reversed(agent.stack.interactions)
-                    if isinstance(interaction, TaskResult)
+                    index
+                    for index in range(len(main_interactions) - 1, -1, -1)
+                    if isinstance(main_interactions[index], TaskResult)
                 ),
                 None,
             )
-            if task_result is None or task_result.finish_type is None:
+            if result_index is None:
+                return None
+            task_result = main_interactions[result_index]
+            if not isinstance(task_result, TaskResult):
+                return None
+
+            task_definition = next(
+                (
+                    interaction
+                    for interaction in reversed(
+                        main_interactions[:result_index]
+                    )
+                    if isinstance(interaction, TaskDefinition)
+                ),
+                None,
+            )
+            if task_definition is None:
+                return None
+
+            # A later chain/definition means this result belongs to an earlier
+            # stage, not the current root-task boundary.
+            if any(
+                isinstance(interaction, (TaskChain, TaskDefinition))
+                for interaction in main_interactions[result_index + 1 :]
+            ):
+                return None
+
+            # An oracle may create a TaskResult and stop before stepping it. It
+            # is terminal only if that step would not schedule another task.
+            if (
+                result_index == len(main_interactions) - 1
+                and task_definition.task is not None
+                and self._task_has_pending_continuation(task_definition.task)
+            ):
+                return None
+
+            if task_result.finish_type is None:
                 return None
             results.append(task_result.finish_type == "success")
         return all(results) if results else None
+
+    def finalize_router_outcome(
+        self,
+        *,
+        max_steps_reached: bool = False,
+        error: bool = False,
+    ) -> None:
+        """Report an edition outcome when this execution boundary is final.
+
+        This is shared by ``run`` and the step-based CLI/app runners. A
+        resumable wait remains unreported; an unhandled error or exhausted
+        step budget is a failure. Reporting remains idempotent for the lifetime
+        of this ``Session`` instance.
+        """
+        if error:
+            self._report_router_outcome(False)
+            return
+
+        terminal_success = self._terminal_success()
+        if terminal_success is not None:
+            self._report_router_outcome(terminal_success)
+        elif max_steps_reached:
+            self._report_router_outcome(False)
 
     def _report_router_outcome(self, success: bool) -> None:
         """Best-effort, once-per-session bridge to gimle-router."""

--- a/src/gimle/hugin/cli/create_agent.py
+++ b/src/gimle/hugin/cli/create_agent.py
@@ -465,6 +465,7 @@ Examples:
             max_steps=args.max_steps,
             prefix="    ",
             clear_width=40,
+            session=session,
         )
         if last_error:
             logging.error("Error during agent step", exc_info=last_error)

--- a/src/gimle/hugin/cli/interactive/screens/agents.py
+++ b/src/gimle/hugin/cli/interactive/screens/agents.py
@@ -304,6 +304,7 @@ class AgentsScreen(BaseScreen):
             # Set agent context for logging
             set_agent_context(agent.id, self.state.selected_session_id)
             step_count = 0
+            run_error = False
             try:
                 while step_count < max_steps:
                     # Check controller before each step
@@ -320,8 +321,12 @@ class AgentsScreen(BaseScreen):
                     step_count += 1
                     self.state.storage.save_session(session)
             except Exception:
-                pass
+                run_error = True
             finally:
+                session.finalize_router_outcome(
+                    max_steps_reached=step_count >= max_steps,
+                    error=run_error,
+                )
                 clear_agent_context()
                 self.state.storage.save_session(session)
                 # Refresh state to show updated agent

--- a/src/gimle/hugin/cli/interactive/screens/interactions.py
+++ b/src/gimle/hugin/cli/interactive/screens/interactions.py
@@ -422,6 +422,7 @@ class InteractionsScreen(BaseScreen):
             # Set agent context for logging
             set_agent_context(agent.id, self.state.selected_session_id)
             step_count = 0
+            run_error = False
             try:
                 while step_count < max_steps:
                     # Check controller before each step
@@ -441,8 +442,13 @@ class InteractionsScreen(BaseScreen):
                     step_count += 1
                     self.state.storage.save_session(session)
             except Exception as e:
+                run_error = True
                 logger.error(f"Agent {agent.id} error: {e}")
             finally:
+                session.finalize_router_outcome(
+                    max_steps_reached=step_count >= max_steps,
+                    error=run_error,
+                )
                 clear_agent_context()
                 self.state.storage.save_session(session)
                 # Refresh state to show updated agent

--- a/src/gimle/hugin/cli/interactive/screens/new_agent.py
+++ b/src/gimle/hugin/cli/interactive/screens/new_agent.py
@@ -375,6 +375,7 @@ class NewAgentScreen(BaseScreen):
                 # Set agent context for logging
                 set_agent_context(agent.id, session.id)
                 step_count = 0
+                run_error = False
                 try:
                     while step_count < self.max_steps:
                         # Check controller before each step
@@ -392,8 +393,13 @@ class NewAgentScreen(BaseScreen):
                         step_count += 1
                         self.state.storage.save_session(session)
                 except Exception as e:
+                    run_error = True
                     self.error_message = f"Agent error: {e}"
                 finally:
+                    session.finalize_router_outcome(
+                        max_steps_reached=step_count >= self.max_steps,
+                        error=run_error,
+                    )
                     clear_agent_context()
                     self.state.storage.save_session(session)
                     # Refresh state to show new agent

--- a/src/gimle/hugin/cli/ui.py
+++ b/src/gimle/hugin/cli/ui.py
@@ -266,6 +266,7 @@ def run_steps_with_spinner(
         clear_width: Width to clear when done
         spinner: Deprecated, uses AnimatedSpinner frames
         session: Optional Session object for detecting AskHuman interactions
+            and finalizing its router outcome when this loop ends
         interactive: Whether to prompt for human input (default True)
         step_delay: Delay in seconds between steps (default 0.0)
 
@@ -318,6 +319,14 @@ def run_steps_with_spinner(
                 break
     finally:
         animated.stop(show_completed=True)
+
+    if session is not None:
+        session.finalize_router_outcome(
+            max_steps_reached=(
+                max_steps is not None and step_count >= max_steps
+            ),
+            error=last_error is not None,
+        )
 
     return step_count, last_error
 

--- a/tests/test_session_router_outcome.py
+++ b/tests/test_session_router_outcome.py
@@ -9,6 +9,7 @@ from gimle.hugin.agent.config import Config
 from gimle.hugin.agent.environment import Environment
 from gimle.hugin.agent.session import Session
 from gimle.hugin.agent.task import Task
+from gimle.hugin.cli.ui import run_steps_with_spinner
 from gimle.hugin.interaction.task_definition import TaskDefinition
 from gimle.hugin.interaction.task_result import TaskResult
 from gimle.hugin.interaction.waiting import Waiting
@@ -82,6 +83,52 @@ def test_waiting_session_does_not_report_a_premature_failure():
     report.assert_not_called()
 
 
+def test_direct_session_step_reports_a_terminal_result():
+    """The step-based public runner reports at its terminal boundary."""
+    session = Session(environment=Environment())
+    _agent(session, finish_type="success")
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        assert session.step() is False
+
+    report.assert_called_once_with(session.id, success=True)
+
+
+def test_spinner_step_loop_reports_budget_exhaustion():
+    """The CLI's step loop finalizes a session that reaches its budget."""
+    session = Session(environment=Environment())
+    agent = Agent(
+        session=session,
+        config=Config(
+            name="test-agent",
+            description="test agent",
+            system_template="test",
+            tools=[],
+        ),
+    )
+    interaction = Mock()
+    interaction.step.return_value = True
+    interaction.artifacts = []
+    interaction.branch = None
+    agent.stack.add_interaction(interaction)
+    session.add_agent(agent)
+
+    with (
+        patch("gimle.hugin.agent.session.report_outcome") as report,
+        patch("gimle.hugin.cli.ui.AnimatedSpinner"),
+    ):
+        steps, error = run_steps_with_spinner(
+            step_fn=session.step,
+            save_fn=Mock(),
+            max_steps=1,
+            session=session,
+        )
+
+    assert steps == 1
+    assert error is None
+    report.assert_called_once_with(session.id, success=False)
+
+
 def test_child_result_does_not_override_root_result():
     """Only the root task decides the edition-level outcome."""
     session = Session(environment=Environment())
@@ -90,6 +137,54 @@ def test_child_result_does_not_override_root_result():
 
     with patch("gimle.hugin.agent.session.report_outcome") as report:
         session.run()
+
+    report.assert_called_once_with(session.id, success=True)
+
+
+def test_named_branch_result_does_not_complete_an_unfinished_root():
+    """A branch result is not an edition result while the root is waiting."""
+    session = Session(environment=Environment())
+    root = _agent(session)
+    root.stack.add_interaction(
+        TaskDefinition(
+            stack=root.stack,
+            task=Task(name="branch", description="branch", prompt="branch"),
+            branch="branch-a",
+        ),
+        branch="branch-a",
+    )
+    root.stack.add_interaction(
+        TaskResult(
+            stack=root.stack,
+            branch="branch-a",
+            finish_type="failure",
+            result={"finish_type": "failure"},
+        ),
+        branch="branch-a",
+    )
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        session.finalize_router_outcome()
+
+    report.assert_not_called()
+
+
+def test_named_branch_result_does_not_override_root_success():
+    """A later branch failure cannot replace the root branch's success."""
+    session = Session(environment=Environment())
+    root = _agent(session, finish_type="success")
+    root.stack.add_interaction(
+        TaskResult(
+            stack=root.stack,
+            branch="branch-a",
+            finish_type="failure",
+            result={"finish_type": "failure"},
+        ),
+        branch="branch-a",
+    )
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        session.finalize_router_outcome()
 
     report.assert_called_once_with(session.id, success=True)
 
@@ -130,6 +225,89 @@ def test_terminal_result_wins_when_created_on_the_last_allowed_step():
     report.assert_called_once_with(session.id, success=True)
 
 
+def test_intermediate_task_result_does_not_beat_budget_exhaustion():
+    """A result with a pending next task is not the edition's final result."""
+    session = Session(environment=Environment())
+    agent = Agent(
+        session=session,
+        config=Config(
+            name="test-agent",
+            description="test agent",
+            system_template="test",
+            tools=[],
+        ),
+    )
+    agent.stack.add_interaction(
+        TaskDefinition(
+            stack=agent.stack,
+            task=Task(
+                name="first",
+                description="first",
+                prompt="first",
+                next_task="second",
+            ),
+        )
+    )
+    agent.stack.add_interaction(
+        TaskResult(
+            stack=agent.stack,
+            finish_type="success",
+            result={"finish_type": "success"},
+        )
+    )
+    session.add_agent(agent)
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        assert session.run(max_steps=1) == 1
+
+    report.assert_called_once_with(session.id, success=False)
+
+
+def test_final_task_sequence_result_is_terminal():
+    """An exhausted task sequence still reports its final result."""
+    session = Session(environment=Environment())
+    agent = Agent(
+        session=session,
+        config=Config(
+            name="test-agent",
+            description="test agent",
+            system_template="test",
+            tools=[],
+        ),
+    )
+    agent.stack.add_interaction(
+        TaskDefinition(
+            stack=agent.stack,
+            task=Task(
+                name="second",
+                description="second",
+                prompt="second",
+                task_sequence=["first", "second"],
+                parameters={
+                    "_chain_sequence_index": {
+                        "type": "integer",
+                        "description": "current sequence index",
+                        "value": 1,
+                    }
+                },
+            ),
+        )
+    )
+    agent.stack.add_interaction(
+        TaskResult(
+            stack=agent.stack,
+            finish_type="success",
+            result={"finish_type": "success"},
+        )
+    )
+    session.add_agent(agent)
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        assert session.run(max_steps=1) == 1
+
+    report.assert_called_once_with(session.id, success=True)
+
+
 def test_session_exception_reports_failure_and_is_reraised():
     """Unhandled edition errors report failure without changing propagation."""
     session = Session(environment=Environment())
@@ -152,6 +330,32 @@ def test_session_exception_reports_failure_and_is_reraised():
     with patch("gimle.hugin.agent.session.report_outcome") as report:
         with pytest.raises(RuntimeError, match="boom"):
             session.run()
+
+    report.assert_called_once_with(session.id, success=False)
+
+
+def test_direct_session_step_exception_reports_failure_and_is_reraised():
+    """Direct step runners preserve the same unhandled-error contract."""
+    session = Session(environment=Environment())
+    agent = Agent(
+        session=session,
+        config=Config(
+            name="test-agent",
+            description="test agent",
+            system_template="test",
+            tools=[],
+        ),
+    )
+    interaction = Mock()
+    interaction.step.side_effect = RuntimeError("boom")
+    interaction.artifacts = []
+    interaction.branch = None
+    agent.stack.add_interaction(interaction)
+    session.add_agent(agent)
+
+    with patch("gimle.hugin.agent.session.report_outcome") as report:
+        with pytest.raises(RuntimeError, match="boom"):
+            session.step()
 
     report.assert_called_once_with(session.id, success=False)
 


### PR DESCRIPTION
## Summary

- add one idempotent `Session.finalize_router_outcome()` boundary shared by
  `Session.run()`, direct `Session.step()` loops, the CLI spinner, the creator,
  TUI runners, and the remaining app-specific step loops
- report step-budget exhaustion and unhandled step-loop errors consistently
- derive terminal results only from root agents' main branches, so named branch
  results cannot complete or override the edition
- reject intermediate `TaskResult` values while `next_task` or a remaining
  `task_sequence` stage is pending

## Root cause

PR #88 attached outcome reporting only to `Session.run()`, while Hugin's normal
CLI and several apps execute repeated `Session.step()` or `Agent.step()` calls.
Its terminal scan also selected the latest `TaskResult` anywhere in an agent's
stack, without respecting branch identity or deterministic task continuations.

That left common production paths unreported and could send incorrect labels to
gimle-router for branched or chained agents.

## Impact

Every production runner in `src/` and `apps/` now reaches the same best-effort,
once-per-session outcome finalizer. Resumable waits remain unreported, terminal
root results win over budget exhaustion on the last step, and router failures
still cannot break an edition.

## Validation

- `1096 passed, 71 skipped` in the full pytest suite
- focused router/session/task-chain regressions pass
- `mypy src` clean across 152 source files
- Black, isort, flake8, detect-secrets, whitespace, EOF, and `git diff --check`
  pass for the changed files
